### PR TITLE
Defined "fast IMU corrections" reset bit.

### DIFF
--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -121,7 +121,7 @@ class ResetRequest(MessagePayload):
     ## Restart the navigation engine, but do not clear its position estimate.
     RESTART_NAVIGATION_ENGINE = 0x00000001
     ## Delete all GNSS corrections information.
-    RESET_CORRECTIONS = 0x00000002
+    RESET_GNSS_CORRECTIONS = 0x00000002
     ## @}
 
     ##
@@ -131,20 +131,24 @@ class ResetRequest(MessagePayload):
     RESET_POSITION_DATA = 0x00000100
     ## Delete all saved satellite ephemeris.
     RESET_EPHEMERIS = 0x00000200
+    ## Reset bias estimates, and other IMU corrections that are typically estimated quickly.
+    RESET_FAST_IMU_CORRECTIONS = 0x00000400
     ## @}
 
     ##
     # @name Clear Long Lived Data
     # @{
-    ## Reset all stored navigation engine data, including position, velocity, and orientation state, as well as training
-    ## data.
+    ##
+    # Reset all stored navigation engine data, including position, velocity, and orientation state, as well as all IMU
+    # corrections (fast and slow) and other training data.
     RESET_NAVIGATION_ENGINE_DATA = 0x00001000
 
-    ## Reset the device calibration data.
     ##
-    ## @note
-    ## This does _not_ reset any existing navigation engine state. It is recommended that you set @ref
-    ## RESET_NAVIGATION_ENGINE_DATA as well under normal circumstances.
+    # Reset the device calibration data.
+    #
+    # @note
+    # This does _not_ reset any existing navigation engine state. It is recommended that you set @ref
+    # RESET_NAVIGATION_ENGINE_DATA as well under normal circumstances.
     RESET_CALIBRATION_DATA = 0x00002000
     ## @}
 
@@ -159,30 +163,68 @@ class ResetRequest(MessagePayload):
     # @name Device Reset Bitmasks
     # @{
 
-    ## Perform a device hot start: reload the navigation engine and clear all runtime data (GNSS corrections, etc.), but
-    ## do not reset any saved state data (position, orientation, training parameters, calibration, etc.).
     ##
-    ## A hot start is typically used to restart the navigation engine in a deterministic state, particularly for logging
-    ## purposes.
+    # Perform a device hot start.
+    #
+    # A hot start is typically used to restart the navigation engine in a
+    # deterministic state, particularly for logging purposes.
+    #
+    # To be reset:
+    # - The navigation engine (@ref RESTART_NAVIGATION_ENGINE)
+    # - All runtime data (GNSS corrections (@ref RESET_GNSS_CORRECTIONS), etc.)
+    #
+    # Not reset:
+    # - Position, velocity, orientation (@ref RESET_POSITION_DATA)
+    # - Calibration data (@ref RESET_CALIBRATION_DATA)
+    # - User configuration settings (@ref RESET_CONFIG)
     HOT_START = 0x000000FF
 
-    ## Perform a device warm start: reload the navigation engine, resetting the saved position, velocity, and
-    ## orientation, but do not reset training parameters or calibration data.
     ##
-    ## A warm start is typically used to reset the device's position estimate in case of error.
+    # Perform a device warm start.
+    #
+    # A warm start is typically used to reset the device's estimate of position
+    # and kinematic state in case of error.
+    #
+    # To be reset:
+    # - The navigation engine (@ref RESTART_NAVIGATION_ENGINE)
+    # - All runtime data (GNSS corrections (@ref RESET_GNSS_CORRECTIONS), etc.)
+    # - Position, velocity, orientation (@ref RESET_POSITION_DATA)
+    #
+    # Not reset:
+    # - Fast IMU corrections (@ref RESET_FAST_IMU_CORRECTIONS)
+    # - Training parameters (slowly estimated IMU corrections, temperature
+    #   compensation, etc.; @ref RESET_NAVIGATION_ENGINE_DATA)
+    # - Calibration data (@ref RESET_CALIBRATION_DATA)
+    # - User configuration settings (@ref RESET_CONFIG)
     WARM_START = 0x000001FF
 
-    ## Perform a device cold start: reset the navigation engine including saved position, velocity, and orientation
-    ## state, but do not reset training data, calibration data, or user configuration parameters.
     ##
-    ## @note
-    ## To reset training or calibration data as well, set the @ref RESET_NAVIGATION_ENGINE_DATA and @ref
-    ## RESET_CALIBRATION_DATA bits.
+    # Perform a device cold start.
+    #
+    # A cold start is typically used to reset the device's state estimate in the
+    # case of error that cannot be resolved by a @ref WARM_START.
+    #
+    # To be reset:
+    # - The navigation engine (@ref RESTART_NAVIGATION_ENGINE)
+    # - All runtime data (GNSS corrections (@ref RESET_GNSS_CORRECTIONS), etc.)
+    # - Position, velocity, orientation (@ref RESET_POSITION_DATA)
+    # - Fast IMU corrections (@ref RESET_FAST_IMU_CORRECTIONS)
+    #
+    # Not reset:
+    # - Training parameters (slowly estimated IMU corrections, temperature
+    #   compensation, etc.; @ref RESET_NAVIGATION_ENGINE_DATA)
+    # - Calibration data (@ref RESET_CALIBRATION_DATA)
+    # - User configuration settings (@ref RESET_CONFIG)
+    #
+    # @note
+    # To reset training or calibration data as well, set the @ref
+    # RESET_NAVIGATION_ENGINE_DATA and @ref RESET_CALIBRATION_DATA bits.
     COLD_START = 0x00000FFF
 
-    ## Restart mask to set all persistent data, including calibration and user configuration, back to factory defaults.
     ##
-    ## Note: Upper 8 bits reserved for future use (e.g., hardware reset).
+    # Restart mask to set all persistent data, including calibration and user configuration, back to factory defaults.
+    #
+    # Note: Upper 8 bits reserved for future use (e.g., hardware reset).
     FACTORY_RESET = 0x00FFFFFF
 
     ## @}


### PR DESCRIPTION
This distinguishes between IMU corrections that may be observed quickly, and those that take more time to estimate.