### PR TITLE
Added mixed content support to all example applications.

### DIFF
--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -14,7 +14,7 @@ from fusion_engine_client.analysis.file_index import FileIndex, FileIndexBuilder
 from fusion_engine_client.messages import MessageHeader, MessagePayload, message_type_to_class, message_type_by_name
 from fusion_engine_client.parsers import FusionEngineDecoder
 from fusion_engine_client.utils.argument_parser import ArgumentParser
-from fusion_engine_client.utils.log import locate_log
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 from fusion_engine_client.utils.time_range import TimeRange
 
 
@@ -65,7 +65,7 @@ other types of data.
              "file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
              "improve data read speed in the future.")
     log_parser.add_argument(
-        '--log-base-dir', metavar='DIR', default='/logs',
+        '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
         help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
     log_parser.add_argument(
         'log',

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -70,7 +70,7 @@ other types of data.
     log_parser.add_argument(
         'log',
         help="The log to be read. May be one of:\n"
-             "- The path to a .p1log file\n"
+             "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
              "- The path to a FusionEngine log directory\n"
              "- A pattern matching a FusionEngine log directory under the specified base directory "
              "(see find_fusion_engine_log() and --log-base-dir)")

--- a/python/bin/separate_mixed_log.py
+++ b/python/bin/separate_mixed_log.py
@@ -11,7 +11,8 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.utils.argument_parser import ArgumentParser
 from fusion_engine_client.utils import trace
-from fusion_engine_client.utils.log import extract_fusion_engine_log, find_log_file, CANDIDATE_MIXED_FILES
+from fusion_engine_client.utils.log import extract_fusion_engine_log, find_log_file, CANDIDATE_MIXED_FILES, \
+    DEFAULT_LOG_BASE_DIR
 
 
 def main():
@@ -20,7 +21,7 @@ Extract FusionEngine message contents from a binary file containing mixed data
 (e.g., interleaved RTCM and FusionEngine messages).
 """)
 
-    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is"
                              "specified.")
     parser.add_argument('-c', '--candidate-files', type=str, metavar='DIR',

--- a/python/examples/analyze_data.py
+++ b/python/examples/analyze_data.py
@@ -45,15 +45,17 @@ Compute the average LLA position for the data contained in a *.p1log file.
         logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
 
     # Read pose data from the file.
+    #
+    # Note that we explicitly ask the FileReader to return the data converted to numpy arrays so we can analyze it
+    # below.
     reader = FileReader(input_path)
-    result = reader.read(message_types=[PoseMessage], show_progress=True)
+    result = reader.read(message_types=[PoseMessage], show_progress=True, return_numpy=True)
 
     # Print out the messages that were read.
     pose_data = result[PoseMessage.MESSAGE_TYPE]
     for message in pose_data.messages:
         logger.info(str(message))
 
-    # Convert the data to numpy arrays for analysis, then compute and print the average LLA value.
-    pose_data.to_numpy()
+    # Compute and print the average LLA value.
     mean_lla_deg = np.mean(pose_data.lla_deg, axis=1)
     logger.info('Average position: %.6f, %.6f, %.3f' % tuple(mean_lla_deg))

--- a/python/examples/analyze_data.py
+++ b/python/examples/analyze_data.py
@@ -10,24 +10,42 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader
 from fusion_engine_client.messages.core import *
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
 Compute the average LLA position for the data contained in a *.p1log file.
-
-Note that the specified file must contain only FusionEngine messages. For logs
-containing mixed content, see separate_mixed_log.py.
 """)
-    parser.add_argument('file', type=str, help="The path to a binary file to be read.")
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
+                        help="The base directory containing FusionEngine logs to be searched if a log pattern is "
+                             "specified.")
+    parser.add_argument('log',
+                        help="The log to be read. May be one of:\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
+                             "- The path to a FusionEngine log directory\n"
+                             "- A pattern matching a FusionEngine log directory under the specified base directory "
+                             "(see find_fusion_engine_log() and --log-base-dir)")
     options = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s:%(lineno)d - %(message)s')
     logger = logging.getLogger('point_one.fusion_engine')
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
+
+    # Locate the input file and set the output directory.
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir)
+    if input_path is None:
+        sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
 
     # Read pose data from the file.
-    reader = FileReader(options.file)
+    reader = FileReader(input_path)
     result = reader.read(message_types=[PoseMessage], show_progress=True)
 
     # Print out the messages that were read.

