### PR TITLE
Search for `/logs` directory by default, and fix version string display.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -811,8 +811,7 @@ class Analyzer(object):
         if len(result[VersionInfoMessage.MESSAGE_TYPE].messages) != 0:
             version = result[VersionInfoMessage.MESSAGE_TYPE].messages[-1]
             version_types = {'fw': 'Firmware', 'engine': 'FusionEngine', 'hw': 'Hardware', 'rx': 'GNSS Receiver'}
-            # Strip 'b' from byte string conversion
-            version_values = [str(vars(version)[k + '_version_str'])[1:] for k in version_types.keys()]
+            version_values = [str(vars(version)[k + '_version_str']) for k in version_types.keys()]
             version_table = _data_to_table(['Type', 'Version'], [list(version_types.values()), version_values])
         else:
             version_table = 'No version information.'

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -602,7 +602,7 @@ class CalibrationStatus(MessagePayload):
         string += '  Pitch: %.1f deg (std dev: %.1f deg, max: %.1f deg)%s\n' % \
                   (self.ypr_deg[1], self.ypr_std_dev_deg[1], self.mounting_angle_max_std_dev_deg[1],
                    ' [OK]' if self.ypr_std_dev_deg[1] < self.mounting_angle_max_std_dev_deg[1] else '')
-        string += '  Roll: %.1f deg (std dev: %.1f deg, max: %.1f deg)%s\n' % \
+        string += '  Roll: %.1f deg (std dev: %.1f deg, max: %.1f deg)%s' % \
                   (self.ypr_deg[2], self.ypr_std_dev_deg[2], self.mounting_angle_max_std_dev_deg[2],
                    ' [OK]' if self.ypr_std_dev_deg[2] < self.mounting_angle_max_std_dev_deg[2] else '')
         return string

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -13,12 +13,24 @@ MANIFEST_FILE_NAME = 'maniphest.json'
 
 CANDIDATE_MIXED_FILES = ['input.raw', 'input.bin', 'input.rtcm3']
 
+# Determine the default log base directory in the following order of priority:
+# - P1_LOG_BASE_DIR environment variable
+# - If Windows, set to `My Documents/logs`
+# - Otherwise (Linux/Mac):
+#   - Use `/logs` if it exists
+#   - Otherwise, use `~/logs`
+#
+# Note that this is the default value. It can still be overridden by setting `log_base_dir` in all functions below
+# (typically controlled by a --log-base-dir argument to an application).
 DEFAULT_LOG_BASE_DIR = os.getenv('P1_LOG_BASE_DIR')
 if DEFAULT_LOG_BASE_DIR is None:
     if os.name == "nt":
         DEFAULT_LOG_BASE_DIR = os.path.expandvars("%USERPROFILE%/Documents/logs")
     else:
-        DEFAULT_LOG_BASE_DIR = os.path.expanduser("~/logs")
+        if os.path.exists('/logs'):
+            DEFAULT_LOG_BASE_DIR = '/logs'
+        else:
+            DEFAULT_LOG_BASE_DIR = os.path.expanduser("~/logs")
 
 
 def find_log_by_pattern(pattern, log_base_dir=DEFAULT_LOG_BASE_DIR, allow_multiple=False,


### PR DESCRIPTION
# Changes
- On Linux/Mac, default to `/logs` base directory if it exists, otherwise use `~/logs`

# Fixes
- Fixed missing leading character in version strings in `p1_display` index file