### PR TITLE
Added `print_contents` utility.

### DIFF
--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -69,6 +69,11 @@ other types of data.
         message_types = set(message_types)
 
     decoder = FusionEngineDecoder()
+
+    first_p1_time_sec = None
+    last_p1_time_sec = None
+    first_system_time_sec = None
+    last_system_time_sec = None
     total_messages = 0
     message_stats = {}
     with open(input_path, 'rb') as f:
@@ -83,6 +88,18 @@ other types of data.
             for (header, message) in messages:
                 if len(message_types) == 0 or header.message_type in message_types:
                     if options.summary:
+                        p1_time = message.__dict__.get('p1_time', None)
+                        if p1_time is not None:
+                            if first_p1_time_sec is None:
+                                first_p1_time_sec = float(p1_time)
+                            last_p1_time_sec = float(p1_time)
+
+                        system_time_ns = message.__dict__.get('system_time_ns', None)
+                        if system_time_ns is not None:
+                            if first_system_time_sec is None:
+                                first_system_time_sec = system_time_ns * 1e-9
+                            last_system_time_sec = system_time_ns * 1e-9
+
                         total_messages += 1
                         if header.message_type not in message_stats:
                             message_stats[header.message_type] = {
@@ -97,6 +114,10 @@ other types of data.
     if options.summary:
         print('Input file: %s' % input_path)
         print('Log ID: %s' % log_id)
+        if first_p1_time_sec is not None:
+            print('Duration: %d seconds' % (last_p1_time_sec - first_p1_time_sec))
+        elif first_system_time_sec is not None:
+            print('Duration: %d seconds' % (last_system_time_sec - first_system_time_sec))
         print('')
 
         format_string = '| {:<50} | {:>8} |'

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import os
+import sys
+
+# Add the Python root directory (fusion-engine-client/python/) to the import search path.
+root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(root_dir)
+
+from fusion_engine_client.messages import MessagePayload, message_type_to_class, message_type_by_name
+from fusion_engine_client.parsers import FusionEngineDecoder
+from fusion_engine_client.utils.log import locate_log
+
+
+def print_message(header, contents):
+    if isinstance(contents, MessagePayload):
+        parts = str(contents).split('\n')
+        parts[0] += ' [sequence=%d, size=%d B]' % (header.sequence_number, header.get_message_size())
+        print('\n'.join(parts))
+    else:
+        print('Decoded %s message [sequence=%d, size=%d B]' %
+              (header.get_type_string(), header.sequence_number, header.get_message_size()))
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="""\
+Decode and print the contents of messages contained in a *.p1log file or other
+binary file containing FusionEngine messages. The binary file may also contain
+other types of data.
+""")
+    parser.add_argument('-t', '--type', type=str, action='append',
+                        help="An optional list of class names corresponding with the message types to be displayed. "
+                             "Supported types:\n%s" % '\n'.join(['  %s' % c for c in message_type_by_name.keys()]))
+    parser.add_argument('-s', '--summary', action='store_true',
+                        help="Print a summary of the messages in the file.")
+
+    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+                        help="The base directory containing FusionEngine logs to be searched if a log pattern is "
+                             "specified.")
+    parser.add_argument('log',
+                        help="The log to be read. May be one of:\n"
+                             "- The path to a .p1log file\n"
+                             "- The path to a FusionEngine log directory\n"
+                             "- A pattern matching a FusionEngine log directory under the specified base directory "
+                             "(see find_fusion_engine_log() and --log-base-dir)")
+
+    options = parser.parse_args()
+
+    # Locate the input file and set the output directory.
+    input_path, log_id = locate_log(input_path=options.log, log_base_dir=options.log_base_dir, return_log_id=True)
+    if input_path is None:
+        # locate_log() will log an error.
+        sys.exit(1)
+
+    # If the user specified a set of message names, lookup their type values. Below, we will limit the printout to only
+    # those message types.
+    message_types = []
+    if options.type is not None:
+        # Convert to lowercase to perform case-insensitive search.
+        type_by_name = {k.lower(): v for k, v in message_type_by_name.items()}
+        for name in options.type:
+            message_type = type_by_name.get(name.lower(), None)
+            if message_type is None:
+                print("Unrecognized message type '%s'." % name)
+                sys.exit(1)
+            else:
+                message_types.append(message_type)
+        message_types = set(message_types)
+
+    decoder = FusionEngineDecoder()
+    total_messages = 0
+    message_stats = {}
+    with open(input_path, 'rb') as f:
+        while True:
+            # Read the next message header.
+            data = f.read(1024)
+            if len(data) == 0:
+                break
+
+            # Decode the incoming data and print the contents of any complete messages.
+            messages = decoder.on_data(data)
+            for (header, message) in messages:
+                if len(message_types) == 0 or header.message_type in message_types:
+                    if options.summary:
+                        total_messages += 1
+                        if header.message_type not in message_stats:
+                            message_stats[header.message_type] = {
+                                'count': 1
+                            }
+                        else:
+                            entry = message_stats[header.message_type]
+                            entry['count'] += 1
+                    else:
+                        print_message(header, message)
+
+    if options.summary:
+        print('Input file: %s' % input_path)
+        print('Log ID: %s' % log_id)
+        print('')
+
+        format_string = '| {:<50} | {:>8} |'
+        print(format_string.format('Message Type', 'Count'))
+        print(format_string.format('-' * 50, '-' * 8))
+        for type, info in message_stats.items():
+            print(format_string.format(message_type_to_class[type].__name__, info['count']))
+        print(format_string.format('-' * 50, '-' * 8))
+        print(format_string.format('Total', total_messages))