--- a/python/examples/analyze_data.py
+++ b/python/examples/analyze_data.py
@@ -56,6 +56,7 @@ Compute the average LLA position for the data contained in a *.p1log file.
     for message in pose_data.messages:
         logger.info(str(message))
 
-    # Compute and print the average LLA value.
-    mean_lla_deg = np.mean(pose_data.lla_deg, axis=1)
+    # Compute and print the average LLA value. Limit only to valid solutions.
+    idx = pose_data.solution_type != SolutionType.Invalid
+    mean_lla_deg = np.mean(pose_data.lla_deg[:, idx], axis=1)
     logger.info('Average position: %.6f, %.6f, %.3f' % tuple(mean_lla_deg))

--- a/python/examples/extract_imu_data.py
+++ b/python/examples/extract_imu_data.py
@@ -10,7 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file
+from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
 
 if __name__ == "__main__":
     # Parse arguments.
@@ -20,7 +20,7 @@ Extract IMU accelerometer and gyroscope measurements.
 Note that the specified file must contain only FusionEngine messages. For logs
 containing mixed content, see separate_mixed_log.py.
 """)
-    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',

--- a/python/examples/extract_imu_data.py
+++ b/python/examples/extract_imu_data.py
@@ -10,22 +10,20 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 if __name__ == "__main__":
     # Parse arguments.
     parser = ArgumentParser(description="""\
 Extract IMU accelerometer and gyroscope measurements.
-
-Note that the specified file must contain only FusionEngine messages. For logs
-containing mixed content, see separate_mixed_log.py.
 """)
     parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',
                         help="The log to be read. May be one of:\n"
-                             "- The path to a .p1log file\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
                              "- The path to a FusionEngine log directory\n"
                              "- A pattern matching a FusionEngine log directory under the specified base directory "
                              "(see find_fusion_engine_log() and --log-base-dir)")
@@ -37,17 +35,15 @@ containing mixed content, see separate_mixed_log.py.
     logger.setLevel(logging.INFO)
 
     # Locate the input file and set the output directory.
-    try:
-        input_path, output_dir, log_id = find_p1log_file(options.log, return_output_dir=True, return_log_id=True,
-                                                         log_base_dir=options.log_base_dir)
-
-        if log_id is None:
-            logger.info('Loading %s.' % os.path.basename(input_path))
-        else:
-            logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
-    except FileNotFoundError as e:
-        logger.error(str(e))
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir)
+    if input_path is None:
         sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
 
     # Read satellite data from the file.
     reader = FileReader(input_path)

--- a/python/examples/extract_position_data.py
+++ b/python/examples/extract_position_data.py
@@ -10,7 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader, TimeAlignmentMode
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file
+from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
 
 KML_TEMPLATE = """\
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -44,7 +44,7 @@ Extract position data to both CSV and KML files.
 Note that the specified file must contain only FusionEngine messages. For logs
 containing mixed content, see separate_mixed_log.py.
 """)
-    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',

--- a/python/examples/extract_position_data.py
+++ b/python/examples/extract_position_data.py
@@ -10,7 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader, TimeAlignmentMode
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 KML_TEMPLATE = """\
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -40,16 +40,14 @@ if __name__ == "__main__":
     # Parse arguments.
     parser = ArgumentParser(description="""\
 Extract position data to both CSV and KML files.
-
-Note that the specified file must contain only FusionEngine messages. For logs
-containing mixed content, see separate_mixed_log.py.
 """)
     parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',
                         help="The log to be read. May be one of:\n"
-                             "- The path to a .p1log file\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
                              "- The path to a FusionEngine log directory\n"
                              "- A pattern matching a FusionEngine log directory under the specified base directory "
                              "(see find_fusion_engine_log() and --log-base-dir)")
@@ -61,17 +59,15 @@ containing mixed content, see separate_mixed_log.py.
     logger.setLevel(logging.INFO)
 
     # Locate the input file and set the output directory.
-    try:
-        input_path, output_dir, log_id = find_p1log_file(options.log, return_output_dir=True, return_log_id=True,
-                                                         log_base_dir=options.log_base_dir)
-
-        if log_id is None:
-            logger.info('Loading %s.' % os.path.basename(input_path))
-        else:
-            logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
-    except FileNotFoundError as e:
-        logger.error(str(e))
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir)
+    if input_path is None:
         sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
 
     # Read pose and satellite data from the file.
     #

