### PR TITLE
Switched to mainline gpstime (0.6.2) for Windows leap seconds fixes.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,8 +3,6 @@ construct>=2.10.0
 
 # Required for analysis tools only.
 argparse-formatter>=1.4
-# Note: Using the P1 fork of gpstime until Windows and microsecond fixes are mainlined.
-https://github.com/PointOneNav/gpstime/archive/f9e2ab58a8beeeafee992d87a0eafc50887ba849.zip#egg=gpstime
-#gpstime>=0.4.6
+gpstime>=0.6.2
 plotly>=4.0.0
 pymap3d>=2.4.3

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,13 +5,13 @@ setup(
     version='v1.11.2',
     packages=find_packages(where='.'),
     install_requires=[
-        'gpstime @ https://github.com/PointOneNav/gpstime/archive/f9e2ab58a8beeeafee992d87a0eafc50887ba849.zip#egg=gpstime',
         'numpy>=1.16.0',
         'construct>=2.10.0',
     ],
     extras_require={
         'analysis': [
             'argparse-formatter>=1.4',
+            'gpstime>=0.6.2',
             'plotly>=4.0.0',
             'pymap3d>=2.4.3',
         ],


### PR DESCRIPTION
This resolves issues downloading/updating the leap seconds file when necessary, particularly on Windows machines.