### PR TITLE
Added apply-and-save to message rate config, and other minor fixes.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -929,10 +929,13 @@ class SetMessageOutputRate(MessagePayload):
     MESSAGE_TYPE = MessageType.SET_OUTPUT_MESSAGE_RATE
     MESSAGE_VERSION = 0
 
+    # Flag to immediately save the config after applying this setting.
+    FLAG_APPLY_AND_SAVE = 0x01
+
     SetMessageOutputRateConstruct = Struct(
         "output_interface" / _InterfaceIDConstruct,
         "protocol" / AutoEnum(Int8ul, ProtocolType),
-        Padding(1),
+        "flags" / Int8ul,
         "message_id" / Int16ul,
         "rate" / AutoEnum(Int8ul, MessageRate),
         Padding(3),
@@ -942,7 +945,8 @@ class SetMessageOutputRate(MessagePayload):
                  output_interface: InterfaceID = None,
                  protocol: ProtocolType = ProtocolType.INVALID,
                  message_id: int = 0,
-                 rate: MessageRate = MessageRate.OFF):
+                 rate: MessageRate = MessageRate.OFF,
+                 flags: int = 0x0):
         if output_interface is None:
             self.output_interface = InterfaceID()
         else:
@@ -950,6 +954,7 @@ class SetMessageOutputRate(MessagePayload):
         self.protocol = protocol
         self.message_id = message_id
         self.rate = rate
+        self.flags = flags
 
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         packed_data = self.SetMessageOutputRateConstruct.build(self.__dict__)
@@ -961,7 +966,7 @@ class SetMessageOutputRate(MessagePayload):
         return parsed._io.tell()
 
     def __str__(self):
-        fields = ['output_interface', 'protocol', 'message_id', 'rate']
+        fields = ['output_interface', 'protocol', 'message_id', 'rate', 'flags']
         string = f'Set Message Output Rate Command\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -962,7 +962,7 @@ class SetMessageOutputRate(MessagePayload):
 
     def __str__(self):
         fields = ['output_interface', 'protocol', 'message_id', 'rate']
-        string = f'Set Output Interface Streams Config Command\n'
+        string = f'Set Message Output Rate Command\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')
             string += f'  {field}: {val}\n'
@@ -1011,7 +1011,7 @@ class GetMessageOutputRate(MessagePayload):
 
     def __str__(self):
         fields = ['output_interface', 'protocol', 'request_source', 'message_id']
-        string = f'Get Output Interface Streams Config\n'
+        string = f'Get Message Output Rate Command\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')
             string += f'  {field}: {val}\n'

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1502,13 +1502,17 @@ struct alignas(4) SetMessageOutputRate : public MessagePayload {
       MessageType::SET_OUTPUT_MESSAGE_RATE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
+  /** Flag to immediately save the config after applying this setting. */
+  static constexpr uint8_t FLAG_APPLY_AND_SAVE = 0x01;
+
   /** The output interface to configure. */
   InterfaceID output_interface = {};
 
   /** The message protocol being configured. */
   ProtocolType protocol = ProtocolType::INVALID;
 
-  uint8_t reserved1[1] = {0};
+  /** Bitmask of additional flags to modify the command. */
+  uint8_t flags = 0;
 
   /**
    * The ID of the desired message type (e.g., 10000 for FusionEngine

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1501,11 +1501,25 @@ struct alignas(4) SetMessageOutputRate : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::SET_OUTPUT_MESSAGE_RATE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
+
+  /** The output interface to configure. */
   InterfaceID output_interface = {};
+
+  /** The message protocol being configured. */
   ProtocolType protocol = ProtocolType::INVALID;
+
   uint8_t reserved1[1] = {0};
+
+  /**
+   * The ID of the desired message type (e.g., 10000 for FusionEngine
+   * @ref MessageType::POSE messages). See @ref NmeaMessageType for NMEA-0183
+   * messages.
+   */
   uint16_t message_id = 0;
+
+  /** The desired message rate. */
   MessageRate rate = MessageRate::OFF;
+
   uint8_t reserved2[3] = {0};
 };
 