--- a/python/examples/extract_satellite_info.py
+++ b/python/examples/extract_satellite_info.py
@@ -10,22 +10,20 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 if __name__ == "__main__":
     # Parse arguments.
     parser = ArgumentParser(description="""\
 Extract satellite azimuth, elevation, and L1 signal C/N0 data to a CSV file.
-
-Note that the specified file must contain only FusionEngine messages. For logs
-containing mixed content, see separate_mixed_log.py.
 """)
     parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',
                         help="The log to be read. May be one of:\n"
-                             "- The path to a .p1log file\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
                              "- The path to a FusionEngine log directory\n"
                              "- A pattern matching a FusionEngine log directory under the specified base directory "
                              "(see find_fusion_engine_log() and --log-base-dir)")
@@ -37,17 +35,15 @@ containing mixed content, see separate_mixed_log.py.
     logger.setLevel(logging.INFO)
 
     # Locate the input file and set the output directory.
-    try:
-        input_path, output_dir, log_id = find_p1log_file(options.log, return_output_dir=True, return_log_id=True,
-                                                         log_base_dir=options.log_base_dir)
-
-        if log_id is None:
-            logger.info('Loading %s.' % os.path.basename(input_path))
-        else:
-            logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
-    except FileNotFoundError as e:
-        logger.error(str(e))
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir)
+    if input_path is None:
         sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
 
     # Read satellite data from the file.
     reader = FileReader(input_path)

--- a/python/examples/extract_satellite_info.py
+++ b/python/examples/extract_satellite_info.py
@@ -10,7 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.analysis.file_reader import FileReader
 from fusion_engine_client.messages.core import *
-from fusion_engine_client.utils.log import find_p1log_file
+from fusion_engine_client.utils.log import find_p1log_file, DEFAULT_LOG_BASE_DIR
 
 if __name__ == "__main__":
     # Parse arguments.
@@ -20,7 +20,7 @@ Extract satellite azimuth, elevation, and L1 signal C/N0 data to a CSV file.
 Note that the specified file must contain only FusionEngine messages. For logs
 containing mixed content, see separate_mixed_log.py.
 """)
-    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',

--- a/python/examples/message_decode.py
+++ b/python/examples/message_decode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from argparse import ArgumentParser
+import logging
 import os
 import sys
 
@@ -9,6 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.messages.core import MessagePayload
 from fusion_engine_client.parsers import FusionEngineDecoder
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 
 def print_message(header, contents):
@@ -27,10 +29,41 @@ Decode and print the contents of messages contained in a *.p1log file or other
 binary file containing FusionEngine messages. The binary file may also contain
 other types of data.
 """)
-    parser.add_argument('file', type=str, help="The path to a binary file to be read.")
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
+                        help="The base directory containing FusionEngine logs to be searched if a log pattern is "
+                             "specified.")
+    parser.add_argument('log',
+                        help="The log to be read. May be one of:\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
+                             "- The path to a FusionEngine log directory\n"
+                             "- A pattern matching a FusionEngine log directory under the specified base directory "
+                             "(see find_fusion_engine_log() and --log-base-dir)")
     options = parser.parse_args()
 
-    f = open(options.file, 'rb')
+    # Configure logging.
+    logging.basicConfig(format='%(message)s')
+    logger = logging.getLogger('point_one.fusion_engine')
+    logger.setLevel(logging.INFO)
+
+    # Locate the input file and set the output directory.
+    #
+    # Note here that we intentionally tell locate_log() _not_ to convert the input file to a *.p1log file
+    # (extract_fusion_engine_data=False). That way, if it finds a file containing a mix of FusionEngine messages and
+    # other data, we can use that file directly to demonstrate how the FusionEngineDecoder class operates.
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir, extract_fusion_engine_data=False)
+    if input_path is None:
+        sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
+
+    # Read binary data from the file a 1 KB chunk at a time and decode any FusionEngine messages in the stream. Any data
+    # that is not part of a FusionEngine message will be ignored.
+    f = open(input_path, 'rb')
 
     decoder = FusionEngineDecoder()
     while True:

--- a/python/examples/raw_message_decode.py
+++ b/python/examples/raw_message_decode.py
@@ -40,8 +40,8 @@ def decode_message(header, data, offset):
     elif header.message_type == GNSSSatelliteMessage.MESSAGE_TYPE:
         contents = GNSSSatelliteMessage()
         contents.unpack(buffer=data, offset=offset)
