### PR TITLE
Disable pull request trigger for CI builds.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -9,9 +9,6 @@ on:
     # Build on a push of any tag named v* (v1.0, etc.) and generate a release.
     tags:
       - 'v*'
-  pull_request:
-    # Build when a pull request is opened or updated.
-    types: [opened, synchronize, reopened]
 
 jobs:
   # Check code style.


### PR DESCRIPTION
We already build all branches, so this is redundant.