### PR TITLE
Enabled style checking and Python unit tests in CI, and added contributor instructions.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -275,11 +275,35 @@ jobs:
         aws s3 cp --acl public-read docs/favicon.ico s3://docs.pointonenav.com/fusion-engine/
         aws s3 cp --acl public-read docs/point_one_logo.png s3://docs.pointonenav.com/fusion-engine/
 
+  # Run Python unit tests.
+  test_python:
+    name: Python Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install Python Requirements
+      run: |
+        pip install -r requirements.txt
+        pip install pytest
+
+    - name: Run Unit Tests
+      run: |
+        python -m pytest
+
   # Create a release only on a tag (not on a branch push).
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [check_style, build_bazel, build_cmake, build_doxygen, upload_doxygen]
+    needs: [check_style, build_bazel, build_cmake, build_doxygen, upload_doxygen, test_python]
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -9,6 +9,9 @@ on:
     # Build on a push of any tag named v* (v1.0, etc.) and generate a release.
     tags:
       - 'v*'
+  pull_request:
+    # Build when a pull request is opened or updated.
+    types: [opened, synchronize, reopened]
 
 jobs:
   # Check code style.

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -11,6 +11,31 @@ on:
       - 'v*'
 
 jobs:
+  # Check code style.
+  check_style:
+    name: Check Style
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Check Python formatting.
+    - name: Check Python Formatting
+      id: autopep8
+      uses: peter-evans/autopep8@v1
+      with:
+        args: --in-place python/fusion_engine_client python/examples python/bin python/tests
+
+    - name: Test Python Result
+      if: steps.autopep8.outputs.exit-code == 2
+      run: exit 1
+
+    # Check C++ formatting.
+    - name: Check C++ Formatting
+      uses: jidicula/clang-format-action@v4.4.1
+      with:
+        clang-format-version: '13'
+        check-path: '.'
+
   # Build the library and example applications (Bazel).
   build_bazel:
     name: Bazel Build
