### PR TITLE
Fixed reading issues when all message types are requested (empty set).

### DIFF
--- a/python/fusion_engine_client/analysis/file_index.py
+++ b/python/fusion_engine_client/analysis/file_index.py
@@ -381,10 +381,16 @@ class FileIndex(object):
                 end = key.end + p1_t0 if key.end is not None else None
             return self.get_time_range(start, end, 'include_nans')
         # Key is an index slice or a list of individual element indices. Return a subset of the data.
-        else:
-            if isinstance(key, (set, list, tuple)):
-                key = np.array(key)
+        elif isinstance(key, slice):
             return FileIndex(data=self._data[key], t0=self.t0)
+        elif isinstance(key, (set, list, tuple)):
+            if len(key) > 0:
+                key = np.array(key)
+                return FileIndex(data=self._data[key], t0=self.t0)
+            else:
+                return FileIndex(data=[], t0=self.t0)
+        else:
+            raise ValueError('Unsupported key type.')
 
     def __iter__(self):
         if self._data is None:

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -57,6 +57,8 @@ class MixedLogReader(object):
             self.message_types = set((message_types.get_type(),))
         else:
             self.message_types = set([(t.get_type() if MessagePayload.is_subclass(t) else t) for t in message_types])
+            if len(self.message_types) == 0:
+                self.message_types = None
 
         self.valid_count = 0
         self.message_counts = {}

--- a/python/tests/test_file_index.py
+++ b/python/tests/test_file_index.py
@@ -94,6 +94,12 @@ def test_index_slice():
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
 
+    # Pass empty set -- remove all elements.
+    sliced_index = index[set()]
+    raw = []
+    assert _test_time(sliced_index.time, raw)
+    assert (sliced_index.offset == [e[2] for e in raw]).all()
+
 
 def test_time_slice():
     def _lower_bound(time):


### PR DESCRIPTION
# Fixes
- Fixed MixedLogReader handling of empty message type set
- Fixed FileIndex slicing crash if user set is empty