--- a/python/fusion_engine_client/messages/__init__.py
+++ b/python/fusion_engine_client/messages/__init__.py
@@ -34,3 +34,5 @@ message_type_to_class = {
 }
 
 messages_with_system_time = [t for t, c in message_type_to_class.items() if hasattr(c(), 'system_time_ns')]
+
+message_type_by_name = {c.__name__: t for t, c in message_type_to_class.items()}

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -266,12 +266,13 @@ class VersionInfoMessage(MessagePayload):
         return parsed._io.tell()
 
     def __str__(self):
-        fields = ['system_time_ns', 'fw_version_str', 'engine_version_str', 'hw_version_str', 'rx_version_str']
         string = f'Version Data\n'
-        for field in fields:
-            val = str(self.__dict__[field]).replace('Container:', '')
-            string += f'  {field}: {val}\n'
-        return string.rstrip()
+        string += f'  System time: %.1f sec\n' % (self.system_time_ns * 1e-9)
+        string += f'  Firmware: {self.fw_version_str}\n'
+        string += f'  FusionEngine: {self.engine_version_str}\n'
+        string += f'  Hardware: {self.hw_version_str}\n'
+        string += f'  GNSS receiver: {self.rx_version_str}'
+        return string
 
     def calcsize(self) -> int:
         return len(self.pack())

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -375,6 +375,10 @@ class MessagePayload:
         return cls.MESSAGE_TYPE
 
     @classmethod
+    def get_type_string(cls):
+        return MessageType.get_type_string(cls.get_type())
+
+    @classmethod
     def get_version(cls) -> int:
         return cls.MESSAGE_VERSION
 

--- a/python/fusion_engine_client/parsers/decoder.py
+++ b/python/fusion_engine_client/parsers/decoder.py
@@ -95,6 +95,9 @@ class FusionEngineDecoder:
         if isinstance(data, int):
             data = data.to_bytes(1, 'big')
 
+        if len(data) == 0:
+            return []
+
         # Append the new data to the buffer.
         self._buffer += data
 

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -4,6 +4,7 @@ import os
 import logging
 
 from ..messages import MessageHeader, MessageType
