### PR TITLE
Set all bits in `FACTORY_RESET` mask, and other minor cleanup.

### DIFF
--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -3,7 +3,6 @@ from typing import Dict, Tuple, Union
 from collections import deque
 import copy
 from datetime import datetime
-from enum import IntEnum
 import io
 import logging
 import os
@@ -12,6 +11,7 @@ import numpy as np
 
 from ..messages import *
 from ..utils import trace
+from ..utils.enum_utils import IntEnum
 from .file_index import FileIndex, FileIndexBuilder
 
 

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -4,6 +4,7 @@ from typing import NamedTuple, Optional, List
 from construct import (Struct, Float32l, Int32ul, Int16ul, Int8ul, Padding, this, Flag, Bytes, Array, Adapter)
 
 from ..utils.construct_utils import NamedTupleAdapter, AutoEnum
+from ..utils.enum_utils import IntEnum
 from .defs import *
 
 
@@ -16,9 +17,6 @@ class ConfigurationSource(IntEnum):
     ACTIVE = 0
     SAVED = 1
 
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
-
 
 class ConfigType(IntEnum):
     INVALID = 0
@@ -30,9 +28,6 @@ class ConfigType(IntEnum):
     WHEEL_CONFIG = 21
     UART0_BAUD = 256
     UART1_BAUD = 257
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class Direction(IntEnum):
@@ -50,9 +45,6 @@ class Direction(IntEnum):
     DOWN = 5,
     ## Error value.
     INVALID = 255
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class VehicleModel(IntEnum):
@@ -91,9 +83,6 @@ class VehicleModel(IntEnum):
 
     BMW_7 = 200
 
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
-
 
 class WheelSensorType(IntEnum):
     NONE = 0,
@@ -101,9 +90,6 @@ class WheelSensorType(IntEnum):
     TICKS = 2,
     WHEEL_SPEED = 3,
     VEHICLE_SPEED = 4
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class AppliedSpeedType(IntEnum):
@@ -113,17 +99,11 @@ class AppliedSpeedType(IntEnum):
     FRONT_AND_REAR_WHEELS = 3,
     VEHICLE_BODY = 4
 
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
-
 
 class SteeringType(IntEnum):
     UNKNOWN_STEERING = 0,
     FRONT_STEERING = 1,
     FRONT_AND_REAR_STEERING = 2
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class TransportType(IntEnum):
@@ -137,15 +117,9 @@ class TransportType(IntEnum):
     ## This is used for requesting the configuration for all interfaces.
     ALL = 255,
 
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
-
 
 class UpdateAction(IntEnum):
     REPLACE = 0
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class _ConfigClassGenerator:
@@ -522,9 +496,6 @@ class SaveAction(IntEnum):
     SAVE = 0
     REVERT_TO_SAVED = 1
     REVERT_TO_DEFAULT = 2
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class SaveConfigMessage(MessagePayload):

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -54,6 +54,7 @@ class Direction(IntEnum):
     def __str__(self):
         return super().__str__().replace(self.__class__.__name__ + '.', '')
 
+
 class VehicleModel(IntEnum):
     UNKNOWN_VEHICLE = 0,
     DATASPEED_CD4 = 1,
@@ -93,6 +94,7 @@ class VehicleModel(IntEnum):
     def __str__(self):
         return super().__str__().replace(self.__class__.__name__ + '.', '')
 
+
 class WheelSensorType(IntEnum):
     NONE = 0,
     TICK_RATE = 1,
@@ -103,6 +105,7 @@ class WheelSensorType(IntEnum):
     def __str__(self):
         return super().__str__().replace(self.__class__.__name__ + '.', '')
 
+
 class AppliedSpeedType(IntEnum):
     APPLIED_NONE = 0,
     REAR_WHEELS = 1,
@@ -112,6 +115,7 @@ class AppliedSpeedType(IntEnum):
 
     def __str__(self):
         return super().__str__().replace(self.__class__.__name__ + '.', '')
+
 
 class SteeringType(IntEnum):
     UNKNOWN_STEERING = 0,
