### PR TITLE
Improved command-line argument handling in `p1_display.py`.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1282,9 +1282,10 @@ Load and display information stored in a FusionEngine binary file.
                              "specified and a .p1i file does not exist, do not generate one. Otherwise, a .p1i file "
                              "will be created automatically to improve data read speed in the future.")
     parser.add_argument('--mapbox-token', metavar='TOKEN',
-                        help="A Mapbox token to use when generating a map. If unspecified, the token will be read from "
-                             "the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment variables if set. If no token "
-                             "is available, a map will not be displayed.")
+                        help="A Mapbox token to use for satellite imagery when generating a map. If unspecified, the "
+                             "token will be read from the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment "
+                             "variables if set. If no token is available, a default map will be displayed using Open "
+                             "Street Maps data.")
     parser.add_argument('-m', '--measurements', action=TriStateBooleanAction,
                         help="Plot incoming measurement data (slow).")
     parser.add_argument('--no-index', action=TriStateBooleanAction,

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1274,44 +1274,53 @@ def main():
     parser = ArgumentParser(description="""\
 Load and display information stored in a FusionEngine binary file.
 """)
-    parser.add_argument('--absolute-time', '--abs', action=TriStateBooleanAction,
-                        help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as "
-                             "relative to the first message in the file.")
-    parser.add_argument('--ignore-index', action=TriStateBooleanAction,
-                        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If "
-                             "specified and a .p1i file does not exist, do not generate one. Otherwise, a .p1i file "
-                             "will be created automatically to improve data read speed in the future.")
-    parser.add_argument('--mapbox-token', metavar='TOKEN',
-                        help="A Mapbox token to use for satellite imagery when generating a map. If unspecified, the "
-                             "token will be read from the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment "
-                             "variables if set. If no token is available, a default map will be displayed using Open "
-                             "Street Maps data.")
-    parser.add_argument('-m', '--measurements', action=TriStateBooleanAction,
-                        help="Plot incoming measurement data (slow).")
-    parser.add_argument('--no-index', action=TriStateBooleanAction,
-                        help="Do not automatically open the plots in a web browser.")
-    parser.add_argument('-o', '--output', type=str, metavar='DIR',
-                        help="The directory where output will be stored. Defaults to the current directory, or to "
-                             "'<log_dir>/plot_fusion_engine/' if reading from a log.")
-    parser.add_argument('-p', '--prefix', metavar='PREFIX',
-                        help="If specified, prepend each filename with PREFIX.")
-    parser.add_argument('-t', '--time', type=str, metavar='[START][:END]',
-                        help="The desired time range to be analyzed. Both start and end may be omitted to read from "
-                             "beginning or to the end of the file. By default, timestamps are treated as relative to "
-                             "the first message in the file. See --absolute-time.")
-    parser.add_argument('-v', '--verbose', action='count', default=0,
-                        help="Print verbose/trace debugging messages.")
 
-    parser.add_argument('--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
-                        help="The base directory containing FusionEngine logs to be searched if a log pattern is "
-                             "specified.")
-    parser.add_argument('log',
-                        help="The log to be read. May be one of:\n"
-                             "- The path to a .p1log file or a file containing FusionEngine messages and other "
-                             "content\n"
-                             "- The path to a FusionEngine log directory\n"
-                             "- A pattern matching a FusionEngine log directory under the specified base directory "
-                             "(see find_fusion_engine_log() and --log-base-dir)")
+    parser.add_argument(
+        '--absolute-time', '--abs', action=TriStateBooleanAction,
+        help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as relative to the first "
+             "message in the file.")
+    parser.add_argument(
+        '--ignore-index', action=TriStateBooleanAction,
+        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a "
+             ".p1i file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
+             "improve data read speed in the future.")
+    parser.add_argument(
+        '--mapbox-token', metavar='TOKEN',
+        help="A Mapbox token to use for satellite imagery when generating a map. If unspecified, the token will be "
+             "read from the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment variables if set. If no token is "
+             "available, a default map will be displayed using Open Street Maps data.")
+    parser.add_argument(
+        '-m', '--measurements', action=TriStateBooleanAction,
+        help="Plot incoming measurement data (slow).")
+    parser.add_argument(
+        '--no-index', action=TriStateBooleanAction,
+        help="Do not automatically open the plots in a web browser.")
+    parser.add_argument(
+        '-o', '--output', type=str, metavar='DIR',
+        help="The directory where output will be stored. Defaults to the current directory, or to "
+              "'<log_dir>/plot_fusion_engine/' if reading from a log.")
+    parser.add_argument(
+        '-p', '--prefix', metavar='PREFIX',
+        help="If specified, prepend each filename with PREFIX.")
+    parser.add_argument(
+        '-t', '--time', type=str, metavar='[START][:END]',
+        help="The desired time range to be analyzed. Both start and end may be omitted to read from beginning or to "
+             "the end of the file. By default, timestamps are treated as relative to the first message in the file. "
+             "See --absolute-time.")
+    parser.add_argument(
+        '-v', '--verbose', action='count', default=0,
+        help="Print verbose/trace debugging messages.")
+
+    parser.add_argument(
+        '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
+        help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
+    parser.add_argument(
+        'log',
+        help="The log to be read. May be one of:\n"
+             "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
+             "- The path to a FusionEngine log directory\n"
+             "- A pattern matching a FusionEngine log directory under the specified base directory "
+             "(see find_fusion_engine_log() and --log-base-dir)")
     options = parser.parse_args()
 
     # Configure logging.

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -988,7 +988,7 @@ class Analyzer(object):
 
         self._add_figure(name="imu", figure=figure, title="Measurements: IMU")
 
-    def generate_event_table(self):
+    def plot_events(self):
         """!
         @brief Generate a table of event notifications.
         """
@@ -1398,7 +1398,7 @@ Load and display information stored in a FusionEngine binary file.
         analyzer.plot_imu()
         analyzer.plot_wheel_data()
 
-    analyzer.generate_event_table()
+    analyzer.plot_events()
 
     analyzer.generate_index(auto_open=not options.no_index)
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -25,7 +25,7 @@ from ..messages import *
 from .attitude import get_enu_rotation_matrix
 from .file_reader import FileReader
 from ..utils import trace
-from ..utils.argument_parser import ArgumentParser
+from ..utils.argument_parser import ArgumentParser, TriStateBooleanAction
 from ..utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 _logger = logging.getLogger('point_one.fusion_engine.analysis.analyzer')
 
@@ -1274,10 +1274,10 @@ def main():
     parser = ArgumentParser(description="""\
 Load and display information stored in a FusionEngine binary file.
 """)
-    parser.add_argument('--absolute-time', '--abs', action='store_true',
+    parser.add_argument('--absolute-time', '--abs', action=TriStateBooleanAction,
                         help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as "
                              "relative to the first message in the file.")
-    parser.add_argument('--ignore-index', action='store_true',
+    parser.add_argument('--ignore-index', action=TriStateBooleanAction,
                         help="If set, do not load the .p1i index file corresponding with the .p1log data file. If "
                              "specified and a .p1i file does not exist, do not generate one. Otherwise, a .p1i file "
                              "will be created automatically to improve data read speed in the future.")
@@ -1285,9 +1285,9 @@ Load and display information stored in a FusionEngine binary file.
                         help="A Mapbox token to use when generating a map. If unspecified, the token will be read from "
                              "the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment variables if set. If no token "
                              "is available, a map will not be displayed.")
-    parser.add_argument('-m', '--measurements', action='store_true',
+    parser.add_argument('-m', '--measurements', action=TriStateBooleanAction,
                         help="Plot incoming measurement data (slow).")
-    parser.add_argument('--no-index', action='store_true',
+    parser.add_argument('--no-index', action=TriStateBooleanAction,
                         help="Do not automatically open the plots in a web browser.")
     parser.add_argument('-o', '--output', type=str, metavar='DIR',
                         help="The directory where output will be stored. Defaults to the current directory, or to "

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1275,52 +1275,58 @@ def main():
 Load and display information stored in a FusionEngine binary file.
 """)
 
-    parser.add_argument(
-        '--absolute-time', '--abs', action=TriStateBooleanAction,
-        help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as relative to the first "
-             "message in the file.")
-    parser.add_argument(
-        '--ignore-index', action=TriStateBooleanAction,
-        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a "
-             ".p1i file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
-             "improve data read speed in the future.")
-    parser.add_argument(
-        '--mapbox-token', metavar='TOKEN',
+    plot_group = parser.add_argument_group('Plot Control')
+    plot_group.add_argument('--mapbox-token', metavar='TOKEN',
         help="A Mapbox token to use for satellite imagery when generating a map. If unspecified, the token will be "
              "read from the MAPBOX_ACCESS_TOKEN or MapboxAccessToken environment variables if set. If no token is "
              "available, a default map will be displayed using Open Street Maps data.")
-    parser.add_argument(
+    plot_group.add_argument(
         '-m', '--measurements', action=TriStateBooleanAction,
         help="Plot incoming measurement data (slow).")
-    parser.add_argument(
-        '--no-index', action=TriStateBooleanAction,
-        help="Do not automatically open the plots in a web browser.")
-    parser.add_argument(
-        '-o', '--output', type=str, metavar='DIR',
-        help="The directory where output will be stored. Defaults to the current directory, or to "
-              "'<log_dir>/plot_fusion_engine/' if reading from a log.")
-    parser.add_argument(
-        '-p', '--prefix', metavar='PREFIX',
-        help="If specified, prepend each filename with PREFIX.")
-    parser.add_argument(
+
+    time_group = parser.add_argument_group('Time Control')
+    time_group.add_argument(
+        '--absolute-time', '--abs', action=TriStateBooleanAction,
+        help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as relative to the first "
+             "message in the file.")
+    time_group.add_argument(
         '-t', '--time', type=str, metavar='[START][:END]',
         help="The desired time range to be analyzed. Both start and end may be omitted to read from beginning or to "
              "the end of the file. By default, timestamps are treated as relative to the first message in the file. "
              "See --absolute-time.")
-    parser.add_argument(
-        '-v', '--verbose', action='count', default=0,
-        help="Print verbose/trace debugging messages.")
 
-    parser.add_argument(
+    log_group = parser.add_argument_group('Input File/Log Control')
+    log_group.add_argument(
+        '--ignore-index', action=TriStateBooleanAction,
+        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a "
+             ".p1i file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
+             "improve data read speed in the future.")
+    log_group.add_argument(
         '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
         help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
-    parser.add_argument(
+    log_group.add_argument(
         'log',
         help="The log to be read. May be one of:\n"
              "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
              "- The path to a FusionEngine log directory\n"
              "- A pattern matching a FusionEngine log directory under the specified base directory "
              "(see find_fusion_engine_log() and --log-base-dir)")
+
+    output_group = parser.add_argument_group('Output Control')
+    output_group.add_argument(
+        '--no-index', action=TriStateBooleanAction,
+        help="Do not automatically open the plots in a web browser.")
+    output_group.add_argument(
+        '-o', '--output', type=str, metavar='DIR',
+        help="The directory where output will be stored. Defaults to the current directory, or to "
+              "'<log_dir>/plot_fusion_engine/' if reading from a log.")
+    output_group.add_argument(
+        '-p', '--prefix', metavar='PREFIX',
+        help="If specified, prepend each filename with PREFIX.")
+    output_group.add_argument(
+        '-v', '--verbose', action='count', default=0,
+        help="Print verbose/trace debugging messages.")
+
     options = parser.parse_args()
 
     # Configure logging.

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -594,7 +594,7 @@ class Analyzer(object):
 
         self._plot_displacement('Pose Displacement', time, solution_type, displacement_enu_m, std_enu_m)
 
-    def plot_relative_position_to_base_station(self):
+    def plot_relative_position(self):
         """!
         @brief Generate a topocentric (top-down) plot of relative position vs base station, as well as plot of relative
                position over time.
@@ -1390,7 +1390,7 @@ Load and display information stored in a FusionEngine binary file.
     analyzer.plot_solution_type()
     analyzer.plot_pose()
     analyzer.plot_pose_displacement()
-    analyzer.plot_relative_position_to_base_station()
+    analyzer.plot_relative_position()
     analyzer.plot_map(mapbox_token=options.mapbox_token)
     analyzer.plot_calibration()
 

--- a/python/fusion_engine_client/utils/argument_parser.py
+++ b/python/fusion_engine_client/utils/argument_parser.py
@@ -269,6 +269,12 @@ class TriStateBooleanAction(argparse.Action):
             if option_string is not None and option_string.startswith('--no-'):
                 if values is not None:
                     raise ValueError('Value string not supported for %s.' % option_string)
+                # This is a special case. Normally, for an argument `--foo`, self.options_strings contains `--foo` and
+                # `--no-foo`. On the other hand, if the original argument is prefixed with "no-" like `--no-bar`,
+                # self.options_strings will contain `--no-bar` and `--no-no-bar`. In that case, specifying `--no-bar` on
+                # the command line should return true, not false.
+                elif option_string == self.option_strings[0]:
+                    result = True
                 else:
                     result = False
             else:

--- a/python/fusion_engine_client/utils/argument_parser.py
+++ b/python/fusion_engine_client/utils/argument_parser.py
@@ -199,8 +199,8 @@ class ArgumentParser(argparse.ArgumentParser):
 
         super(ArgumentParser, self).__init__(*args, **kwargs)
 
-        self._positionals.title = 'Positional arguments'
-        self._optionals.title = 'Optional arguments'
+        self._positionals.title = 'Positional Arguments'
+        self._optionals.title = 'Optional Arguments'
 
         if overwrite_help:
             self.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,

--- a/python/fusion_engine_client/utils/argument_parser.py
+++ b/python/fusion_engine_client/utils/argument_parser.py
@@ -135,6 +135,11 @@ class TriStateBooleanAction(argparse.Action):
         setattr(namespace, self.dest, result)
 
 
+class CSVAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, [v.strip() for v in values.split(',')])
+
+
 class TriStateBoolFormatter(argparse.HelpFormatter):
     def _format_action_invocation(self, action):
         if isinstance(action, TriStateBooleanAction):

--- a/python/fusion_engine_client/utils/argument_parser.py
+++ b/python/fusion_engine_client/utils/argument_parser.py
@@ -10,12 +10,152 @@
 from __future__ import absolute_import
 
 import argparse
+import copy
 
 from argparse_formatter import FlexiFormatter
 
 
+class TriStateBooleanAction(argparse.Action):
+    POSSIBLE_VALUES = ('true', 'false', 't', 'f', 'yes', 'no', 'y', 'n', 'on', 'off', '1', '0')
+
+    """!
+    @brief Return a boolean argument taking a variety of values, that may be `None` if not specified.
+
+    This action is similar to `argparse.BooleanOptionalAction` (Python 3.9+), except that it adds two additional
+    features:
+    1. The user may specify an optional value string in addition to `--foo` and `--no-foo`. Supported values include:
+       `true, false, t, f, yes, no, y, n, on, off, 1, 0`
+    2. By default, the argument defaults to `None` if not specified, rather than `True` or `False. This allows the
+       application to explicitly detect if the argument was not specified and take an alternative action. `default` may
+       be set to `True` or `False` to disable this behavior.
+
+    Example usage:
+    ```
+                 # None (unless `default` is set)
+    --foo        # True
+    --foo=true   # True
+    --foo=false  # False
+    --no-foo     # False
+    ```
+    """
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar=None):
+        for option_string in option_strings:
+            if not option_string.startswith('-'):
+                raise ValueError('Positional arguments not supported for tri-state bool actions.')
+
+        # Unfortunately Python argparse does not have a way to selectively capture an optional argument value only if it
+        # meets some criteria. This means that we cannot support argument syntax with spaces:
+        #   --foo true
+        # If we tried to by setting nargs='?', if the user did not specify a truthiness value and just did --foo, any
+        # positional arguments after --foo would be captured incorrectly. Python would not know that we don't want to
+        # capture it. For example, if the user specified:
+        #  --foo abc def
+        # abc would be captured by --foo, and would not show up as a positional argument.
+        #
+        # To get around this, we only support = syntax, and we add all --foo=value variants as option names
+        # (option_strings) rather than values. For ['--foo', '--bar'], we generate:
+        #   --foo
+        #   --no-foo
+        #   --foo=true
+        #   --foo=false
+        #   ...
+        #   --bar
+        #   ...
+        #
+        # By default, when you run --help, the resulting output will be a bit of a mess:
+        #   Optional arguments:
+        #     --foo, --no-foo, --foo=true, --foo=false, --foo=t, ...
+        #
+        # We provide the TriStateBoolFormatter class below to instead print:
+        #   Optional arguments:
+        #     --foo[=<true, false, t, f, yes, no, y, n, on, off, 1, 0>], --no-foo
+        _option_strings = copy.copy(option_strings)
+        long_option_strings = [o for o in option_strings if o.startswith('--')]
+        _option_strings.extend([f'--no-{o[2:]}' for o in long_option_strings])
+        for v in self.POSSIBLE_VALUES:
+            _option_strings.extend([f'{o}={v}' for o in long_option_strings])
+
+        if help is not None and default is not None and default != argparse.SUPPRESS:
+            help += " (default: %(default)s)"
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            const=True,
+            default=default if default is not None else False,
+            type=None,
+            choices=None,
+            required=required,
+            help=help,
+            metavar=None)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string is None:
+            # Caught in constructor. Should not happen.
+            raise ValueError('Positional arguments not supported for tri-state bool actions.')
+
+        parts = option_string.split('=')
+        name = parts[0]
+        if len(parts) > 1:
+            # Taken from distutils.util.strtobool().
+            value = parts[1].lower()
+            if value in ('y', 'yes', 't', 'true', 'on', '1'):
+                result = True
+            elif value in ('n', 'no', 'f', 'false', 'off', '0'):
+                result = False
+            else:
+                raise ValueError("Invalid boolean value %r." % value)
+        elif name.startswith('--no-'):
+            # There is a special case here. If the user named the argument `--no-foo`, they will have the options:
+            #   1. --no-foo
+            #   2. --no-no-foo
+            # We strip out the leading `--no-` to check if (1) is present in the options strings. If so, this is case
+            # (2) and they want us to return false. If not, this is case (1) and we should return true.
+            #
+            # For the more typical `--bar`, we'll only ever see `--no-` prefix for the false case, and this condition
+            # will correctly identify case (2):
+            #   1. --foo
+            #   2. --no-bar
+            if name.replace('--no-', '--') in self.option_strings:
+                result = False
+            else:
+                result = True
+        else:
+            result = True
+
+        setattr(namespace, self.dest, result)
+
+
+class TriStateBoolFormatter(argparse.HelpFormatter):
+    def _format_action_invocation(self, action):
+        if isinstance(action, TriStateBooleanAction):
+            def _format(option):
+                # Note: Special case handling for --no-no-foo. See explanation in TriStateBooleanAction.
+                if ((option.startswith('--no-') and option.replace('--no-', '--') in action.option_strings) or
+                    not option.startswith('--')):
+                    return option
+                elif '=' in option:
+                    return None
+                else:
+                    return f"{option}[=<{', '.join(TriStateBooleanAction.POSSIBLE_VALUES)}>]"
+
+            strings = [_format(o) for o in action.option_strings]
+            return ', '.join([o for o in strings if o is not None])
+        else:
+            return super(TriStateBoolFormatter, self)._format_action_invocation(action)
+
+
 # Modified from argparse.ArgumentDefaultsHelpFormatter to omit when default is None.
-class ArgumentDefaultsHelpFormatter(argparse.HelpFormatter):
+class ArgumentDefaultsHelpFormatter(TriStateBoolFormatter):
     def _get_help_string(self, action):
         help = action.help
         if '%(default)' not in action.help:
@@ -207,91 +347,3 @@ def rename_option(parser, input, dest=None, *args):
     # Update the destination if requested.
     if dest is not None:
         action.dest = dest.lstrip('-').replace('-', '_')
-
-
-class TriStateBooleanAction(argparse.Action):
-    """!
-    @brief Return a boolean argument taking a variety of values, that may be `None` if not specified.
-
-    This action is similar to `argparse.BooleanOptionalAction` (Python 3.9+), except that it adds two additional
-    features:
-    1. The user may specify an optional value string in addition to `--foo` and `--no-foo`. Supported values include:
-       `true, false, t, f, yes, no, y, n, on, off, 1, 0`
-    2. By default, the argument defaults to `None` if not specified, rather than `True` or `False. This allows the
-       application to explicitly detect if the argument was not specified and take an alternative action. `default` may
-       be set to `True` or `False` to disable this behavior.
-
-    Example usage:
-    ```
-                 # None (unless `default` is set)
-    --foo        # True
-    --foo=true   # True
-    --foo=false  # False
-    --no-foo     # False
-    ```
-    """
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 default=None,
-                 type=None,
-                 choices=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
-
-        _option_strings = []
-        for option_string in option_strings:
-            _option_strings.append(option_string)
-
-            if option_string.startswith('--'):
-                option_string = '--no-' + option_string[2:]
-                _option_strings.append(option_string)
-
-        if help is not None and default is not None and default is not SUPPRESS:
-            help += " (default: %(default)s)"
-
-        self.possible_values = ('true', 'false', 't', 'f', 'yes', 'no', 'y', 'n', 'on', 'off', '1', '0')
-
-        super().__init__(
-            option_strings=_option_strings,
-            dest=dest,
-            nargs='?',
-            default=default,
-            type=None,
-            choices=None,
-            required=required,
-            help=help,
-            metavar=','.join(self.possible_values))
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string is None or option_string in self.option_strings:
-            if option_string is not None and option_string.startswith('--no-'):
-                if values is not None:
-                    raise ValueError('Value string not supported for %s.' % option_string)
-                # This is a special case. Normally, for an argument `--foo`, self.options_strings contains `--foo` and
-                # `--no-foo`. On the other hand, if the original argument is prefixed with "no-" like `--no-bar`,
-                # self.options_strings will contain `--no-bar` and `--no-no-bar`. In that case, specifying `--no-bar` on
-                # the command line should return true, not false.
-                elif option_string == self.option_strings[0]:
-                    result = True
-                else:
-                    result = False
-            else:
-                if values is None:
-                    result = True
-                else:
-                    # Taken from distutils.util.strtobool().
-                    val = values.lower()
-                    if val in ('y', 'yes', 't', 'true', 'on', '1'):
-                        result = True
-                    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
-                        result = False
-                    else:
-                        raise ValueError("Invalid boolean value %r." % val)
-
-            setattr(namespace, self.dest, result)
-
-    def format_usage(self):
-        options = '[={%s}]' % ','.join(self.possible_values)
-        return ', '.join([s + options if i == 0 else s for i, s in enumerate(self.option_strings)])


### PR DESCRIPTION
# New Features
- Added optional syntax for specifying boolean argument values (`--foo`, `--foo=false`, `--no-foo`, etc.)
- Added `--plot` option to `p1_display.py` to support specifying which plots to display

# Changes
- Reorganized `p1_display.py` arguments into groups