### PR TITLE
Fixed crash when converting calibration status messages to numpy.

### DIFF
--- a/python/bin/separate_mixed_log.py
+++ b/python/bin/separate_mixed_log.py
@@ -48,7 +48,7 @@ Extract FusionEngine message contents from a binary file containing mixed data
     options = parser.parse_args()
 
     # Configure logging.
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.basicConfig(level=logging.INFO, format='%(message)s', stream=sys.stdout)
     logger = logging.getLogger('point_one.fusion_engine')
     if options.verbose == 1:
         logger.setLevel(logging.DEBUG)

--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -66,7 +66,12 @@ class MessageData(object):
                             if (key not in ('message_type', 'message_class', 'params', 'messages') and
                                     isinstance(value, np.ndarray)):
                                 if len(value.shape) == 1:
-                                    self.__dict__[key] = value[keep_idx]
+                                    if len(value) == len(keep_idx):
+                                        self.__dict__[key] = value[keep_idx]
+                                    else:
+                                        # Field has a different length than the time vector. It is likely a
+                                        # non-time-varying element (e.g., a position std dev threshold).
+                                        pass
                                 elif len(value.shape) == 2:
                                     if value.shape[0] == len(is_nan):
                                         # Assuming first dimension is time.

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -363,8 +363,9 @@ def extract_fusion_engine_log(input_path, output_path=None, warn_on_gaps=True, r
                        (header.sequence_number - prev_sequence_number) != 1 and \
                        not (header.sequence_number == 0 and prev_sequence_number == 0xFFFFFFFF):
                         func = _logger.warning if warn_on_gaps else _logger.debug
-                        func('Data gap detected @ %d (0x%x). [sequence=%d, prev_sequence=%d, # messages=%d]' %
-                             (offset, offset, header.sequence_number, prev_sequence_number, valid_count + 1))
+                        func('Data gap detected @ %d (0x%x). [sequence=%d, gap_size=%d, total_messages=%d]' %
+                             (offset, offset, header.sequence_number, header.sequence_number - prev_sequence_number,
+                              valid_count + 1))
                     prev_sequence_number = header.sequence_number
 
                     _logger.debug('Read %s message @ %d (0x%x). [length=%d B, sequence=%d, # messages=%d]' %


### PR DESCRIPTION
# Changes
- Send `separate_mixed_log` output to stdout, not stderr

# Fixes
- Fixed crash trying to convert non-scalar, non-time-varying data to numpy