### PR TITLE
Suppress expected numpy warning.

### DIFF
--- a/python/fusion_engine_client/parsers/file_index.py
+++ b/python/fusion_engine_client/parsers/file_index.py
@@ -451,7 +451,10 @@ class FileIndex(object):
     def _to_raw(cls, data):
         time_sec = data['time']
         idx = np.isnan(time_sec)
+        # Ignore `RuntimeWarning: invalid value encountered in cast` since we want the NaN to be cast to int.
+        np.seterr(invalid="ignore")
         raw_data = data.astype(dtype=cls._RAW_DTYPE)
+        np.seterr(invalid="warn")
         raw_data['int'][idx] = Timestamp._INVALID
         return raw_data
 


### PR DESCRIPTION
This is a really minor thing, but this warning is expected in the situation where we're doing this cast, so we should suppress it.