@@ -254,7 +279,7 @@ jobs:
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build_bazel, build_cmake, build_doxygen, upload_doxygen]
+    needs: [check_style, build_bazel, build_cmake, build_doxygen, upload_doxygen]
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,201 @@
+# Contributing To Point One FusionEngine Client
+
+We welcome code and documentation contributions from users!
+
+### Table Of Contents:
+  * [Reporting Issues](#reporting-issues)
+  * [Submitting Changes](#submitting-changes)
+
+## Reporting Issues
+
+If you encounter a problem, please
+[search to see if an issue exists](https://github.com/PointOneNav/fusion-engine-client/issues). If not, please
+[submit a new ticket](https://github.com/PointOneNav/fusion-engine-client/issues/new) and include the following
+information:
+- A description of the issue
+- Steps to replicate the issue, including a minimal example if possible
+- The commit hash of the [FusionEngine Client](https://github.com/PointOneNav/fusion-engine-client) repo on which you
+  encountered the issue
+- The type and version of operating system you are running on
+- Any other information, logs, screenshots, or outputs you wish to share
+
+If you need support with Point One FusionEngine or a Point One device (Atlas, Quectel LG69T, etc.), please contact
+support@pointonenav.com.
+
+## Submitting Changes
+
+### Creating A Branch
+
+1. Update your local copy of the [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository
+   to ensure you have the latest version of the code.
+   ```
+   git fetch origin
+   ```
+2. Create a new branch on top of `origin/master`.
+   ```
+   git checkout -b my-feature origin/master
+   ```
+
+> Important note: Do not use `git pull` to update an existing branch with new changes from `master`. Use `git rebase`
+> instead. See [below](#updating-to-the-latest-changes-rebasing) for details.
+
+Note that you should _never_ work directly on the `master` branch.
+
+### Make The Change
+
+1. Make your code changes and test them.
+   - Note that any new C++ files or applications must be added to both CMake (`CMakeLists.txt`) and Bazel (`BUILD`)
+     configuration files.
+   - For Python development, we strongly recommend the use of a Python virtual environment. See
+     [Using A Python Virtual Environment](python/README.md#using-a-python-virtual-environment).
+2. Use a style checking tool to make sure your changes meet our coding style rules.
+   - For C++, install [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) (e.g.,
+     `sudo apt install clang-format`) and run as follows:
+     ```
+     clang-format -i path/to/file.cc
+     ```
+   - For Python, install [`autopep8`](https://pypi.org/project/autopep8/) (`pip install autopep8`) and run as follows:
+     ```
+     autopep8 -i path/to/file.py
+     ```
+3. Commit your changes as separate functional commits as described below.
+
+**A good commit:**
+- Has a message summarizing the change and what it is fixing (if applicable)
+- Contains a single functional change to the code, where possible (e.g., fix a bug, add a new example)
+- Can be compiled and tested without depending on later commits
+
+Examples:
+```
+- Added a plot of navigation solution type over time.
+- Fixed incorrect TCP socket timeout parameters.
+```
+
+**A bad commit:**
+- Has a commit message that does not explain what you intended to do or why
+- Changes multiple things at the same time, especially if the commit message
+  only reflects one change (or none!)
+
+Examples:
+```
+- Fixes
+- It works now
+```
+
+Small, functional commits make changes easier to review, understand, and test if issues arise.
+
+We encourage you to commit changes as you make them, and to use partial staging (`git add -p`) to commit relevant
+changes together, or a Git GUI that supports partial staging such as [`git-cola`](https://git-cola.github.io/) or
+[Git Kraken](https://www.gitkraken.com/).
+
+### Submit A Pull Request
+
+1. If you have not already, create a fork of the
+   [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository on Github and add it to your
+   local repository:
+   ```
+   git remote add my-fork git@github.com:username/fusion-engine-client.git
+   ```
+2. Push your new branch to your fork.
+   ```
+   git push my-fork my-feature
+   ```
+3. Go to the Github page for your fork and create a new pull request from `username:my-feature` into
+   `PointOneNav:master`.
+   - Your pull request summary must be a single sentence explaining the changes. For example:
+     - Good: `Added a Linux TCP example C++ application.`
+     - Bad: `Python changes`
+   - The pull request description should include a detailed summary of any relevant changes. If possible, the summary
+     should be organized into the following 3 sections as needed:
+     ```
+     # New Features
+     - Added a Linux TCP example C++ application.
+
+     # Changes
+     - Made example message display code common between multiple example applications.
+
+     # Fixes
+     - Fixed position plotting support.
+     ```
+
+### Updating To The Latest Changes (Rebasing)
+
+> TL;DR _Never_ use `git pull` or `git merge` when updating your code. Always use `git rebase`.
+>
+> ```
+> git fetch origin
+> git checkout my-feature
+> git rebase origin/master
+> git push -f my-fork my-feature
+> ```
+
+In this repository, we make an effort to maintain a linear Git history at all times. This means that, instead of using
+`git pull` to obtain the latest code changes, we use `git rebase`.
+
+![Courtesy of https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase.](
+https://wac-cdn.atlassian.com/dam/jcr:4e576671-1b7f-43db-afb5-cf8db8df8e4a/01%20What%20is%20git%20rebase.svg?cdnVersion=140)
+
+Having a linear history has a few advantages:
+- It makes the history simpler to follow by avoiding lots of merges back and forth between branches from multiple
+  developers.
+- It makes it possible to test changes quickly and easily when searching for the first place a bug was introduced by
+  searching one commit at a time.
+  - You can use `git bisect` to do this automatically.
+  - This is the reason we request [small commits with a single functional change](#make-the-change): so that each
+    commit can be tested if needed to confirm that it does what it intends and doesn't cause problems.
+- Conflicts are easier to resolve on larger branches since they happen at an individual commit level, and you can simply
+  correct that commit so that it does what it is supposed to with the new upstream `origin/master` changes.
+  - By contrast, when you have a conflict with a `git merge`, the conflicting code might include several unrelated
+    changes, and it can sometimes be hard to figure out the correct resolution.
+
+In general, rebasing is pretty simple. In order to update your code with the latest changes on `origin/master`, do the
+following:
+
+1. Fetch the latest changes.
+   ```
+   git fetch origin
+   ```
+2. Rebase your branch onto the new version of `origin/master`.
+   ```
+   git checkout my-feature
+   git rebase origin/master
+   ```
+   This recreates your commits one at a time as if they were created on top of the new version of `origin/master`. If
+   you hit a conflict, simply fix that commit so that it does what it was originally intended to do, and then continue
+   (`git rebase --continue`).
+
+   (Compare this with `git merge origin/master`, which you should _never_ do.)
+3. Update your fork using a force push.
+   ```
+   git push -f my-fork my-feature
+   ```
+
+`git rebase` has a lot of other really useful features. Most notably, you can use `fixup!` commits to correct issues in
+existing commits. For example, say we forgot a semicolon in a commit and that commit does not compile. We could do the
+following:
+```
+2231360 Added a new C++ example.
+ee2adc2 Fixed a serialization bug.
+113b2aa Fixed missing semicolon in new example.
+```
+but that means that commit `2231360` can't be compiled and tested when looking for a bug. Instead, you can mark the
+commit as a `fixup!`:
+```
+pick 2231360 Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+pick 113b2aa fixup! Added a new C++ example.
+```
+and then you can use an interactive rebase (`git rebase -i origin/master`) to squash them together before merging the
+changes:
+```
+pick 2231360 Added a new C++ example.
+fixup 113b2aa fixup! Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+```
+The resulting commit is a combination of the original change and the semicolon fix:
+```
+pick aabd112 Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+```
+
+See https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase for more information about rebasing.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ time, as well as processing recorded output data. Both C++ and Python are suppor
 
 See http://docs.pointonenav.com/fusion-engine/ for the latest API documentation.
 
-If you encounter an issue, please [submit a ticket](#reporting-issues). For questions and support, please contact
-support@pointonenav.com.
+This library is released under the [MIT license agreement](LICENSE). We welcome code and documentation contributions
+from users. See [Contributing](CONTRIBUTING.md) for instructions on how to report issues and develop, test, and submit
+code changes.
+
+If you encounter an issue, please [submit a ticket](CONTRIBUTING.md#reporting-issues). If you need support with Point
+One FusionEngine or a Point One device (Atlas, Quectel LG69T, etc.), please contact support@pointonenav.com.
+
+### Table Of Contents
 
 * [Requirements](#requirements)
 * [Directory Structure](#directory-structure)
@@ -32,9 +38,6 @@ support@pointonenav.com.
   * [Endianness](#endianness)
 * [Usage](#usage)
   * [Body Coordinate Frame Definition](#body-coordinate-frame-definition)
-* [Contributing](#contributing)
-  * [Reporting Issues](#reporting-issues)
-  * [Submitting Changes](#submitting-changes)
 
 ### Requirements
 
@@ -263,198 +266,3 @@ See the `message_decode` example for more details.
 The platform body axes are defined as +x forward, +y left, and +z up. A positive yaw is a left turn, positive pitch
 points the nose of the vehicle down, and positive roll is a roll toward the right. Yaw is measured from east in a
 counter-clockwise direction. For example, north is +90 degrees (i.e., `heading = 90.0 - yaw`).
-
-# Contributing
-
-We welcome code and documentation contributions from users!
-
-## Reporting Issues
-
-If you encounter a problem, please
-[search to see if an issue exists](https://github.com/PointOneNav/fusion-engine-client/issues). If not, please
-[submit a  new ticket](https://github.com/PointOneNav/fusion-engine-client/issues/new) and include the following
-information:
-- A description of the issue
-- Steps to replicate the issue, including a minimal example if possible
-- The commit hash of the [FusionEngine Client](https://github.com/PointOneNav/fusion-engine-client) repo on which you
-  encountered the issue
-- The type and version of operating system you are running on
-- Any other information, logs, screenshots, or outputs you wish to share
-
-## Submitting Changes
-
-### Creating A Branch
-
-1. Update your local copy of the [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository
-   to ensure you have the latest version of the code.
-   ```
-   git fetch origin
-   ```
-2. Create a new branch on top of `origin/master`.
-   ```
-   git checkout -b my-feature origin/master
-   ```
-
-> Important note: Do not use `git pull` to update an existing branch with new changes from `master`. Use `git rebase`
-> instead. See [below](#updating-to-the-latest-changes-rebasing) for details.
-
-Note that you should _never_ work directly on the `master` branch.
-
-### Make The Change
-
-1. Make your code changes and test them.
-   - Note that any new C++ files or applications must be added to both CMake (`CMakeLists.txt`) and Bazel (`BUILD`)
-     configuration files.
-   - For Python development, we strongly recommend the use of a Python virtual environment. See
-     [Using A Python Virtual Environment](python/README.md#using-a-python-virtual-environment).
-2. Use a style checking tool to make sure your changes meet our coding style rules.
-   - For C++, install [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) (e.g.,
-     `sudo apt install clang-format`) and run as follows:
-     ```
-     clang-format -i path/to/file.cc
-     ```
-   - For Python, install [`autopep8`](https://pypi.org/project/autopep8/) (`pip install autopep8`) and run as follows:
-     ```
-     autopep8 -i path/to/file.py
-     ```
-3. Commit your changes as separate functional commits as described below.
-
-**A good commit:**
-- Has a message summarizing the change and what it is fixing (if applicable)
-- Contains a single functional change to the code, where possible (e.g., fix a bug, add a new example)
-- Can be compiled and tested without depending on later commits
-
-Examples:
-```
-- Added a plot of navigation solution type over time.
-- Fixed incorrect TCP socket timeout parameters.
-```
-
-**A bad commit:**
-- Has a commit message that does not explain what you intended to do or why
-- Changes multiple things at the same time, especially if the commit message
-  only reflects one change (or none!)
-
-Examples:
-```
-- Fixes
-- It works now
-```
-
-Small, functional commits make changes easier to review, understand, and test if issues arise.
-
-We encourage you to commit changes as you make them, and to use partial staging (`git add -p`) to commit relevant
-changes together, or a Git GUI that supports partial staging such as [`git-cola`](https://git-cola.github.io/) or
-[Git Kraken](https://www.gitkraken.com/).
-
-### Submit A Pull Request
-
-1. If you have not already, create a fork of the
-   [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository on Github and add it to your
-   local repository:
-   ```
-   git remote add my-fork git@github.com:username/fusion-engine-client.git
-   ```
-2. Push your new branch to your fork.
-   ```
-   git push my-fork my-feature
-   ```
-3. Go to the Github page for your fork and create a new pull request from `username:my-feature` into
-   `PointOneNav:master`.
-   - Your pull request summary must be a single sentence explaining the changes. For example:
-     - Good: `Added a Linux TCP example C++ application.`
-     - Bad: `Python changes`
-   - The pull request description should include a detailed summary of any relevant changes. If possible, the summary
-     should be organized into the following 3 sections as needed:
-     ```
-     # New Features
-     - Added a Linux TCP example C++ application.
-
-     # Changes
-     - Made example message display code common between multiple example applications.
-
-     # Fixes
-     - Fixed position plotting support.
-     ```
-
-### Updating To The Latest Changes (Rebasing)
-
-> TL;DR _Never_ use `git pull` or `git merge` when updating your code. Always use `git rebase`.
->
-> ```
-> git fetch origin
-> git checkout my-feature
-> git rebase origin/master
-> git push -f my-fork my-feature
-> ```
-
-In this repository, we make an effort to maintain a linear Git history at all times. This means that, instead of using
-`git pull` to obtain the latest code changes, we use `git rebase`.
-
-![Courtesy of https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase.](
-https://wac-cdn.atlassian.com/dam/jcr:4e576671-1b7f-43db-afb5-cf8db8df8e4a/01%20What%20is%20git%20rebase.svg?cdnVersion=140)
-
-Having a linear history has a few advantages:
-- It makes the history simpler to follow by avoiding lots of merges back and forth between branches from multiple
-  developers.
-- It makes it possible to test changes quickly and easily when searching for the first place a bug was introduced by
-  searching one commit at a time.
-  - You can use `git bisect` to do this automatically.
-  - This is the reason we request [small commits with a single functional change](#make-the-change): so that each
-    commit can be tested if needed to confirm that it does what it intends and doesn't cause problems.
-- Conflicts are easier to resolve on larger branches since they happen at an individual commit level, and you can simply
-  correct that commit so that it does what it is supposed to with the new upstream `origin/master` changes.
-  - By contrast, when you have a conflict with a `git merge`, the conflicting code might include several unrelated
-    changes, and it can sometimes be hard to figure out the correct resolution.
-
-In general, rebasing is pretty simple. In order to update your code with the latest changes on `origin/master`, do the
-following:
-
-1. Fetch the latest changes.
-   ```
-   git fetch origin
-   ```
-2. Rebase your branch onto the new version of `origin/master`.
-   ```
-   git checkout my-feature
-   git rebase origin/master
-   ```
-   This recreates your commits one at a time as if they were created on top of the new version of `origin/master`. If
-   you hit a conflict, simply fix that commit so that it does what it was originally intended to do, and then continue
-   (`git rebase --continue`).
-
-   (Compare this with `git merge origin/master`, which you should _never_ do.)
-3. Update your fork using a force push.
-   ```
-   git push -f my-fork my-feature
-   ```
-
-`git rebase` has a lot of other really useful features. Most notably, you can use `fixup!` commits to correct issues in
-existing commits. For example, say we forgot a semicolon in a commit and that commit does not compile. We could do the
-following:
-```
-2231360 Added a new C++ example.
-ee2adc2 Fixed a serialization bug.
-113b2aa Fixed missing semicolon in new example.
-```
-but that means that commit `2231360` can't be compiled and tested when looking for a bug. Instead, you can mark the
-commit as a `fixup!`:
-```
-pick 2231360 Added a new C++ example.
-pick ee2adc2 Fixed a serialization bug.
-pick 113b2aa fixup! Added a new C++ example.
-```
-and then you can use an interactive rebase (`git rebase -i origin/master`) to squash them together before merging the
-changes:
-```
-pick 2231360 Added a new C++ example.
-fixup 113b2aa fixup! Added a new C++ example.
-pick ee2adc2 Fixed a serialization bug.
-```
-The resulting commit is a combination of the original change and the semicolon fix:
-```
-pick aabd112 Added a new C++ example.
-pick ee2adc2 Fixed a serialization bug.
-```
-
-See https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase for more information about rebasing.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ time, as well as processing recorded output data. Both C++ and Python are suppor
 
 See http://docs.pointonenav.com/fusion-engine/ for the latest API documentation.
 
+If you encounter an issue, please [submit a ticket](#reporting-issues). For questions and support, please contact
+support@pointonenav.com.
+
 * [Requirements](#requirements)
 * [Directory Structure](#directory-structure)
   * [Example Applications](#example-applications)
@@ -29,6 +32,9 @@ See http://docs.pointonenav.com/fusion-engine/ for the latest API documentation.
   * [Endianness](#endianness)
 * [Usage](#usage)
   * [Body Coordinate Frame Definition](#body-coordinate-frame-definition)
+* [Contributing](#contributing)
+  * [Reporting Issues](#reporting-issues)
+  * [Submitting Changes](#submitting-changes)
 
 ### Requirements
 
@@ -257,3 +263,198 @@ See the `message_decode` example for more details.
 The platform body axes are defined as +x forward, +y left, and +z up. A positive yaw is a left turn, positive pitch
 points the nose of the vehicle down, and positive roll is a roll toward the right. Yaw is measured from east in a
 counter-clockwise direction. For example, north is +90 degrees (i.e., `heading = 90.0 - yaw`).
+
+# Contributing
+
+We welcome code and documentation contributions from users!
+
+## Reporting Issues
+
+If you encounter a problem, please
+[search to see if an issue exists](https://github.com/PointOneNav/fusion-engine-client/issues). If not, please
+[submit a  new ticket](https://github.com/PointOneNav/fusion-engine-client/issues/new) and include the following
+information:
+- A description of the issue
+- Steps to replicate the issue, including a minimal example if possible
+- The commit hash of the [FusionEngine Client](https://github.com/PointOneNav/fusion-engine-client) repo on which you
+  encountered the issue
+- The type and version of operating system you are running on
+- Any other information, logs, screenshots, or outputs you wish to share
+
+## Submitting Changes
+
+### Creating A Branch
+
+1. Update your local copy of the [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository
+   to ensure you have the latest version of the code.
+   ```
+   git fetch origin
+   ```
+2. Create a new branch on top of `origin/master`.
+   ```
+   git checkout -b my-feature origin/master
+   ```
+
+> Important note: Do not use `git pull` to update an existing branch with new changes from `master`. Use `git rebase`
+> instead. See [below](#updating-to-the-latest-changes-rebasing) for details.
+
+Note that you should _never_ work directly on the `master` branch.
+
+### Make The Change
+
+1. Make your code changes and test them.
+   - Note that any new C++ files or applications must be added to both CMake (`CMakeLists.txt`) and Bazel (`BUILD`)
+     configuration files.
+   - For Python development, we strongly recommend the use of a Python virtual environment. See
+     [Using A Python Virtual Environment](python/README.md#using-a-python-virtual-environment).
+2. Use a style checking tool to make sure your changes meet our coding style rules.
+   - For C++, install [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) (e.g.,
+     `sudo apt install clang-format`) and run as follows:
+     ```
+     clang-format -i path/to/file.cc
+     ```
+   - For Python, install [`autopep8`](https://pypi.org/project/autopep8/) (`pip install autopep8`) and run as follows:
+     ```
+     autopep8 -i path/to/file.py
+     ```
+3. Commit your changes as separate functional commits as described below.
+
+**A good commit:**
+- Has a message summarizing the change and what it is fixing (if applicable)
+- Contains a single functional change to the code, where possible (e.g., fix a bug, add a new example)
+- Can be compiled and tested without depending on later commits
+
+Examples:
+```
+- Added a plot of navigation solution type over time.
+- Fixed incorrect TCP socket timeout parameters.
+```
+
+**A bad commit:**
+- Has a commit message that does not explain what you intended to do or why
+- Changes multiple things at the same time, especially if the commit message
+  only reflects one change (or none!)
+
+Examples:
+```
+- Fixes
+- It works now
+```
+
+Small, functional commits make changes easier to review, understand, and test if issues arise.
+
+We encourage you to commit changes as you make them, and to use partial staging (`git add -p`) to commit relevant
+changes together, or a Git GUI that supports partial staging such as [`git-cola`](https://git-cola.github.io/) or
+[Git Kraken](https://www.gitkraken.com/).
+
+### Submit A Pull Request
+
+1. If you have not already, create a fork of the
+   [fusion-engine-client](https://github.com/PointOneNav/fusion-engine-client) repository on Github and add it to your
+   local repository:
+   ```
+   git remote add my-fork git@github.com:username/fusion-engine-client.git
+   ```
+2. Push your new branch to your fork.
+   ```
+   git push my-fork my-feature
+   ```
+3. Go to the Github page for your fork and create a new pull request from `username:my-feature` into
+   `PointOneNav:master`.
+   - Your pull request summary must be a single sentence explaining the changes. For example:
+     - Good: `Added a Linux TCP example C++ application.`
+     - Bad: `Python changes`
+   - The pull request description should include a detailed summary of any relevant changes. If possible, the summary
+     should be organized into the following 3 sections as needed:
+     ```
+     # New Features
+     - Added a Linux TCP example C++ application.
+
+     # Changes
+     - Made example message display code common between multiple example applications.
+
+     # Fixes
+     - Fixed position plotting support.
+     ```
+
+### Updating To The Latest Changes (Rebasing)
+
+> TL;DR _Never_ use `git pull` or `git merge` when updating your code. Always use `git rebase`.
+>
+> ```
+> git fetch origin
+> git checkout my-feature
+> git rebase origin/master
+> git push -f my-fork my-feature
+> ```
+
+In this repository, we make an effort to maintain a linear Git history at all times. This means that, instead of using
+`git pull` to obtain the latest code changes, we use `git rebase`.
+
+![Courtesy of https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase.](
+https://wac-cdn.atlassian.com/dam/jcr:4e576671-1b7f-43db-afb5-cf8db8df8e4a/01%20What%20is%20git%20rebase.svg?cdnVersion=140)
+
+Having a linear history has a few advantages:
+- It makes the history simpler to follow by avoiding lots of merges back and forth between branches from multiple
+  developers.
+- It makes it possible to test changes quickly and easily when searching for the first place a bug was introduced by
+  searching one commit at a time.
+  - You can use `git bisect` to do this automatically.
+  - This is the reason we request [small commits with a single functional change](#make-the-change): so that each
+    commit can be tested if needed to confirm that it does what it intends and doesn't cause problems.
+- Conflicts are easier to resolve on larger branches since they happen at an individual commit level, and you can simply
+  correct that commit so that it does what it is supposed to with the new upstream `origin/master` changes.
+  - By contrast, when you have a conflict with a `git merge`, the conflicting code might include several unrelated
+    changes, and it can sometimes be hard to figure out the correct resolution.
+
+In general, rebasing is pretty simple. In order to update your code with the latest changes on `origin/master`, do the
+following:
+
+1. Fetch the latest changes.
+   ```
+   git fetch origin
+   ```
+2. Rebase your branch onto the new version of `origin/master`.
+   ```
+   git checkout my-feature
+   git rebase origin/master
+   ```
+   This recreates your commits one at a time as if they were created on top of the new version of `origin/master`. If
+   you hit a conflict, simply fix that commit so that it does what it was originally intended to do, and then continue
+   (`git rebase --continue`).
+
+   (Compare this with `git merge origin/master`, which you should _never_ do.)
+3. Update your fork using a force push.
+   ```
+   git push -f my-fork my-feature
+   ```
+
+`git rebase` has a lot of other really useful features. Most notably, you can use `fixup!` commits to correct issues in
+existing commits. For example, say we forgot a semicolon in a commit and that commit does not compile. We could do the
+following:
+```
+2231360 Added a new C++ example.
+ee2adc2 Fixed a serialization bug.
+113b2aa Fixed missing semicolon in new example.
+```
+but that means that commit `2231360` can't be compiled and tested when looking for a bug. Instead, you can mark the
+commit as a `fixup!`:
+```
+pick 2231360 Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+pick 113b2aa fixup! Added a new C++ example.
+```
+and then you can use an interactive rebase (`git rebase -i origin/master`) to squash them together before merging the
+changes:
+```
+pick 2231360 Added a new C++ example.
+fixup 113b2aa fixup! Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+```
+The resulting commit is a combination of the original change and the semicolon fix:
+```
+pick aabd112 Added a new C++ example.
+pick ee2adc2 Fixed a serialization bug.
+```
+
+See https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase for more information about rebasing.

--- a/examples/tcp_client/linux_tcp_client.cc
+++ b/examples/tcp_client/linux_tcp_client.cc
@@ -99,14 +99,12 @@ contents.
     if (bytes_read == 0) {
       printf("Socket closed remotely.\n");
       break;
-    }
-    else if (bytes_read < 0) {
+    } else if (bytes_read < 0) {
       printf("Error reading from socket: %s (%d)\n", std::strerror(errno),
              errno);
       ret = 4;
       break;
-    }
-    else {
+    } else {
       total_bytes_read += bytes_read;
       framer.OnData(buffer, (size_t)bytes_read);
     }

--- a/python/.pep8
+++ b/python/.pep8
@@ -1,0 +1,10 @@
+[pycodestyle]
+max_line_length = 120
+aggressive = 3
+recursive = true
+
+# - E265,E266 - Do not reformat double-# Doxygen comment blocks.
+# - E402 - Do not reorder imports to the top of the file (fusion_engine_client
+#   imports in the example applications must come after the sys.path.append()
+#   call).
+ignore = E265,E266,E402

--- a/python/examples/extract_position_data.py
+++ b/python/examples/extract_position_data.py
@@ -39,7 +39,7 @@ KML_TEMPLATE = """\
 if __name__ == "__main__":
     # Parse arguments.
     parser = ArgumentParser(description="""\
-Extract position data to both CSV and KML files.  
+Extract position data to both CSV and KML files.
 """)
     parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "

--- a/python/examples/message_decode.py
+++ b/python/examples/message_decode.py
@@ -54,6 +54,7 @@ def decode_message(header, data, offset):
 
     return True
 
+
 decode_message.expected_sequence_number = 0
 
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -428,8 +428,7 @@ class Analyzer(object):
 
         links = ''
         title_to_name = {e['title']: n for n, e in self.plots.items()}
-        titles = list(title_to_name.keys())
-        titles.sort()
+        titles = sorted(title_to_name.keys())
         for title in titles:
             name = title_to_name[title]
             entry = self.plots[name]
@@ -549,7 +548,7 @@ Duration: %(duration_sec).1f seconds
     def _open_browser(self, filename):
         try:
             webbrowser.open("file:///" + os.path.abspath(filename))
-        except:
+        except BaseException:
             self.logger.error("Unable to open web browser.")
 
     @classmethod

--- a/python/fusion_engine_client/analysis/attitude.py
+++ b/python/fusion_engine_client/analysis/attitude.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def get_ned_rotation_matrix(latitude, longitude, deg=False):
     """!
     @brief Get the rotation matrix resolving from ECEF to the local NED frame.

--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -63,7 +63,7 @@ class MessageData(object):
                         keep_idx = ~is_nan
                         for key, value in self.__dict__.items():
                             if (key not in ('message_type', 'message_class', 'params', 'messages') and
-                                isinstance(value, np.ndarray)):
+                                    isinstance(value, np.ndarray)):
                                 if len(value.shape) == 1:
                                     self.__dict__[key] = value[keep_idx]
                                 elif len(value.shape) == 2:
@@ -375,7 +375,7 @@ class FileReader(object):
         if num_needed == 0:
             # Nothing to read. Return cached data.
             self.logger.debug('Requested data already cached. [# types=%d, start=%s, end=%s]' %
-                              (len(message_types),  str(time_range[0]), str(time_range[1])))
+                              (len(message_types), str(time_range[0]), str(time_range[1])))
             return result
         elif self.file is None:
             raise IOError("File not open.")
@@ -545,7 +545,7 @@ class FileReader(object):
             if (not message_needed and
                 self.t0 is not None and
                 (not system_time_messages_requested or self.system_t0 is not None) and
-                not generate_index):
+                    not generate_index):
                 continue
 
             # Now decode the payload.
@@ -778,6 +778,7 @@ class FileReader(object):
                 # Now interlace messages with defaults as needed.
                 messages = entry['messages']
                 cls = entry['class']
+
                 def _get_value(i):
                     message_idx = message_indices[i]
                     if message_idx >= 0:

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -40,15 +40,15 @@ class Direction(IntEnum):
 
 
 class TransportType(IntEnum):
-  INVALID = 0,
-  SERIAL = 1,
-  FILE = 2,
-  TCP_CLIENT = 3,
-  TCP_SERVER = 4,
-  UDP_CLIENT = 5,
-  UDP_SERVER = 6,
-  ## This is used for requesting the configuration for all interfaces.
-  ALL = 255,
+    INVALID = 0,
+    SERIAL = 1,
+    FILE = 2,
+    TCP_CLIENT = 3,
+    TCP_SERVER = 4,
+    UDP_CLIENT = 5,
+    UDP_SERVER = 6,
+    ## This is used for requesting the configuration for all interfaces.
+    ALL = 255,
 
 
 class UpdateAction(IntEnum):
@@ -179,12 +179,14 @@ class DeviceLeverArmConfig(_conf_gen.Point3F):
     """
     pass
 
+
 @_conf_gen.create_config_class(ConfigType.GNSS_LEVER_ARM, _conf_gen.Point3FConstruct)
 class GnssLeverArmConfig(_conf_gen.Point3F):
     """!
     @brief The location of the GNSS antenna with respect to the vehicle body frame (in meters).
     """
     pass
+
 
 @_conf_gen.create_config_class(ConfigType.OUTPUT_LEVER_ARM, _conf_gen.Point3FConstruct)
 class OutputLeverArmConfig(_conf_gen.Point3F):
@@ -193,6 +195,7 @@ class OutputLeverArmConfig(_conf_gen.Point3F):
     """
     pass
 
+
 @_conf_gen.create_config_class(ConfigType.UART0_BAUD, _conf_gen.UInt32Construct)
 class Uart0BaudConfig(_conf_gen.IntegerVal):
     """!
@@ -200,12 +203,14 @@ class Uart0BaudConfig(_conf_gen.IntegerVal):
     """
     pass
 
+
 @_conf_gen.create_config_class(ConfigType.UART1_BAUD, _conf_gen.UInt32Construct)
 class Uart1BaudConfig(_conf_gen.IntegerVal):
     """!
     @brief The UART1 serial baud rate (in bits/second).
     """
     pass
+
 
 @_conf_gen.create_config_class(ConfigType.DEVICE_COARSE_ORIENTATION, _conf_gen.CoarseOrientationConstruct)
 class DeviceCourseOrientationConfig(_conf_gen.CoarseOrientation):
@@ -223,6 +228,7 @@ class DeviceCourseOrientationConfig(_conf_gen.CoarseOrientation):
       trunk)
     """
     pass
+
 
 @_conf_gen.create_config_class(ConfigType.INVALID, _conf_gen.EmptyConstruct)
 class InvalidConfig(_conf_gen.Empty):
@@ -266,7 +272,7 @@ class SetConfigMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if not isinstance(self.config_object, _conf_gen.ConfigClass):
             raise TypeError(f'The config_object member ({str(self.config_object)}) must be set to a class decorated '
-                             'with create_config_class.')
+                            'with create_config_class.')
         config_type = self.config_object.GetType()
         construct_obj = _conf_gen.CONFIG_MAP[config_type]
         data = construct_obj.build(self.config_object)
@@ -404,7 +410,7 @@ class ConfigResponseMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if not isinstance(self.config_object, _conf_gen.ConfigClass):
             raise TypeError(f'The config_object member ({str(self.config_object)}) must be set to a class decorated '
-                             'with create_config_class.')
+                            'with create_config_class.')
         values = dict(self.__dict__)
         config_type = self.config_object.GetType()
         construct_obj = _conf_gen.CONFIG_MAP[config_type]
@@ -457,6 +463,7 @@ class _OutputInterfaceConfigConstruct(Adapter):
     """!
     Adapter to handle setting `num_streams` implicitly.
     """
+
     def __init__(self):
         super().__init__(Struct(
             "output_interface" / _InterfaceIDConstruct,

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -116,7 +116,7 @@ class MessageType(IntEnum):
             try:
                 if int(type) >= MessageType.RESERVED:
                     return 'RESERVED (%s)' % str(type)
-            except:
+            except BaseException:
                 pass
 
             return 'UNKNOWN (%s)' % str(type)
@@ -201,8 +201,8 @@ class Timestamp:
 class MessageHeader:
     INVALID_SOURCE_ID = 0xFFFFFFFF
 
-    _SYNC0 = 0x2E # '.'
-    _SYNC1 = 0x31 # '1'
+    _SYNC0 = 0x2E  # '.'
+    _SYNC1 = 0x31  # '1'
 
     _FORMAT = '<BB2xIBBHIII'
     _SIZE: int = struct.calcsize(_FORMAT)
@@ -366,6 +366,7 @@ class MessagePayload:
     """!
     @brief Message payload API.
     """
+
     def __init__(self):
         pass
 
@@ -393,7 +394,8 @@ class MessagePayload:
         return repr(self)
 
 
-def PackedDataToBuffer(packed_data: bytes, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
+def PackedDataToBuffer(packed_data: bytes, buffer: bytes = None, offset: int = 0,
+                       return_buffer: bool = True) -> (bytes, int):
     if buffer is None:
         buffer = packed_data
     else:

--- a/python/fusion_engine_client/messages/ros.py
+++ b/python/fusion_engine_client/messages/ros.py
@@ -292,20 +292,21 @@ class IMUMessage(MessagePayload):
 
         offset += self.p1_time.pack(buffer, offset, return_buffer=False)
 
-        struct.pack_into(IMUMessage._FORMAT, buffer, offset,
-                         self.orientation[0], self.orientation[1], self.orientation[2], self.orientation[3],
-                         self.orientation_covariance[0], self.orientation_covariance[1], self.orientation_covariance[2],
-                         self.orientation_covariance[3], self.orientation_covariance[4], self.orientation_covariance[5],
-                         self.orientation_covariance[6], self.orientation_covariance[7], self.orientation_covariance[8],
-                         self.angular_velocity_rps[0], self.angular_velocity_rps[1], self.angular_velocity_rps[2],
-                         self.angular_velocity_covariance[0], self.angular_velocity_covariance[1], self.angular_velocity_covariance[2],
-                         self.angular_velocity_covariance[3], self.angular_velocity_covariance[4], self.angular_velocity_covariance[5],
-                         self.angular_velocity_covariance[6], self.angular_velocity_covariance[7], self.angular_velocity_covariance[8],
-                         self.acceleration_mps2[0], self.acceleration_mps2[1], self.acceleration_mps2[2],
-                         self.acceleration_covariance[0], self.acceleration_covariance[1], self.acceleration_covariance[2],
-                         self.acceleration_covariance[3], self.acceleration_covariance[4], self.acceleration_covariance[5],
-                         self.acceleration_covariance[6], self.acceleration_covariance[7], self.acceleration_covariance[8],
-                         )
+        struct.pack_into(
+            IMUMessage._FORMAT, buffer, offset,
+            self.orientation[0], self.orientation[1], self.orientation[2], self.orientation[3],
+            self.orientation_covariance[0], self.orientation_covariance[1], self.orientation_covariance[2],
+            self.orientation_covariance[3], self.orientation_covariance[4], self.orientation_covariance[5],
+            self.orientation_covariance[6], self.orientation_covariance[7], self.orientation_covariance[8],
+            self.angular_velocity_rps[0], self.angular_velocity_rps[1], self.angular_velocity_rps[2],
+            self.angular_velocity_covariance[0], self.angular_velocity_covariance[1], self.angular_velocity_covariance[2],  # noqa
+            self.angular_velocity_covariance[3], self.angular_velocity_covariance[4], self.angular_velocity_covariance[5],  # noqa
+            self.angular_velocity_covariance[6], self.angular_velocity_covariance[7], self.angular_velocity_covariance[8],  # noqa
+            self.acceleration_mps2[0], self.acceleration_mps2[1], self.acceleration_mps2[2],
+            self.acceleration_covariance[0], self.acceleration_covariance[1], self.acceleration_covariance[2],
+            self.acceleration_covariance[3], self.acceleration_covariance[4], self.acceleration_covariance[5],
+            self.acceleration_covariance[6], self.acceleration_covariance[7], self.acceleration_covariance[8],
+            )
 
         if return_buffer:
             return buffer
@@ -316,19 +317,19 @@ class IMUMessage(MessagePayload):
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
-        ( self.orientation[0], self.orientation[1], self.orientation[2], self.orientation[3],
-                         self.orientation_covariance[0], self.orientation_covariance[1], self.orientation_covariance[2],
-                         self.orientation_covariance[3], self.orientation_covariance[4], self.orientation_covariance[5],
-                         self.orientation_covariance[6], self.orientation_covariance[7], self.orientation_covariance[8],
-                         self.angular_velocity_rps[0], self.angular_velocity_rps[1], self.angular_velocity_rps[2],
-                         self.angular_velocity_covariance[0], self.angular_velocity_covariance[1], self.angular_velocity_covariance[2],
-                         self.angular_velocity_covariance[3], self.angular_velocity_covariance[4], self.angular_velocity_covariance[5],
-                         self.angular_velocity_covariance[6], self.angular_velocity_covariance[7], self.angular_velocity_covariance[8],
-                         self.acceleration_mps2[0], self.acceleration_mps2[1], self.acceleration_mps2[2],
-                         self.acceleration_covariance[0], self.acceleration_covariance[1], self.acceleration_covariance[2],
-                         self.acceleration_covariance[3], self.acceleration_covariance[4], self.acceleration_covariance[5],
-                         self.acceleration_covariance[6], self.acceleration_covariance[7], self.acceleration_covariance[8],
-                         ) = \
+        (self.orientation[0], self.orientation[1], self.orientation[2], self.orientation[3],
+         self.orientation_covariance[0], self.orientation_covariance[1], self.orientation_covariance[2],
+         self.orientation_covariance[3], self.orientation_covariance[4], self.orientation_covariance[5],
+         self.orientation_covariance[6], self.orientation_covariance[7], self.orientation_covariance[8],
+         self.angular_velocity_rps[0], self.angular_velocity_rps[1], self.angular_velocity_rps[2],
+         self.angular_velocity_covariance[0], self.angular_velocity_covariance[1], self.angular_velocity_covariance[2],
+         self.angular_velocity_covariance[3], self.angular_velocity_covariance[4], self.angular_velocity_covariance[5],
+         self.angular_velocity_covariance[6], self.angular_velocity_covariance[7], self.angular_velocity_covariance[8],
+         self.acceleration_mps2[0], self.acceleration_mps2[1], self.acceleration_mps2[2],
+         self.acceleration_covariance[0], self.acceleration_covariance[1], self.acceleration_covariance[2],
+         self.acceleration_covariance[3], self.acceleration_covariance[4], self.acceleration_covariance[5],
+         self.acceleration_covariance[6], self.acceleration_covariance[7], self.acceleration_covariance[8],
+         ) = \
             struct.unpack_from(IMUMessage._FORMAT,
                                buffer=buffer, offset=offset)
         offset += IMUMessage._SIZE

--- a/python/fusion_engine_client/parsers/decoder.py
+++ b/python/fusion_engine_client/parsers/decoder.py
@@ -80,7 +80,7 @@ class FusionEngineDecoder:
                 is not recognized, the second argument will be a `bytes` containing the uninterpreted payload contents.
         """
         # Cast singleton byte values to a byte array.
-        if type(data) == int:
+        if isinstance(data, int):
             data = data.to_bytes(1, 'big')
 
         # Append the new data to the buffer.

--- a/python/fusion_engine_client/utils/construct_utils.py
+++ b/python/fusion_engine_client/utils/construct_utils.py
@@ -124,6 +124,7 @@ class EnumAdapter(Adapter):
     def _encode(self, obj, context, path):
         return obj
 
+
 def AutoEnum(construct_cls, enum_cls):
     """!
     @brief Wrapper for @ref EnumAdapter to make its arguments simpler.

--- a/python/fusion_engine_client/utils/trace.py
+++ b/python/fusion_engine_client/utils/trace.py
@@ -12,6 +12,7 @@ if not hasattr(logging, 'TRACE'):
     else:
         logging._nameToLevel['TRACE'] = logging.TRACE
         logging._levelToName[logging.TRACE] = 'TRACE'
+
     def trace(self, msg, *args, **kwargs):
         self.log(logging.TRACE, msg, *args, **kwargs)
     logging.Logger.trace = trace

--- a/src/point_one/fusion_engine/common/portability.h
+++ b/src/point_one/fusion_engine/common/portability.h
@@ -11,28 +11,28 @@
 // - https://gcc.gnu.org/wiki/Visibility.
 // - https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/port_def.inc
 #if defined(_WIN32) || defined(_MSC_VER) || defined(__CYGWIN__)
-  #ifdef BUILDING_DLL
-    #ifdef __GNUC__
-      #define P1_EXPORT __attribute__ ((dllexport))
-    #else
-      #define P1_EXPORT __declspec(dllexport)
-    #endif
-  #else
-    #ifdef __GNUC__
-      #define P1_EXPORT __attribute__ ((dllimport))
-    #else
-      #define P1_EXPORT __declspec(dllimport)
-    #endif
-  #endif
-  #define P1_HIDDEN
+#  ifdef BUILDING_DLL
+#    ifdef __GNUC__
+#      define P1_EXPORT __attribute__((dllexport))
+#    else
+#      define P1_EXPORT __declspec(dllexport)
+#    endif
+#  else
+#    ifdef __GNUC__
+#      define P1_EXPORT __attribute__((dllimport))
+#    else
+#      define P1_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+#  define P1_HIDDEN
 #else
-  #if __GNUC__ >= 4
-    #define P1_EXPORT __attribute__ ((visibility ("default")))
-    #define P1_HIDDEN  __attribute__ ((visibility ("hidden")))
-  #else
-    #define P1_EXPORT
-    #define P1_HIDDEN
-  #endif
+#  if __GNUC__ >= 4
+#    define P1_EXPORT __attribute__((visibility("default")))
+#    define P1_HIDDEN __attribute__((visibility("hidden")))
+#  else
+#    define P1_EXPORT
+#    define P1_HIDDEN
+#  endif
 #endif
 
 // ssize_t is a POSIX extension and is not supported on Windows.
@@ -41,6 +41,6 @@ typedef int32_t p1_ssize_t;
 #elif defined(_MSC_VER)
 typedef int64_t p1_ssize_t;
 #else
-#include <sys/types.h> // For ssize_t
+#  include <sys/types.h> // For ssize_t
 typedef ssize_t p1_ssize_t;
 #endif

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -10,8 +10,8 @@
 // Zero-sized arrays are supported by MSVC, GCC, and Clang, and we use them as
 // convenience placeholders for variable sized message payloads.
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4200)
+#  pragma warning(push)
+#  pragma warning(disable : 4200)
 #endif
 
 #include <ostream>
@@ -678,7 +678,8 @@ struct alignas(4) GetOutputInterfaceConfigMessage : public MessagePayload {
  * ```
  */
 struct alignas(4) OutputInterfaceConfigResponseMessage : public MessagePayload {
-  static constexpr MessageType MESSAGE_TYPE = MessageType::OUTPUT_INFERFACE_STREAMS_DATA;
+  static constexpr MessageType MESSAGE_TYPE =
+      MessageType::OUTPUT_INFERFACE_STREAMS_DATA;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
   /** The source of the parameter value (active, saved, etc.). */
@@ -713,5 +714,5 @@ struct alignas(4) OutputInterfaceConfigResponseMessage : public MessagePayload {
 } // namespace point_one
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#  pragma warning(pop)
 #endif

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -10,8 +10,8 @@
 // Zero-sized arrays are supported by MSVC, GCC, and Clang, and we use them as
 // convenience placeholders for variable sized message payloads.
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4200)
+#  pragma warning(push)
+#  pragma warning(disable : 4200)
 #endif
 
 #include "point_one/fusion_engine/messages/defs.h"
@@ -316,5 +316,5 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
 } // namespace point_one
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#  pragma warning(pop)
 #endif

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -183,9 +183,12 @@ enum class MessageType : uint16_t {
   SAVE_CONFIG = 13102, ///< @ref SaveConfigMessage
   CONFIG_DATA = 13103, ///< @ref ConfigResponseMessage
 
-  SET_OUTPUT_INFERFACE_STREAMS = 13200, ///< @ref SetOutputInterfaceConfigMessage
-  GET_OUTPUT_INFERFACE_STREAMS = 13201, ///< @ref GetOutputInterfaceConfigMessage
-  OUTPUT_INFERFACE_STREAMS_DATA = 13202, ///< @ref OutputInterfaceConfigResponseMessage
+  SET_OUTPUT_INFERFACE_STREAMS =
+      13200, ///< @ref SetOutputInterfaceConfigMessage
+  GET_OUTPUT_INFERFACE_STREAMS =
+      13201, ///< @ref GetOutputInterfaceConfigMessage
+  OUTPUT_INFERFACE_STREAMS_DATA =
+      13202, ///< @ref OutputInterfaceConfigResponseMessage
 
   MAX_VALUE = CONFIG_DATA, ///< The maximum defined @ref MessageType enum value.
 };

--- a/src/point_one/fusion_engine/parsers/fusion_engine_framer.cc
+++ b/src/point_one/fusion_engine/parsers/fusion_engine_framer.cc
@@ -19,7 +19,7 @@ using namespace point_one::fusion_engine::parsers;
 
 /******************************************************************************/
 class PrintableByte {
-public:
+ public:
   uint8_t byte_;
 
   PrintableByte(uint8_t byte) : byte_(byte) {}
@@ -63,8 +63,7 @@ void FusionEngineFramer::SetBuffer(void* buffer, size_t capacity_bytes) {
   if (buffer == nullptr) {
     managed_buffer_.reset(new uint8_t[capacity_bytes]);
     buffer = managed_buffer_.get();
-  }
-  else if (buffer != managed_buffer_.get()) {
+  } else if (buffer != managed_buffer_.get()) {
     managed_buffer_.reset(nullptr);
   }
 
@@ -98,13 +97,11 @@ size_t FusionEngineFramer::OnData(const uint8_t* buffer, size_t length_bytes) {
       p1_ssize_t dispatched_message_size = OnByte(false);
       if (dispatched_message_size == 0) {
         // Waiting for more data. Nothing to do.
-      }
-      else if (dispatched_message_size > 0) {
+      } else if (dispatched_message_size > 0) {
         // Message framed successfully. Reset for the next one.
         next_byte_index_ = 0;
         total_dispatched_bytes += (size_t)dispatched_message_size;
-      }
-      else if (next_byte_index_ > 0) {
+      } else if (next_byte_index_ > 0) {
         // If OnByte() indicated an error (size < 0) and there is still data in
         // the buffer, either the CRC failed or the payload was too big to fit
         // in the buffer.
@@ -116,15 +113,13 @@ size_t FusionEngineFramer::OnData(const uint8_t* buffer, size_t length_bytes) {
         // somewhere after byte 0. Perform a resync operation to find valid
         // messages.
         total_dispatched_bytes += Resync();
-      }
-      else {
+      } else {
         // OnByte() caught an unrecoverable error and reset the buffer. Nothing
         // to do.
       }
     }
     return total_dispatched_bytes;
-  }
-  else {
+  } else {
     return 0;
   }
 }
@@ -161,8 +156,7 @@ p1_ssize_t FusionEngineFramer::OnByte(bool quiet) {
     if (byte == MessageHeader::SYNC0) {
       VLOG(4) << "Found sync byte 0.";
       state_ = State::SYNC1;
-    }
-    else {
+    } else {
       --next_byte_index_;
     }
   }
@@ -174,12 +168,10 @@ p1_ssize_t FusionEngineFramer::OnByte(bool quiet) {
       VLOG(4) << "Found duplicate sync byte 0.";
       state_ = State::SYNC1;
       --next_byte_index_;
-    }
-    else if (byte == MessageHeader::SYNC1) {
+    } else if (byte == MessageHeader::SYNC1) {
       VLOG(3) << "Preamble found. Waiting for header.";
       state_ = State::HEADER;
-    }
-    else {
+    } else {
       VLOG(4) << "Did not find sync byte 1. Resetting. [byte="
               << PrintableByte(byte) << "]";
       state_ = State::SYNC0;
@@ -214,14 +206,12 @@ p1_ssize_t FusionEngineFramer::OnByte(bool quiet) {
         else {
           state_ = State::DATA;
         }
-      }
-      else {
+      } else {
         if (quiet) {
           VLOG(2) << "Message too large for buffer. [size="
                   << current_message_size_
                   << " B, buffer_capacity=" << capacity_bytes_ << " B]";
-        }
-        else {
+        } else {
           LOG(WARNING) << "Message too large for buffer. [size="
                        << current_message_size_
                        << " B, buffer_capacity=" << capacity_bytes_ << " B]";
@@ -268,8 +258,7 @@ p1_ssize_t FusionEngineFramer::OnByte(bool quiet) {
       }
       state_ = State::SYNC0;
       return static_cast<p1_ssize_t>(current_message_size_);
-    }
-    else {
+    } else {
       if (quiet) {
         VLOG(2) << "CRC check failed. [message=" << header->message_type << " ("
                 << (unsigned)header->message_type
@@ -277,8 +266,7 @@ p1_ssize_t FusionEngineFramer::OnByte(bool quiet) {
                 << ", size=" << current_message_size_ << " B, crc=0x"
                 << std::hex << std::setfill('0') << std::setw(8) << crc
                 << ", expected_crc=0x" << std::setw(8) << header->crc << "]";
-      }
-      else {
+      } else {
         LOG(WARNING) << "CRC check failed. [message=" << header->message_type
                      << " (" << (unsigned)header->message_type
                      << "), seq=" << header->sequence_number
@@ -339,8 +327,7 @@ size_t FusionEngineFramer::Resync() {
         available_bytes -= offset;
         std::memmove(buffer_, buffer_ + offset, available_bytes);
         offset = 0;
-      }
-      else {
+      } else {
         VLOG(4) << "Skipping non-sync byte 0 @ offset " << offset << "/"
                 << available_bytes << ". [byte=" << PrintableByte(current_byte)
                 << "]";
@@ -374,8 +361,7 @@ size_t FusionEngineFramer::Resync() {
             << ". [message_size=" << message_size << ", "
             << (available_bytes - message_size - 1)
             << " candidate bytes remaining]";
-      }
-      else {
+      } else {
         --available_bytes;
         size_t prev_offset = offset;
         offset = 0;

--- a/src/point_one/fusion_engine/parsers/fusion_engine_framer.h
+++ b/src/point_one/fusion_engine/parsers/fusion_engine_framer.h
@@ -44,7 +44,7 @@ namespace parsers {
  * ```
  */
 class FusionEngineFramer {
-public:
+ public:
   /**
    * @brief Construct a framer instance with no buffer allocated.
    *
@@ -96,9 +96,7 @@ public:
    *
    * @param enabled If `true`, issue warnings on errors.
    */
-  void WarnOnError(bool enabled) {
-    warn_on_error_ = enabled;
-  }
+  void WarnOnError(bool enabled) { warn_on_error_ = enabled; }
 
   /**
    * @brief Specify a function to be called when a message is framed.


### PR DESCRIPTION
# Changes
- Run `clang-format` and `autopep8` in CI build to enforce style guidelines
- Run Python unit tests (`pytest`) in CI build
- Added a README section instructions for contributing to the repo