@@ -434,7 +438,7 @@ class SetConfigMessage(MessagePayload):
         "config_change_data" / Bytes(this.config_change_length_bytes),
     )
 
-    def __init__(self, config_object: Optional[_conf_gen.ConfigClass] = None, flags = 0):
+    def __init__(self, config_object: Optional[_conf_gen.ConfigClass] = None, flags=0x0):
         self.config_object = config_object
         self.flags = flags
 

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -184,7 +184,7 @@ class ResetRequest(MessagePayload):
     # - Position, velocity, orientation (@ref RESET_POSITION_DATA)
     # - Calibration data (@ref RESET_CALIBRATION_DATA)
     # - User configuration settings (@ref RESET_CONFIG)
-    # - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+    # - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
     HOT_START = 0x000000FF
 
     ##
@@ -204,7 +204,7 @@ class ResetRequest(MessagePayload):
     #   compensation, etc.; @ref RESET_NAVIGATION_ENGINE_DATA)
     # - Calibration data (@ref RESET_CALIBRATION_DATA)
     # - User configuration settings (@ref RESET_CONFIG)
-    # - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+    # - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
     WARM_START = 0x000001FF
 
     ##
@@ -218,7 +218,7 @@ class ResetRequest(MessagePayload):
     # - All runtime data (GNSS corrections (@ref RESET_GNSS_CORRECTIONS), etc.)
     # - Position, velocity, orientation (@ref RESET_POSITION_DATA)
     # - Fast IMU corrections (@ref RESET_FAST_IMU_CORRECTIONS)
-    # - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+    # - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
     #
     # Not reset:
     # - Training parameters (slowly estimated IMU corrections, temperature

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -1,8 +1,7 @@
-from enum import IntEnum
-
 from construct import (Struct, Int64ul, Int16ul, Int8ul, Padding, this, Bytes, PaddedString)
 
 from ..utils.construct_utils import AutoEnum
+from ..utils.enum_utils import IntEnum
 from .defs import *
 
 
@@ -334,9 +333,6 @@ class EventNotificationMessage(MessagePayload):
         LOG = 0
         RESET = 1
         CONFIG_CHANGE = 2