-    elif header.message_type == ros.PoseMessage.MESSAGE_TYPE:
-        contents = ros.PoseMessage()
+    elif header.message_type == ros.ROSPoseMessage.MESSAGE_TYPE:
+        contents = ros.ROSPoseMessage()
         contents.unpack(buffer=data, offset=offset)
     elif header.message_type == ros.ROSGPSFixMessage.MESSAGE_TYPE:
         contents = ros.ROSGPSFixMessage()

--- a/python/examples/raw_message_decode.py
+++ b/python/examples/raw_message_decode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from argparse import ArgumentParser
+import logging
 import os
 import sys
 
@@ -9,6 +10,7 @@ sys.path.append(root_dir)
 
 from fusion_engine_client.messages.core import *
 from fusion_engine_client.messages import ros
+from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 
 from examples.message_decode import print_message
 
@@ -63,14 +65,42 @@ decode_message.expected_sequence_number = 0
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
 Manually decode and print the contents of messages contained in a *.p1log file.
-
-Note that this application assumes the file contains _only_ FusionEngine
-messages. For files containing mixed content, see message_decode.py.
 """)
-    parser.add_argument('file', type=str, help="The path to a binary file to be read.")
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
+                        help="The base directory containing FusionEngine logs to be searched if a log pattern is "
+                             "specified.")
+    parser.add_argument('log',
+                        help="The log to be read. May be one of:\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
+                             "- The path to a FusionEngine log directory\n"
+                             "- A pattern matching a FusionEngine log directory under the specified base directory "
+                             "(see find_fusion_engine_log() and --log-base-dir)")
     options = parser.parse_args()
 
-    f = open(options.file, 'rb')
+    # Configure logging.
+    logging.basicConfig(format='%(message)s')
+    logger = logging.getLogger('point_one.fusion_engine')
+    logger.setLevel(logging.INFO)
+
+    # Locate the input file and set the output directory.
+    #
+    # Note that, unlike the message_decode.py example, here we _do_ ask locate_log() to create a *.p1log file for us if
+    # it finds an input file containing a mix of FusionEngine messages and other data. The loop below assumes that the
+    # file we are reading contains _only_ FusionEngine messages.
+    input_path, output_dir, log_id = locate_log(options.log, return_output_dir=True, return_log_id=True,
+                                                log_base_dir=options.log_base_dir)
+    if input_path is None:
+        sys.exit(1)
+
+    if log_id is None:
+        logger.info('Loading %s.' % os.path.basename(input_path))
+    else:
+        logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
+
+    # Read one FusionEngine message at a time from the binary file. If the file contains any data that is not part of a
+    # valid FusionEngine message, we will exit immediately.
+    f = open(input_path, 'rb')
 
     while True:
         # Read the next message header.

--- a/python/examples/raw_tcp_client.py
+++ b/python/examples/raw_tcp_client.py
@@ -15,21 +15,21 @@ from examples.raw_message_decode import decode_message
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
-Connect to an Atlas device over TCP and print out the incoming message
-contents.
+Connect to an Point One device over TCP and print out the incoming message
+contents and/or log the messages to disk.
 
 This example interprets the incoming data directly, and does not use the
 FusionEngineDecoder class. The incoming data stream must contain only
 FusionEngine messages. See also tcp_client.py.
 """)
     parser.add_argument('-p', '--port', type=int, default=30201,
-                        help="The FusionEngine TCP port on the Atlas device.")
-    parser.add_argument('ip_address',
-                        help="The IP address of the Atlas device.")
+                        help="The FusionEngine TCP port on the data source.")
+    parser.add_argument('hostname',
+                        help="The IP address or hostname of the data source.")
     options = parser.parse_args()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((options.ip_address, options.port))
+    sock.connect((socket.gethostbyname(options.hostname), options.port))
 
     received_data = b''
     current_header = None

