### PR TITLE
Fixed missing message types in to_string() function.

### DIFF
--- a/python/examples/message_decode.py
+++ b/python/examples/message_decode.py
@@ -29,6 +29,7 @@ def decode_message(header, data, offset):
 
         print('Pose message @ P1 time %s [sequence=%d, size=%d B]' %
               (str(contents.p1_time), header.sequence_number, len(data)))
+        print('  Solution type: %s' % contents.solution_type.name)
         print('  GPS time: %s' % str(contents.gps_time.as_gps()))
         print('  Position (LLA): %.6f, %.6f, %.3f (deg, deg, m)' % tuple(contents.lla_deg))
         print('  Attitude (YPR): %.2f, %.2f, %.2f (deg, deg, deg)' % tuple(contents.ypr_deg))

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -230,8 +230,23 @@ inline std::string to_string(MessageType type) {
     case MessageType::GNSS_INFO:
       return "GNSS Info";
 
+    case MessageType::GNSS_SATELLITE:
+      return "GNSS Satellite";
+
+    case MessageType::POSE_AUX:
+      return "Pose Auxiliary";
+
     case MessageType::IMU_MEASUREMENT:
       return "IMU Measurement";
+
+    case MessageType::ROS_POSE:
+      return "ROS Pose";
+
+    case MessageType::ROS_GPS_FIX:
+      return "ROS GPSFix";
+
+    case MessageType::ROS_IMU:
+      return "ROS IMU";
 
     default:
       return "Unrecognized Message (" + std::to_string((int)type) + ")";


### PR DESCRIPTION
# Changes
- Print solution type in Python decoder example

# Fixes
- Added missing message types to `to_string()`