-
-        def __str__(self):
-            return super().__str__().replace(self.__class__.__name__ + '.', '')
 
     EventNotificationConstruct = Struct(
         "action" / AutoEnum(Int8ul, Action),

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -233,9 +233,7 @@ class ResetRequest(MessagePayload):
 
     ##
     # Restart mask to set all persistent data, including calibration and user configuration, back to factory defaults.
-    #
-    # Note: Upper 8 bits reserved for future use (e.g., hardware reset).
-    FACTORY_RESET = 0x01FFFFFF
+    FACTORY_RESET = 0xFFFFFFFF
 
     ## @}
 

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -62,9 +62,9 @@ class Response(IntEnum):
     EXECUTION_FAILURE = 5
     ## The header `payload_size_bytes` is in conflict with the size of the message based on its type or type
     ## specific length fields.
-    INCONSISTENT_PAYLOAD_LENGTH = 6,
+    INCONSISTENT_PAYLOAD_LENGTH = 6
     ## Requested data was corrupted and not available.
-    DATA_CORRUPTED = 7,
+    DATA_CORRUPTED = 7
 
 
 class MessageType(IntEnum):

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from enum import IntEnum
 import logging
 import math
 import struct
@@ -7,6 +6,8 @@ from typing import Union
 from zlib import crc32
 
 import numpy as np
+
+from ..utils.enum_utils import IntEnum
 
 _logger = logging.getLogger('point_one.fusion_engine.messages.defs')
 
@@ -22,9 +23,6 @@ class SatelliteType(IntEnum):
     MIXED = 7
     SBAS = 8
     IRNSS = 9
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class SolutionType(IntEnum):
@@ -44,9 +42,6 @@ class SolutionType(IntEnum):
     Visual = 9
     # GNSS precise point positioning (PPP) pseudorange/carrier phase solution.
     PPP = 10
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class Response(IntEnum):
@@ -71,9 +66,6 @@ class Response(IntEnum):
     INCONSISTENT_PAYLOAD_LENGTH = 6
     ## Requested data was corrupted and not available.
     DATA_CORRUPTED = 7
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class MessageType(IntEnum):
@@ -111,9 +103,6 @@ class MessageType(IntEnum):
     OUTPUT_INTERFACE_CONFIG_RESPONSE = 13202
 
     RESERVED = 20000
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
     @classmethod
     def get_type_string(cls, type):

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -23,6 +23,9 @@ class SatelliteType(IntEnum):
     SBAS = 8
     IRNSS = 9
 
+    def __str__(self):
+        return super().__str__().replace(self.__class__.__name__ + '.', '')
+
 
 class SolutionType(IntEnum):
     # Invalid, no position available.
@@ -41,6 +44,9 @@ class SolutionType(IntEnum):
     Visual = 9
     # GNSS precise point positioning (PPP) pseudorange/carrier phase solution.
     PPP = 10
+
+    def __str__(self):
+        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class Response(IntEnum):
@@ -65,6 +71,9 @@ class Response(IntEnum):
     INCONSISTENT_PAYLOAD_LENGTH = 6
     ## Requested data was corrupted and not available.
     DATA_CORRUPTED = 7
+
+    def __str__(self):
+        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class MessageType(IntEnum):
@@ -102,6 +111,9 @@ class MessageType(IntEnum):
     OUTPUT_INTERFACE_CONFIG_RESPONSE = 13202
 
     RESERVED = 20000
+
+    def __str__(self):
+        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
     @classmethod
     def get_type_string(cls, type):

--- a/python/fusion_engine_client/messages/ros.py
+++ b/python/fusion_engine_client/messages/ros.py
@@ -2,6 +2,7 @@ import struct
 
 import numpy as np
 
+from ..utils.enum_utils import IntEnum
 from .defs import *
 
 
@@ -10,9 +11,6 @@ class CovarianceType(IntEnum):
     COVARIANCE_TYPE_APPROXIMATED = 1
     COVARIANCE_TYPE_DIAGONAL_KNOWN = 2
     COVARIANCE_TYPE_KNOWN = 3
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class ROSPoseMessage(MessagePayload):

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -1,9 +1,9 @@
-from enum import IntEnum
 import struct
 from typing import List, Sequence
 
 import numpy as np
 
+from ..utils.enum_utils import IntEnum
 from .defs import *
 
 
@@ -463,9 +463,6 @@ class CalibrationStage(IntEnum):
     UNKNOWN = 0, ##< Calibration stage not known.
     MOUNTING_ANGLE = 1, ##< Estimating IMU mounting angles.
     DONE = 255, ##< Calibration complete.
-
-    def __str__(self):
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
 
 
 class CalibrationStatus(MessagePayload):

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -1,0 +1,13 @@
+from enum import IntEnum as IntEnumBase
+
+
+class IntEnum(IntEnumBase):
+    def __str__(self):
+        # The default str() for the built-in Enum class is ClassName.VALUE. For our purposes, we don't really need the
+        # leading class name prefix, so we remove it. For example:
+        #
+        #   class Foo(IntEnum):
+        #       BAR = 1
+        #
+        #   print(Foo.BAR)   # Prints "BAR", not "Foo.BAR"
+        return super().__str__().replace(self.__class__.__name__ + '.', '')

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -61,7 +61,7 @@ enum class ConfigType : uint16_t {
   GNSS_LEVER_ARM = 18,
 
   /**
-   * The location of the desired output location with respect to the vehicle
+   * The offset of the desired output location with respect to the vehicle
    * body frame (in meters).
    *
    * Payload format: @ref Point3f
@@ -69,14 +69,14 @@ enum class ConfigType : uint16_t {
   OUTPUT_LEVER_ARM = 19,
 
   /**
-   * Information including vehicle model and dimensions.
+   * Information about the vehicle including model and dimensions.
    *
    * Payload format: @ref VehicleDetails
    */
   VEHICLE_DETAILS = 20,
 
   /**
-   * Information pertaining to wheel measurements.
+   * Information pertaining to wheel speed/rotation measurements.
    *
    * Payload format: @ref WheelConfig
    */
@@ -521,7 +521,7 @@ inline std::ostream& operator<<(std::ostream& stream,
 }
 
 /**
- * @brief Information including vehicle model and dimensions.
+ * @brief Information about the vehicle including model and dimensions.
  * @ingroup config_and_ctrl_messages
  */
 struct alignas(4) VehicleDetails {
@@ -723,7 +723,10 @@ struct alignas(4) WheelConfig {
    */
   WheelSensorType wheel_sensor_type = WheelSensorType::NONE;
 
-  /** The type of vehicle/wheel speed measurements to be applied. */
+  /**
+   * The type of vehicle/wheel speed measurements to be applied to the
+   * navigation solution.
+   */
   AppliedSpeedType applied_speed_type = AppliedSpeedType::REAR_WHEELS;
 
   /** Indication of which of the vehicle's wheels are steered. */

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -259,11 +259,11 @@ struct alignas(4) SetConfigMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SET_CONFIG;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
-  /** The type of parameter to be configured. */
-  ConfigType config_type;
-
   /** Flag to immediately save the config after applying this setting. */
   static constexpr uint8_t FLAG_APPLY_AND_SAVE = 0x01;
+
+  /** The type of parameter to be configured. */
+  ConfigType config_type;
 
   /** Bitmask of additional flags to modify the command. */
   uint8_t flags = 0;

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -236,10 +236,8 @@ struct alignas(4) ResetRequest : public MessagePayload {
   /**
    * Restart mask to set all persistent data, including calibration and user
    * configuration, back to factory defaults.
-   *
-   * Note: Upper 8 bits reserved for future use (e.g., hardware reset).
    */
-  static constexpr uint32_t FACTORY_RESET = 0x01FFFFFF;
+  static constexpr uint32_t FACTORY_RESET = 0xFFFFFFFF;
   /** @} */
 
   /** Bit mask of functionality to reset. */

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -183,7 +183,7 @@ struct alignas(4) ResetRequest : public MessagePayload {
    *   compensation, etc.; @ref RESET_NAVIGATION_ENGINE_DATA)
    * - Calibration data (@ref RESET_CALIBRATION_DATA)
    * - User configuration settings (@ref RESET_CONFIG)
-   * - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+   * - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
    */
   static constexpr uint32_t HOT_START = 0x000000FF;
 
@@ -204,7 +204,7 @@ struct alignas(4) ResetRequest : public MessagePayload {
    *   compensation, etc.; @ref RESET_NAVIGATION_ENGINE_DATA)
    * - Calibration data (@ref RESET_CALIBRATION_DATA)
    * - User configuration settings (@ref RESET_CONFIG)
-   * - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+   * - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
    */
   static constexpr uint32_t WARM_START = 0x000001FF;
 
@@ -219,7 +219,7 @@ struct alignas(4) ResetRequest : public MessagePayload {
    * - All runtime data (GNSS corrections (@ref RESET_GNSS_CORRECTIONS), etc.)
    * - Position, velocity, orientation (@ref RESET_POSITION_DATA)
    * - Fast IMU corrections (@ref RESET_FAST_IMU_CORRECTIONS)
-   * - GNSS Measurement engine hardware (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
+   * - GNSS measurement engine (@ref RESTART_GNSS_MEASUREMENT_ENGINE)
    *
    * Not reset:
    * - Training parameters (slowly estimated IMU corrections, temperature

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -125,7 +125,7 @@ inline std::ostream& operator<<(std::ostream& stream, Response val) {
 enum class SolutionType : uint8_t {
   /** Invalid, no position available. */
   Invalid = 0,
-  /** Standalone GNSS fix, no correction data used. */
+  /** Standalone GNSS fix, no GNSS corrections data used. */
   AutonomousGPS = 1,
   /**
    * Differential GNSS pseudorange solution using a local RTK base station or


### PR DESCRIPTION
# Changes
- Set all 32 bits in `FACTORY_RESET`, including the reserved bits
- Documentation and style cleanup
- Added `IntEnum` wrapper class to eliminate duplicate `str()` overloads.