--- a/python/examples/tcp_client.py
+++ b/python/examples/tcp_client.py
@@ -16,7 +16,7 @@ from examples.message_decode import print_message
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
-Connect to an Atlas device over TCP and print out the incoming message
+Connect to an Point One device over TCP and print out the incoming message
 contents and/or log the messages to disk.
 """)
 
@@ -29,12 +29,12 @@ contents and/or log the messages to disk.
     parser.add_argument('-o', '--output', type=str,
                         help="The path to a file where incoming data will be stored.")
     parser.add_argument('-p', '--port', type=int, default=30201,
-                        help="The FusionEngine TCP port on the Atlas device.")
+                        help="The FusionEngine TCP port on the data source.")
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true',
                         help="Do not print anything to the console.")
 
-    parser.add_argument('ip_address',
-                        help="The IP address of the Atlas device.")
+    parser.add_argument('hostname',
+                        help="The IP address or hostname of the data source.")
     options = parser.parse_args()
 
     if options.quiet:
@@ -56,7 +56,7 @@ contents and/or log the messages to disk.
 
     # Connect to the device.
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((options.ip_address, options.port))
+    sock.connect((socket.gethostbyname(options.hostname), options.port))
 
     # Listen for incoming data.
     decoder = FusionEngineDecoder(warn_on_unrecognized=not options.quiet, return_bytes=True)

--- a/python/examples/udp_client.py
+++ b/python/examples/udp_client.py
@@ -15,10 +15,9 @@ from examples.raw_message_decode import decode_message
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
-Connect to an Atlas device over UDP and print out the incoming message contents.
+Connect to a Point One device over UDP and print out the incoming message contents.
 
-When using UDP, you must configure the Atlas device to send data to your
-machine.
+When using UDP, you must configure the device to send data to your machine.
 
 This application assumes that the UDP stream contains only FusionEngine
 messages.

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -26,7 +26,7 @@ from .attitude import get_enu_rotation_matrix
 from .file_reader import FileReader
 from ..utils import trace
 from ..utils.argument_parser import ArgumentParser
-from ..utils.log import locate_log
+from ..utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 _logger = logging.getLogger('point_one.fusion_engine.analysis.analyzer')
 
 
@@ -935,7 +935,7 @@ Load and display information stored in a FusionEngine binary file.
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help="Print verbose/trace debugging messages.")
 
-    parser.add_argument('--log-base-dir', metavar='DIR', default='/logs',
+    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
                         help="The base directory containing FusionEngine logs to be searched if a log pattern is "
                              "specified.")
     parser.add_argument('log',

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -940,7 +940,8 @@ Load and display information stored in a FusionEngine binary file.
                              "specified.")
     parser.add_argument('log',
                         help="The log to be read. May be one of:\n"
-                             "- The path to a .p1log file\n"
+                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
+                             "content\n"
                              "- The path to a FusionEngine log directory\n"
                              "- A pattern matching a FusionEngine log directory under the specified base directory "
                              "(see find_fusion_engine_log() and --log-base-dir)")

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -13,8 +13,15 @@ MANIFEST_FILE_NAME = 'maniphest.json'
 
 CANDIDATE_MIXED_FILES = ['input.raw', 'input.bin', 'input.rtcm3']
 
+DEFAULT_LOG_BASE_DIR = os.getenv('P1_LOG_BASE_DIR')
+if DEFAULT_LOG_BASE_DIR is None:
+    if os.name == "nt":
+        DEFAULT_LOG_BASE_DIR = os.path.expandvars("%USERPROFILE%/Documents/logs")
+    else:
+        DEFAULT_LOG_BASE_DIR = os.path.expanduser("~/logs")
 
-def find_log_by_pattern(pattern, log_base_dir='/logs', allow_multiple=False,
+
+def find_log_by_pattern(pattern, log_base_dir=DEFAULT_LOG_BASE_DIR, allow_multiple=False,
                         log_test_filenames=(MANIFEST_FILE_NAME,), return_test_file=False):
     """!
     @brief Perform a pattern match to locate a log directory containing the specified files.