+from ..utils import trace
 
 _logger = logging.getLogger('point_one.utils.log')
 

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -142,7 +142,7 @@ def find_log_file(input_path, candidate_files=None, return_output_dir=False, ret
     @param return_log_id If `True`, return the ID of the log if the requested path is a FusionEngine log.
     @param log_base_dir The base directory to be searched when performing a pattern match for a log directory.
 
-    @return A tuple containing:
+    @return The path to the located file or a tuple containing:
             - The path to the located file.
             - The path to the located output directory. Only provided if `return_output_dir` is `True`.
             - The log ID string, or `None` if the requested file is not part of a FusionEngine log. Only provided if
@@ -216,7 +216,10 @@ def find_log_file(input_path, candidate_files=None, return_output_dir=False, ret
     if return_log_id:
         result.append(log_id)
 
-    return result
+    if len(result) == 1:
+        return result[0]
+    else:
+        return tuple(result)
 
 
 def find_p1log_file(input_path, return_output_dir=False, return_log_id=False, log_base_dir='/logs'):
@@ -236,7 +239,7 @@ def find_p1log_file(input_path, return_output_dir=False, return_log_id=False, lo
     @param return_log_id If `True`, return the ID of the log if the requested path is a FusionEngine log.
     @param log_base_dir The base directory to be searched when performing a pattern match for a log directory.
 
-    @return A tuple containing:
+    @return The path to the located file or a tuple containing:
             - The path to the located file.
             - The path to the located output directory. Only provided if `return_output_dir` is `True`.
             - The log ID string, or `None` if the requested file is not part of a FusionEngine log. Only provided if
@@ -247,7 +250,11 @@ def find_p1log_file(input_path, return_output_dir=False, return_log_id=False, lo
                        'filter/output/fe_service/output.p1bin']
     result = find_log_file(input_path, candidate_files=candidate_files, return_output_dir=return_output_dir,
                            return_log_id=return_log_id, log_base_dir=log_base_dir)
-    p1log_path = result[0]
+    if isinstance(result, tuple):
+        p1log_path = result[0]
+    else:
+        p1log_path = result
+
     if p1log_path.endswith('.p1log') or p1log_path.endswith('filter/output/fe_service/output.p1bin'):
         return result
     else:
@@ -379,7 +386,7 @@ def locate_log(input_path, log_base_dir='/logs', return_output_dir=False, return
     @param return_output_dir If `True`, return the output directory associated with the located input file.
     @param return_log_id If `True`, return the ID of the log if the requested path is a FusionEngine log.
 
-    @return A tuple of:
+    @return The path to the located file or a tuple of:
             - The path to the located (or extracted) `*.p1log` file
             - The path to the located output directory. Only provided if `return_output_dir` is `True`.
             - The log ID string, or `None` if the requested file is not part of a FusionEngine log. Only provided if
@@ -408,7 +415,10 @@ def locate_log(input_path, log_base_dir='/logs', return_output_dir=False, return
         try:
             result = find_log_file(input_path, candidate_files=CANDIDATE_MIXED_FILES, log_base_dir=log_base_dir,
                                    return_output_dir=return_output_dir, return_log_id=return_log_id)
-            mixed_file_path = result[0]
+            if isinstance(result, tuple):
+                mixed_file_path = result[0]
+            else:
+                mixed_file_path = result
         except (FileNotFoundError, RuntimeError) as e:
             _logger.error(str(e))
             result = [None]
@@ -416,7 +426,11 @@ def locate_log(input_path, log_base_dir='/logs', return_output_dir=False, return
                 result.append(None)
             if return_log_id:
                 result.append(None)
-            return result
+
+            if len(result) == 1:
+                return result[0]
+            else:
+                return tuple(result)
 
     # Now, search for FusionEngine messages within the mixed binary data.
     _logger.info("Found mixed-content log file '%s'." % mixed_file_path)
@@ -429,9 +443,15 @@ def locate_log(input_path, log_base_dir='/logs', return_output_dir=False, return
     _logger.info("Extracting FusionEngine content to '%s'." % fe_path)
     num_messages = extract_fusion_engine_log(input_path=mixed_file_path, output_path=fe_path)
     if num_messages > 0:
-        result = list(result)
-        result[0] = fe_path
-        return result
+        if isinstance(result, tuple):
+            result = list(result)
+            result[0] = fe_path
+            return tuple(result)
+        else:
+            return result
     else:
         _logger.warning('No FusionEngine data extracted from mixed data file.')
-        return [None for _ in result]
+        if isinstance(result, tuple):
+            return [None for _ in result]
+        else:
+            return None


### PR DESCRIPTION
# New Features
- Added `print_contents.py` tool to print summary of logged FusionEngine messages

# Changes
- Return the path string directly in `locate_log()` if no `return_*` options are enabled, rather than a length-1 tuple

# Fixes
- Fixed missing import in `log.py`