### PR TITLE
Fixed file read crash and enum string value.

### DIFF
--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -288,7 +288,7 @@ class MixedLogReader(object):
             self.logger.log(logging.INFO if self.show_progress else logging.DEBUG,
                             'Processed %d/%d bytes (%.1f%%). [elapsed=%.1f sec, rate=%.1f MB/s]' %
                             (self.total_bytes_read, file_size,
-                             100.0 * float(self.total_bytes_read) / file_size,
+                             100.0 if file_size == 0 else 100.0 * float(self.total_bytes_read) / file_size,
                              elapsed_sec, self.total_bytes_read / elapsed_sec / 1e6))
             self.last_print_bytes = self.total_bytes_read
 

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -10,7 +10,7 @@ class IntEnum(IntEnumBase):
         #       BAR = 1
         #
         #   print(Foo.BAR)   # Prints "BAR", not "Foo.BAR"
-        return super().__str__().replace(self.__class__.__name__ + '.', '')
+        return self.name
 
     def to_string(self, include_value=False):
         if include_value:


### PR DESCRIPTION
# Fixes
- Fixed crash when reading specific message types from a `.p1log` file by index if there are no matching messages
- Fixed `IntEnum.str()` response on certain Python versions