@@ -1521,37 +1535,65 @@ struct alignas(4) GetMessageOutputRate : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::GET_OUTPUT_MESSAGE_RATE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
+
+  /** The output interface to be queried. */
   InterfaceID output_interface = {};
+
+  /** The desired message protocol. */
   ProtocolType protocol = ProtocolType::INVALID;
+
   /** The source of the parameter value (active, saved, etc.). */
   ConfigurationSource request_source = ConfigurationSource::ACTIVE;
+
+  /**
+   * The ID of the desired message type (e.g., 10000 for FusionEngine
+   * @ref MessageType::POSE messages). See @ref NmeaMessageType for NMEA-0183
+   * messages.
+   */
   uint16_t message_id = 0;
 };
 
 /**
- * @brief The requested output rate.
+ * @brief Response to a @ref GetMessageOutputRate request.
  * @ingroup config_and_ctrl_messages
  */
 struct alignas(4) MessageOutputRateResponse : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::OUTPUT_MESSAGE_RATE_RESPONSE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
+
   /** The source of the parameter value (active, saved, etc.). */
   ConfigurationSource config_source = ConfigurationSource::ACTIVE;
+
   /**
    * Set to `true` if the active configuration differs from the saved
    * configuration for this parameter.
    */
   bool active_differs_from_saved = false;
+
   /** The response status (success, error, etc.). */
   Response response = Response::OK;
 
   uint8_t reserved1[1] = {0};
+
+  /** The output interface corresponding with this response. */
   InterfaceID output_interface = {};
+
+  /** The protocol of the message being returned. */
   ProtocolType protocol = ProtocolType::INVALID;
+
   uint8_t reserved2[1] = {0};
+
+  /**
+   * The ID of the returned message type (e.g., 10000 for FusionEngine
+   * @ref MessageType::POSE messages). See @ref NmeaMessageType for NMEA-0183
+   * messages.
+   */
   uint16_t message_id = 0;
+
+  /** The current configuration for this message. */
   MessageRate rate = MessageRate::OFF;
+
   uint8_t reserved3[3] = {0};
 };
 

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1441,43 +1441,30 @@ inline const char* to_string(MessageRate value) {
   switch (value) {
     case MessageRate::OFF:
       return "OFF";
-      break;
     case MessageRate::ON_CHANGE:
       return "ON_CHANGE";
-      break;
     case MessageRate::INTERVAL_10_MS:
       return "INTERVAL_10_MS";
-      break;
     case MessageRate::INTERVAL_20_MS:
       return "INTERVAL_20_MS";
-      break;
     case MessageRate::INTERVAL_40_MS:
       return "INTERVAL_40_MS";
-      break;
     case MessageRate::INTERVAL_50_MS:
       return "INTERVAL_50_MS";
-      break;
     case MessageRate::INTERVAL_100_MS:
       return "INTERVAL_100_MS";
-      break;
     case MessageRate::INTERVAL_200_MS:
       return "INTERVAL_200_MS";
-      break;
     case MessageRate::INTERVAL_500_MS:
       return "INTERVAL_500_MS";
-      break;
     case MessageRate::INTERVAL_1_S:
       return "INTERVAL_1_S";
-      break;
     case MessageRate::INTERVAL_2_S:
       return "INTERVAL_2_S";
-      break;
     case MessageRate::INTERVAL_5_S:
       return "INTERVAL_5_S";
-      break;
     case MessageRate::INTERVAL_10_S:
       return "INTERVAL_10_S";
-      break;
     default:
       return "Unrecognized";
   }


### PR DESCRIPTION
# New Features
- Added an apply-and-save flag to `SetOutputMessageRate`, consistent with `SetConfigMessage`

# Fixes
- Corrected rate control message documentation