### PR TITLE
Various fixes for Python tools.

### DIFF
--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -100,10 +100,21 @@ other types of data.
         # Convert to lowercase to perform case-insensitive search.
         type_by_name = {k.lower(): v for k, v in message_type_by_name.items()}
         for name in options.type:
-            message_type = type_by_name.get(name.lower(), None)
+            lower_name = name.lower()
+            message_type = type_by_name.get(lower_name, None)
             if message_type is None:
-                print("Unrecognized message type '%s'." % name)
-                sys.exit(1)
+                # If we can't find an exact match for the key, try a partial match.
+                matches = {k: v for k, v in type_by_name.items() if k.startswith(lower_name)}
+                if len(matches) == 1:
+                    message_types.append(next(iter(matches.values())))
+                elif len(matches) > 1:
+                    types = [v for v in matches.values()]
+                    class_names = [message_type_to_class[t].__name__ for t in types]
+                    print("Found multiple types matching '%s':\n  %s" % (name, '\n  '.join(class_names)))
+                    sys.exit(1)
+                else:
+                    print("Unrecognized message type '%s'." % name)
+                    sys.exit(1)
             else:
                 message_types.append(message_type)
         message_types = set(message_types)

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -53,14 +53,14 @@ other types of data.
         '-s', '--summary', action='store_true',
         help="Print a summary of the messages in the file.")
     parser.add_argument(
-        '--time', type=str, metavar='[START][:END]',
+        '-m', '--message-type', type=str, action='append',
+        help="An optional list of class names corresponding with the message types to be displayed. "
+             "Supported types:\n%s" % '\n'.join(['- %s' % c for c in message_type_by_name.keys()]))
+    parser.add_argument(
+        '-t', '--time', type=str, metavar='[START][:END]',
         help="The desired time range to be analyzed. Both start and end may be omitted to read from beginning or to "
              "the end of the file. By default, timestamps are treated as relative to the first message in the file. "
              "See --absolute-time.")
-    parser.add_argument(
-        '-t', '--type', type=str, action='append',
-        help="An optional list of class names corresponding with the message types to be displayed. "
-             "Supported types:\n%s" % '\n'.join(['- %s' % c for c in message_type_by_name.keys()]))
 
     log_parser = parser.add_argument_group('Log Control')
     log_parser.add_argument(
@@ -96,10 +96,10 @@ other types of data.
     # If the user specified a set of message names, lookup their type values. Below, we will limit the printout to only
     # those message types.
     message_types = []
-    if options.type is not None:
+    if options.message_type is not None:
         # Convert to lowercase to perform case-insensitive search.
         type_by_name = {k.lower(): v for k, v in message_type_by_name.items()}
-        for name in options.type:
+        for name in options.message_type:
             lower_name = name.lower()
             message_type = type_by_name.get(lower_name, None)
             if message_type is None:

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -54,7 +54,8 @@ other types of data.
         help="Print a summary of the messages in the file.")
     parser.add_argument(
         '-m', '--message-type', type=str, action='append',
-        help="An optional list of class names corresponding with the message types to be displayed. "
+        help="An optional list of class names corresponding with the message types to be displayed. May be specified "
+             "multiple times (-m Type 1 -m Type 2), or as a comma-separated list (-m Type1,Type2). "
              "Supported types:\n%s" % '\n'.join(['- %s' % c for c in message_type_by_name.keys()]))
     parser.add_argument(
         '-t', '--time', type=str, metavar='[START][:END]',
@@ -99,7 +100,15 @@ other types of data.
     if options.message_type is not None:
         # Convert to lowercase to perform case-insensitive search.
         type_by_name = {k.lower(): v for k, v in message_type_by_name.items()}
+
+        # Split comma-separated names. That way the user can specify multiple -m entries or comma-separated names (or
+        # a mix of the two):
+        #   -m Type1,Type2 -m Type 3
+        requested_types = []
         for name in options.message_type:
+            requested_types.extend(name.split(','))
+
+        for name in requested_types:
             lower_name = name.lower()
             message_type = type_by_name.get(lower_name, None)
             if message_type is None:

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -164,7 +164,7 @@ other types of data.
 
     # If we have an index file and we're only interested in certain message types, locate them in the index.
     if index_file is not None and len(message_types) != 0:
-        message_indices = np.where(np.isin(index_file.type, message_types))[0]
+        message_indices = np.where(np.isin(index_file.type, list(message_types)))[0]
     else:
         message_indices = None
 

--- a/python/bin/print_contents.py
+++ b/python/bin/print_contents.py
@@ -4,6 +4,8 @@ import io
 import os
 import sys
 
+import numpy as np
+
 # Add the Python root directory (fusion-engine-client/python/) to the import search path to enable FusionEngine imports
 # if this application is being run directly out of the repository and is not installed as a pip package.
 root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1055,9 +1055,9 @@ Load and display information stored in a FusionEngine binary file.
         sys.exit(1)
 
     if log_id is None:
-        _logger.info('Loading %s.' % os.path.basename(input_path))
+        _logger.info('Loading %s.' % input_path)
     else:
-        _logger.info('Loading %s from log %s.' % (os.path.basename(input_path), log_id))
+        _logger.info('Loading %s (log ID: %s).' % (input_path, log_id))
 
     if options.output is None:
         if log_id is not None:

--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -225,7 +225,7 @@ class FileReader(object):
         @param require_system_time If `True`, omit messages that do not contain valid system timestamps.
         @param return_numpy If `True`, convert the results to numpy arrays for analysis.
         @param keep_messages If `return_numpy == True` and `keep_messages == False`, the raw data in the `messages`
-               field will be cleared for each @ref MessageData object for which numpy conversion is supported.
+               field will be cleared for each @ref MessagePayload object for which numpy conversion is supported.
         @param remove_nan_times If `True`, remove messages whose P1 timestamps are `NaN` when converting to numpy.
                Ignored if `return_numpy == False`.
         @param time_align The type of alignment to be performed (for data with P1 timestamps):
@@ -742,8 +742,8 @@ class FileReader(object):
         See @ref MessageData.to_numpy().
 
         @param data A data `dict` as returned by @ref read().
-        @param keep_messages If `False`, the raw data in the `messages` field will be cleared for each @ref MessageData
-               object for which numpy conversion is supported.
+        @param keep_messages If `False`, the raw data in the `messages` field will be cleared for each @ref
+               MessagePayload object for which numpy conversion is supported.
         @param remove_nan_times If `True`, remove entries whose P1 timestamps are `NaN` (if P1 time is available for
                this message type).
         """


### PR DESCRIPTION
# Changes
- Added partial name matching for message type names in `print_contents`
- Changed `-m` (message type) and `-t` (time range) definitions in `print_contents` to match `p1_display`

# Fixes
- Fixed missing system time messages when using an index file in `print_contents`
- Fixed message index check in `print_contents`