@@ -110,7 +117,8 @@ def find_log_by_pattern(pattern, log_base_dir='/logs', allow_multiple=False,
     return matches
 
 
-def find_log_file(input_path, candidate_files=None, return_output_dir=False, return_log_id=False, log_base_dir='/logs'):
+def find_log_file(input_path, candidate_files=None, return_output_dir=False, return_log_id=False,
+                  log_base_dir=DEFAULT_LOG_BASE_DIR):
     """!
     @brief Locate a log directory containing the specified file(s).
 
@@ -223,7 +231,7 @@ def find_log_file(input_path, candidate_files=None, return_output_dir=False, ret
         return tuple(result)
 
 
-def find_p1log_file(input_path, return_output_dir=False, return_log_id=False, log_base_dir='/logs'):
+def find_p1log_file(input_path, return_output_dir=False, return_log_id=False, log_base_dir=DEFAULT_LOG_BASE_DIR):
     """!
     @brief Locate a FusionEngine log directory containing a `*.p1log` file from a list of expected candidate paths.
 
@@ -366,7 +374,7 @@ def extract_fusion_engine_log(input_path, output_path=None, warn_on_gaps=True, r
         return valid_count
 
 
-def locate_log(input_path, log_base_dir='/logs', return_output_dir=False, return_log_id=False):
+def locate_log(input_path, log_base_dir=DEFAULT_LOG_BASE_DIR, return_output_dir=False, return_log_id=False):
     """!
     @brief Locate a FusionEngine `*.p1log` file, or a binary file containing a mixed stream of FusionEngine messages and
            other content.

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -374,7 +374,8 @@ def extract_fusion_engine_log(input_path, output_path=None, warn_on_gaps=True, r
         return valid_count
 
 
-def locate_log(input_path, log_base_dir=DEFAULT_LOG_BASE_DIR, return_output_dir=False, return_log_id=False):
+def locate_log(input_path, log_base_dir=DEFAULT_LOG_BASE_DIR, return_output_dir=False, return_log_id=False,
+               extract_fusion_engine_data=True):
     """!
     @brief Locate a FusionEngine `*.p1log` file, or a binary file containing a mixed stream of FusionEngine messages and
            other content.
@@ -394,6 +395,8 @@ def locate_log(input_path, log_base_dir=DEFAULT_LOG_BASE_DIR, return_output_dir=
     @param log_base_dir The base directory to be searched when performing a pattern match for a log directory.
     @param return_output_dir If `True`, return the output directory associated with the located input file.
     @param return_log_id If `True`, return the ID of the log if the requested path is a FusionEngine log.
+    @param extract_fusion_engine_data If `True`, extract FusionEngine content from a file containing mixed binary data
+           and generate a new `*.p1log` file. Otherwise, return the path to the located mixed binary file.
 
     @return The path to the located file or a tuple of:
             - The path to the located (or extracted) `*.p1log` file
@@ -441,26 +444,38 @@ def locate_log(input_path, log_base_dir=DEFAULT_LOG_BASE_DIR, return_output_dir=
             else:
                 return tuple(result)
 
-    # Now, search for FusionEngine messages within the mixed binary data.
+    # Now, search for and extract FusionEngine messages within the mixed binary data to create a *.p1log file if
+    # requested, or simply return the path to the mixed content file.
     _logger.info("Found mixed-content log file '%s'." % mixed_file_path)
-    log_dir = os.path.dirname(mixed_file_path)
-    if is_mixed_file:
-        fe_path = os.path.splitext(mixed_file_path)[0] + '.p1log'
-    else:
-        fe_path = os.path.join(log_dir, "fusion_engine.p1log")
+    if extract_fusion_engine_data:
+        # If the user specified an actual file, use its name to set the *.p1log file name.
+        if is_mixed_file:
+            fe_path = os.path.splitext(mixed_file_path)[0] + '.p1log'
+        # Otherwise, if they specified a pattern and searched for a log directory, save the output as
+        # fusion_engine.p1log.
+        else:
+            log_dir = os.path.dirname(mixed_file_path)
+            fe_path = os.path.join(log_dir, "fusion_engine.p1log")
 
-    _logger.info("Extracting FusionEngine content to '%s'." % fe_path)
-    num_messages = extract_fusion_engine_log(input_path=mixed_file_path, output_path=fe_path)
-    if num_messages > 0:
+        _logger.info("Extracting FusionEngine content to '%s'." % fe_path)
+        num_messages = extract_fusion_engine_log(input_path=mixed_file_path, output_path=fe_path)
+        if num_messages > 0:
+            if isinstance(result, tuple):
+                result = list(result)
+                result[0] = fe_path
+                return tuple(result)
+            else:
+                return result
+        else:
+            _logger.warning('No FusionEngine data extracted from mixed data file.')
+            if isinstance(result, tuple):
+                return [None for _ in result]
+            else:
+                return None
+    else:
         if isinstance(result, tuple):
             result = list(result)
-            result[0] = fe_path
+            result[0] = mixed_file_path
             return tuple(result)
         else:
             return result
-    else:
-        _logger.warning('No FusionEngine data extracted from mixed data file.')
-        if isinstance(result, tuple):
-            return [None for _ in result]
-        else:
-            return None


### PR DESCRIPTION
# New Features
- Use `locate_log()` to all use of mixed-content binary files in all example applications
- Added hostname lookup support to TCP client example applications

# Changes
- Defined a common log base directory variable (defaults to `~/logs` on Linux, or `My Documents/Logs` on Windows), which can also be using the `P1_LOG_BASE_DIR` environment variable

# Fixes
- Remove invalid solutions in `analyze_data.py` example application
- Fixed use of ROS pose message in raw decode example