### PR TITLE
Updated CMake flow to support FetchContent, and improved README instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Define the project and setup the compiler toolchain. This will establish
 # default compiler/linker flags. If the user specifies a cross-compilation
 # toolchain (-DCMAKE_TOOLCHAIN_FILE=...), it will be applied now.
-project(p1_fusion_engine_client)
+project(p1_fusion_engine_client VERSION 1.15.2)
 
 # Set additional compilation flags.
 if (MSVC)
@@ -40,6 +40,10 @@ target_include_directories(fusion_engine_client PUBLIC ${PROJECT_SOURCE_DIR}/src
 if (MSVC)
     target_compile_definitions(fusion_engine_client PRIVATE BUILDING_DLL)
 endif()
+
+set_target_properties(fusion_engine_client PROPERTIES
+                      VERSION ${PROJECT_VERSION}
+                      SOVERSION ${PROJECT_VERSION_MAJOR})
 
 # Install targets.
 install(TARGETS fusion_engine_client

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,25 @@
 # Copyright (C) Point One Navigation - All Rights Reserved
-project(p1_fusion_engine_client)
-
 cmake_minimum_required(VERSION 3.3.2)
 
-# Option definitions.
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries."
-       ON)
-
-option(BUILD_EXAMPLES "Build example applications." ON)
-
-# Set compilation flags.
+# Set toolchain parameters before calling project().
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Define user options.
+option(P1_FE_BUILD_EXAMPLES "Build example applications." ON)
+
+if (NOT DEFINED BUILD_SHARED_LIBS)
+    option(BUILD_SHARED_LIBS
+           "Build shared libraries instead of static libraries."
+           ON)
+endif()
+
+# Define the project and setup the compiler toolchain. This will establish
+# default compiler/linker flags. If the user specifies a cross-compilation
+# toolchain (-DCMAKE_TOOLCHAIN_FILE=...), it will be applied now.
+project(p1_fusion_engine_client)
+
+# Set additional compilation flags.
 if (MSVC)
     add_compile_options(/W4 /WX)
 else()
@@ -23,15 +30,13 @@ endif()
 # Library Definitions
 ################################################################################
 
-# Add the source directory to the include path.
-include_directories(${PROJECT_SOURCE_DIR}/src)
-
-# All messages and supporting code.
+# Define the fusion_engine_client library and supporting code.
 add_library(fusion_engine_client
             src/point_one/fusion_engine/common/logging.cc
             src/point_one/fusion_engine/messages/crc.cc
             src/point_one/fusion_engine/messages/data_version.cc
             src/point_one/fusion_engine/parsers/fusion_engine_framer.cc)
+target_include_directories(fusion_engine_client PUBLIC ${PROJECT_SOURCE_DIR}/src)
 if (MSVC)
     target_compile_definitions(fusion_engine_client PRIVATE BUILDING_DLL)
 endif()
@@ -44,9 +49,9 @@ install(DIRECTORY src/point_one DESTINATION include
         FILES_MATCHING PATTERN "*.h")
 
 ################################################################################
-# Example Applications
+# Example Applications (Optional)
 ################################################################################
 
-if (BUILD_EXAMPLES)
+if (P1_FE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ sudo make install
 ```
 
 This will generate `libfusion_engine_client.so`, and install the library and header files on your system. By default,
-this will also build the [example applications](#examples).
+this will also build the [example applications](#example-applications). You can disable the example applications by
+specifying `cmake -DP1_FE_BUILD_EXAMPLES=OFF ..`.
 
 #### Compiling (Windows)
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,18 @@ To use this library in an existing Bazel project, add the following to your proj
 ```python
 git_repository(
     name = "fusion_engine_client",
-    branch = "master",
     remote = "git@github.com:PointOneNav/fusion_engine_client.git",
+    tag = "v1.15.2",
 )
 ```
 
-Then add the following dependency to any `cc_library()` or `cc_binary()` definitions in your project:
+Note that we strongly recommend using a specific version of the library in your code by specifying a git tag (e.g.,
+`tag = "v1.15.2"`), and updating that as new versions are released. That way, you can be sure that your code is always
+built with a known version of fusion-engine-client. If you prefer, however, you can tell Bazel to track the latest
+changes by using `branch = "master"` instead.
+
+After declaring the repository in your `WORKSPACE` file, you can add the following dependency to any `cc_library()` or
+`cc_binary()` definitions in your project's `BAZEL` files:
 
 ```python
 cc_library(

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The `examples/` directory contains example applications demonstrating how to use
 - `external_cmake_project` - Download a copy of the FusionEngine Client library from the public repository and import
   it into a CMake project using `FetchContent`.
 - `generate_data` - Generate a binary file containing a fixed set of messages.
+- `tcp_client` - Connect to a device over TCP and display the received FusionEngine messages.
+- `udp_client` - Connect to a device over UDP and display the received FusionEngine messages.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ One FusionEngine or a Point One device (Atlas, Quectel LG69T, etc.), please cont
   * [Example Applications](#example-applications)
 * [Installation](#installation)
   * [CMake](#cmake)
-    * [Compiling (Linux)](#compiling-linux)
-    * [Compiling (Windows)](#compiling-windows)
     * [Including In Your CMake Project](#including-in-your-cmake-project)
+    * [Compiling From Source (Linux)](#compiling-from-source-linux)
+    * [Compiling From Source (Windows)](#compiling-from-source-windows)
     * [Running Examples](#running-examples-1)
   * [Bazel](#bazel)
-    * [Compiling](#compiling)
+    * [Including In Your Bazel Project](#including-in-your-bazel-project)
+    * [Compiling From Source](#compiling-from-source)
     * [Running Examples](#running-examples)
   * [Python](#python)
   * [Compiling Documentation](#compiling-documentation)
@@ -84,36 +85,6 @@ The `examples/` directory contains example applications demonstrating how to use
 
 ### CMake
 
-#### Compiling (Linux)
-
-Use the following steps to compile and install this library using CMake:
-
-```
-mkdir build
-cd build
-cmake ..
-make
-sudo make install
-```
-
-This will generate `libfusion_engine_client.so`, and install the library and header files on your system. By default,
-this will also build the [example applications](#example-applications). You can disable the example applications by
-specifying `cmake -DP1_FE_BUILD_EXAMPLES=OFF ..`.
-
-#### Compiling (Windows)
-
-Use the following steps to compile and install this library using CMake and MSBuild:
-
-```
-mkdir output
-cd output
-cmake ..
-MSBuild p1_fusion_engine_client.sln
-```
-
-> Note: For Windows, we name the build directory `output`. Windows is not case-sensitive, and `build` conflicts with the
-> Bazel `BUILD` file.
-
 #### Including In Your CMake Project
 
 To include this library as part of your CMake project, we recommend using the CMake `FetchContent` feature as shown
@@ -141,6 +112,36 @@ changes by using `GIT_TAG master` instead.
 
 See [examples/external_cmake_project/CMakeLists.txt](examples/external_cmake_project/CMakeLists.txt) for more details.
 
+#### Compiling From Source (Linux)
+
+Use the following steps to compile and install this library using CMake:
+
+```
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+```
+
+This will generate `libfusion_engine_client.so`, and install the library and header files on your system. By default,
+this will also build the [example applications](#example-applications). You can disable the example applications by
+specifying `cmake -DP1_FE_BUILD_EXAMPLES=OFF ..`.
+
+#### Compiling From Source (Windows)
+
+Use the following steps to compile and install this library using CMake and MSBuild:
+
+```
+mkdir output
+cd output
+cmake ..
+MSBuild p1_fusion_engine_client.sln
+```
+
+> Note: For Windows, we name the build directory `output`. Windows is not case-sensitive, and `build` conflicts with the
+> Bazel `BUILD` file.
+
 #### Running Examples
 
 By default, the compiled example applications will be located in `build/examples/` and can be run from there:
@@ -151,7 +152,7 @@ By default, the compiled example applications will be located in `build/examples
 
 ### Bazel
 
-#### Compiling
+#### Including In Your Bazel Project
 
 To use this library in an existing Bazel project, add the following to your project's `WORKSPACE` file:
 
@@ -183,8 +184,10 @@ cc_library(
 If desired, you can add a dependency for only part of the library. For example, to depend on only the core message
 definitions and support code, set your `deps` entry to `@fusion_engine_client//:core`.
 
-Note that there is no need to explicitly compile or link this library when using Bazel - it will be built automatically
-when your application is built. If desired, however, you can build a stand-alone shared library as follows:
+#### Compiling From Source
+
+In general, it is strongly recommended that you let Bazel import and compile the library using `git_repository()` as
+shown above. If you would like to compile the library manually, however, you can run the following command:
 
 ```
 bazel build -c opt //:libfusion_engine_client.so

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ One FusionEngine or a Point One device (Atlas, Quectel LG69T, etc.), please cont
   * [CMake](#cmake)
     * [Compiling (Linux)](#compiling-linux)
     * [Compiling (Windows)](#compiling-windows)
+    * [Including In Your CMake Project](#including-in-your-cmake-project)
     * [Running Examples](#running-examples-1)
   * [Bazel](#bazel)
     * [Compiling](#compiling)
@@ -73,6 +74,8 @@ One FusionEngine or a Point One device (Atlas, Quectel LG69T, etc.), please cont
 
 The `examples/` directory contains example applications demonstrating how to use this library. They are:
 - `message_decode` - Print the contents of messages contained in a binary file.
+- `external_cmake_project` - Download a copy of the FusionEngine Client library from the public repository and import
+  it into a CMake project using `FetchContent`.
 - `generate_data` - Generate a binary file containing a fixed set of messages.
 
 ## Installation
@@ -107,6 +110,33 @@ MSBuild p1_fusion_engine_client.sln
 
 > Note: For Windows, we name the build directory `output`. Windows is not case-sensitive, and `build` conflicts with the
 > Bazel `BUILD` file.
+
+#### Including In Your CMake Project
+
+To include this library as part of your CMake project, we recommend using the CMake `FetchContent` feature as shown
+below, rather than compiling and installing the library manually as in the sections above:
+```cmake
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(P1_FE_BUILD_EXAMPLES OFF)
+include(FetchContent)
+FetchContent_Declare(
+    fusion_engine_client
+    GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
+    GIT_TAG v1.15.2
+)
+FetchContent_Populate(fusion_engine_client)
+add_subdirectory(${fusion_engine_client_SOURCE_DIR})
+
+add_executable(example_app main.cc)
+target_link_libraries(example_app PUBLIC fusion_engine_client)
+```
+
+Note that we strongly recommend using a specific version of the library in your code by specifying a git tag (e.g.,
+`GIT_TAG v1.15.2`), and updating that as new versions are released. That way, you can be sure that your code is always
+built with a known version of fusion-engine-client. If you prefer, however, you can tell CMake to track the latest
+changes by using `GIT_TAG master` instead.
+
+See [examples/external_cmake_project/CMakeLists.txt](examples/external_cmake_project/CMakeLists.txt) for more details.
 
 #### Running Examples
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(.)
-
 add_subdirectory(common)
 
 add_subdirectory(generate_data)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,3 +4,8 @@ add_subdirectory(generate_data)
 add_subdirectory(message_decode)
 add_subdirectory(tcp_client)
 add_subdirectory(udp_client)
+
+# Note that we do _not_ include the external_cmake_project/ subdirectory here.
+# That application is designed as a standalone project, not built by the
+# fusion-engine-client CMake project. See external_cmake_project/CMakeLists.txt
+# for details.

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(print_message STATIC print_message.cc)
+target_link_libraries(print_message PUBLIC fusion_engine_client)

--- a/examples/common/print_message.cc
+++ b/examples/common/print_message.cc
@@ -3,7 +3,7 @@
  * @file
  ******************************************************************************/
 
-#include "common/print_message.h"
+#include "print_message.h"
 
 using namespace point_one::fusion_engine::messages;
 

--- a/examples/external_cmake_project/CMakeLists.txt
+++ b/examples/external_cmake_project/CMakeLists.txt
@@ -1,0 +1,58 @@
+################################################################################
+# This is a simple example of how to import the fusion-engine-client library in
+# your own project using the CMake FetchContent feature. We strongly encourage
+# you to use FetchContent to download fusion-engine-client from the publicly
+# available source code.
+#
+# Alternatively, you may choose to use a git submodule to import the source code
+# into your repository. We do not recommend copying the fusion-engine-client
+# source code directly into your repository. Doing so makes it much more
+# difficult to receive updates as new features and improvements are released.
+################################################################################
+
+cmake_minimum_required(VERSION 3.12)
+
+# We explicitly set the CMake CMP0077 policy to NEW before calling FetchContent
+# below. This policy was adding in CMake 3.12. Setting it to NEW makes it so
+# set() calls here are not overridden by option() definitions in the external
+# library. With default value (OLD), the option() value will be used.
+
+# Specifically, here we want to set(P1_FE_BUILD_EXAMPLES OFF). If we do not set
+# CMP0077 to NEW, the option(P1_FE_BUILD_EXAMPLES ON) definition inside the
+# fusion-engine-client CMake file will ignore that value and set it to ON.
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# Disable example applications from the fusion-engine-client library imported
+# below. We want to build the library and make the fusion_engine_client CMake
+# target available here. If we do not do this, teh add_subdirectory() call below
+# will also import all of the example applications in
+# fusion-engine-client/examples/.
+set(P1_FE_BUILD_EXAMPLES OFF)
+
+project(fusion_engine_usage_example C CXX)
+
+# Use FetchContent to import the fusion-engine-client C++ library using Git.
+#
+# Note that we always recommend using a specific version of the library in your
+# code by specifying a git tag (e.g., `GIT_TAG v1.15.2`), and updating that as
+# new versions are released. That way, you can be sure that your code is always
+# built with a known version of fusion-engine-client.
+#
+# If you prefer, however, you can set the GIT_TAG to track the latest changes by
+# setting `GIT_TAG master` below.
+include(FetchContent)
+FetchContent_Declare(
+    fusion_engine_client
+    GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
+    GIT_TAG v1.15.2
+)
+FetchContent_Populate(fusion_engine_client)
+add_subdirectory(${fusion_engine_client_SOURCE_DIR})
+
+# Now we define an example application that uses the fusion-engine-client
+# library. In your own code, you can link any add_executable() or add_library()
+# target with fusion-engine-client by calling target_link_libraries() as shown.
+add_executable(example_app main.cc)
+target_link_libraries(example_app PUBLIC fusion_engine_client)

--- a/examples/external_cmake_project/main.cc
+++ b/examples/external_cmake_project/main.cc
@@ -1,0 +1,38 @@
+/**************************************************************************/ /**
+* @brief Simple example of linking against the fusion-engine-client library
+*        using CMake.
+*
+* This application does not do anything very interesting. It is meant only as an
+* example of how to import fusion-engine-client in CMake using FetchContent. See
+* the accompanying CMakeLists.txt file.
+*
+* @file
+******************************************************************************/
+
+#include <cstdio>
+
+#include <point_one/fusion_engine/messages/core.h>
+
+using namespace point_one::fusion_engine::messages;
+
+int main(int argc, const char* argv[]) {
+  // Populate a pose message with some content.
+  PoseMessage pose_message;
+
+  pose_message.p1_time.seconds = 123;
+  pose_message.p1_time.fraction_ns = 456000000;
+
+  pose_message.gps_time.seconds = 1282677727;
+  pose_message.gps_time.fraction_ns = 200000000;
+
+  pose_message.solution_type = SolutionType::RTKFixed;
+  pose_message.lla_deg[0] = 37.795137;
+  pose_message.lla_deg[1] = -122.402754;
+  pose_message.lla_deg[2] = 40.8;
+
+  // Print out the LLA position.
+  printf("LLA: %.6f, %.6f, %.2f\n", pose_message.lla_deg[0],
+         pose_message.lla_deg[1], pose_message.lla_deg[2]);
+
+  return 0;
+}

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -181,6 +181,29 @@ with open('${CPP_VERSION_PATH}', 'wt') as f:
 EOF
 git add "${CPP_VERSION_PATH}"
 
+# Update the version string in the C++ CMake file.
+#
+# Note: CMake does not support version suffixes like rc3, etc., so we only use
+# the major.minor.patch version here.
+echo "Updating CMake project version string."
+CMAKE_PATH="CMakeLists.txt"
+cat <<EOF | python3
+import re
+from packaging import version
+
+new_version = version.parse("${VERSION}")
+
+with open('${CMAKE_PATH}', 'rt') as f:
+    cmake_contents = f.read()
+
+with open('${CMAKE_PATH}', 'wt') as f:
+    f.write(re.sub(
+        r'project\\((.* VERSION) .*\\)',
+        f'project(\\\\1 {new_version.major}.{new_version.minor}.{new_version.micro})',
+        cmake_contents))
+EOF
+git add "${CMAKE_PATH}"
+
 # Update the version string in the Python library.
 echo "Updating Python library version string."
 PYTHON_INIT_PATH="python/fusion_engine_client/__init__.py"


### PR DESCRIPTION
# Changes
- Reorganized `CMakeLists.txt` and renamed CMake options flags to allow fusion-engine-client to be imported into a user project using `FetchContent`
- Added a standalone example project using CMake `FetchContent` to import and use this library
- Added explicit README instructions recommending how to include this library in a bigger project for CMake and Bazel