### PR TITLE
Corrected index generation and usage where timestamped measurements are present.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1034,7 +1034,16 @@ class Analyzer(object):
         solution_type_table = _data_to_table(['Position Type', 'Count', 'Percent'], [types, counts, percents])
 
         # Create a table with the types and counts of each FusionEngine message type in the log.
-        message_types, message_counts = np.unique(self.reader.index['type'], return_counts=True)
+        if self.params['absolute_time']:
+            start_time, end_time = self.params['time_range']
+        else:
+            time_range = self.params['time_range']
+            start_time = None if time_range[0] is None else (time_range[0] + float(self.t0))
+            end_time = None if time_range[1] is None else (time_range[1] + float(self.t0))
+
+        index = self.reader.index[start_time:end_time]
+
+        message_types, message_counts = np.unique(index['type'], return_counts=True)
         message_types = [MessageType.get_type_string(t) for t in message_types]
 
         message_counts = message_counts.tolist()

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -996,13 +996,31 @@ class Analyzer(object):
         # we didn't read anything to plot).
         self.reader.generate_index()
 
-        # Calculate the log duration.
-        idx = ~np.isnan(self.reader.index['time'])
-        time = self.reader.index['time'][idx]
-        if len(time) >= 2:
-            duration_sec = time[-1] - time[0]
+        # Restrict the index to the user-requested time range.
+        if self.params['absolute_time']:
+            start_time, end_time = self.params['time_range']
         else:
-            duration_sec = np.nan
+            time_range = self.params['time_range']
+            start_time = None if time_range[0] is None else (time_range[0] + float(self.t0))
+            end_time = None if time_range[1] is None else (time_range[1] + float(self.t0))
+
+        full_index = self.reader.index
+        reduced_index = full_index[start_time:end_time]
+
+        # Calculate the log duration.
+        idx = ~np.isnan(full_index['time'])
+        time = full_index['time'][idx]
+        if len(time) >= 2:
+            log_duration_sec = time[-1] - time[0]
+        else:
+            log_duration_sec = np.nan
+
+        idx = ~np.isnan(reduced_index['time'])
+        time = reduced_index['time'][idx]
+        if len(time) >= 2:
+            processing_duration_sec = time[-1] - time[0]
+        else:
+            processing_duration_sec = np.nan
 
         # Create a table with position solution type statistics.
         result = self.reader.read(message_types=[PoseMessage], **self.params)
@@ -1027,23 +1045,18 @@ class Analyzer(object):
         counts.append('%d' % num_pose_messages)
         percents.append('')
 
-        types.append('Log Duration')
-        counts.append('%.1f seconds' % duration_sec)
+        types.append('Processed Duration')
+        counts.append('%.1f seconds' % processing_duration_sec)
+        percents.append('')
+
+        types.append('Total Log Duration')
+        counts.append('%.1f seconds' % log_duration_sec)
         percents.append('')
 
         solution_type_table = _data_to_table(['Position Type', 'Count', 'Percent'], [types, counts, percents])
 
         # Create a table with the types and counts of each FusionEngine message type in the log.
-        if self.params['absolute_time']:
-            start_time, end_time = self.params['time_range']
-        else:
-            time_range = self.params['time_range']
-            start_time = None if time_range[0] is None else (time_range[0] + float(self.t0))
-            end_time = None if time_range[1] is None else (time_range[1] + float(self.t0))
-
-        index = self.reader.index[start_time:end_time]
-
-        message_types, message_counts = np.unique(index['type'], return_counts=True)
+        message_types, message_counts = np.unique(reduced_index['type'], return_counts=True)
         message_types = [MessageType.get_type_string(t) for t in message_types]
 
         message_counts = message_counts.tolist()

--- a/python/fusion_engine_client/analysis/file_index.py
+++ b/python/fusion_engine_client/analysis/file_index.py
@@ -271,8 +271,8 @@ class FileIndex(object):
             idx = self._data['type'] == key
             return FileIndex(data=self._data[idx], t0=self.t0)
         # Return entries for a list of message types.
-        elif isinstance(key, (set, list, tuple)) and len(key) > 0 and isinstance(key[0], MessageType):
-            idx = np.isin(self._data['type'], key)
+        elif isinstance(key, (set, list, tuple)) and len(key) > 0 and isinstance(next(iter(key)), MessageType):
+            idx = np.isin(self._data['type'], [int(k) for k in key])
             return FileIndex(data=self._data[idx], t0=self.t0)
         # Return a single element by index.
         elif isinstance(key, int):

--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -505,12 +505,22 @@ class FileReader(object):
                     contents.unpack(buffer=buffer, offset=HEADER_SIZE)
 
                     # Extract P1 and system times from this message, if applicable.
-                    p1_time = contents.__dict__.get('p1_time', None)
-                    system_time_ns = contents.__dict__.get('system_time_ns', None)
-                    if system_time_ns is not None:
-                        system_time_sec = system_time_ns * 1e-9
+                    measurement_timestamps = contents.__dict__.get('timestamps', None)
+                    if isinstance(measurement_timestamps, MeasurementTimestamps):
+                        p1_time = measurement_timestamps.p1_time
+                        if measurement_timestamps.measurement_time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
+                            system_time_sec = float(measurement_timestamps.measurement_time)
+                            system_time_ns = system_time_sec * 1e9
+                        else:
+                            system_time_sec = None
+                            system_time_ns = None
                     else:
-                        system_time_sec = None
+                        p1_time = contents.__dict__.get('p1_time', None)
+                        system_time_ns = contents.__dict__.get('system_time_ns', None)
+                        if system_time_ns is not None:
+                            system_time_sec = system_time_ns * 1e-9
+                        else:
+                            system_time_sec = None
 
                 # If we're building up an index file, add an entry for this message. If this is an unrecognized message
                 # type, we won't have P1 time so we'll just insert a nan.

--- a/python/fusion_engine_client/analysis/file_reader.py
+++ b/python/fusion_engine_client/analysis/file_reader.py
@@ -486,8 +486,8 @@ class FileReader(object):
             # If this isn't one of the requested messages, skip it. If we don't know t0 yet or we need the message's P1
             # time to generate an index, continue to unpack.
             if (not message_needed and
-                self.t0 is not None and
-                (not system_time_messages_requested or self.system_t0 is not None) and
+                    self.t0 is not None and
+                    (self.system_t0 is not None or not system_time_messages_requested) and
                     not generate_index):
                 continue
 


### PR DESCRIPTION
# Changes
- Limit message count table to specified time range to match all other tables
- Print total log duration and processed time range duration

# Fixes
- Obtain P1 and system time from `MeasurementTimestamps` block when reading a `.p1log` file
- Fixed missing/invalid timestamps when generating an index file based on a specific message type