### PR TITLE
Added backwards compatibility support for earlier versions of colorama.

### DIFF
--- a/python/fusion_engine_client/utils/trace.py
+++ b/python/fusion_engine_client/utils/trace.py
@@ -3,7 +3,13 @@ import sys
 
 try:
     import colorama
-    colorama.just_fix_windows_console()
+
+    # This function was added in colorama 0.4.6, but some users may be using an earlier version. It only affects
+    # operation in Windows. The deprecated alternative is to call colorama.init().
+    try:
+        colorama.just_fix_windows_console()
+    except AttributeError:
+        colorama.init()
 except ImportError:
     colorama = None
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ construct>=2.10.0
 
 # Required for analysis and example applications only. Not used by the `messages` package.
 argparse-formatter>=1.4
-colorama>=0.4.6
+colorama>=0.4.4
 gpstime>=0.6.2
 plotly>=4.0.0
 pymap3d>=2.4.3

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ setup(
     extras_require={
         'analysis': [
             'argparse-formatter>=1.4',
-            'colorama>=0.4.6',
+            'colorama>=0.4.4',
             'gpstime>=0.6.2',
             'plotly>=4.0.0',
             'pymap3d>=2.4.3',


### PR DESCRIPTION
In particular, the awscli setup.py file currently strictly specifies colorama <0.4.5. Any applications including both awscli and fusion-engine-client will hit a pip dependency conflict if we require >=0.4.6.