### PR TITLE
Fix compiler error due to use of major / minor keywords

### DIFF
--- a/src/point_one/fusion_engine/messages/data_version.h
+++ b/src/point_one/fusion_engine/messages/data_version.h
@@ -27,7 +27,7 @@ struct alignas(4) DataVersion {
 
   constexpr DataVersion() = default;
   constexpr DataVersion(uint8_t major, uint16_t minor)
-      : major(major), minor(minor) {}
+      : major{major}, minor{minor} {}
 
   /**
    * @brief Returns whether the stored version is valid.


### PR DESCRIPTION
When compiling data_version.h, previously it would cause a compiler error due to the use of the names "major" and "minor". These are defined as macros in <sys/sysmacros.h>. So in the initializer list, the compiler interprets those as calls to the corresponding macros instead of as constructors for the member variables.

The fix is to use curly bracket initializers to dis-ambiguate. Using curly bracket initializers is also a best-practice in general to avoid exactly these kinds of ambiguities.

It might also be worth considering avoiding using the names "major" and "minor" in general because they are already defined as macros in the c std library. Perhaps naming these variables "major_version" and "minor_version", or something like that would make sense. I did not make that change in this PR though, since that would be a breaking change.

Full error:
```
In file included from external/fusion_engine_client/src/point_one/fusion_engine/messages/data_version.cc:1:
external/fusion_engine_client/src/point_one/fusion_engine/messages/data_version.h:30:9: error: member initializer 'gnu_dev_major' does not name a non-static data member or base class
      : major(major), minor(minor) {}
        ^~~~~~~~~~~~
/usr/include/x86_64-linux-gnu/sys/sysmacros.h:101:44: note: expanded from macro 'major'
                                           ^~~~~~~~~~~~~~~~~~~
```

Here is a related issue that affected protobuf:
https://github.com/protocolbuffers/protobuf/issues/4654

Edit:
OS version: Ubuntu 18.04
Building with clang-11, with fusion_engine-client as a bazel dependency