### PR TITLE
Apply `assume_utc` to `datetime` objects without a timezone.

### DIFF
--- a/python/fusion_engine_client/messages/__init__.py
+++ b/python/fusion_engine_client/messages/__init__.py
@@ -32,6 +32,7 @@ message_type_to_class = {
     ResetRequest.MESSAGE_TYPE: ResetRequest,
     VersionInfoMessage.MESSAGE_TYPE: VersionInfoMessage,
     EventNotificationMessage.MESSAGE_TYPE: EventNotificationMessage,
+    ShutdownRequest.MESSAGE_TYPE: ShutdownRequest,
     FaultControlMessage.MESSAGE_TYPE: FaultControlMessage,
 
     SetConfigMessage.MESSAGE_TYPE: SetConfigMessage,

--- a/python/tests/test_data_loader.py
+++ b/python/tests/test_data_loader.py
@@ -379,9 +379,21 @@ class TestTimeConversion:
     def test_utc_to_p1(self, data_path):
         self._generate_data(data_path=str(data_path))
         loader = DataLoader(path=str(data_path))
+
         utc_time = datetime.fromtimestamp(Y2K_POSIX_SEC + 53.7, tz=timezone.utc)
         assert loader.convert_to_p1_time(utc_time) == pytest.approx(53.7)
         assert loader.convert_to_p1_time(utc_time.timestamp(), assume_utc=True) == pytest.approx(53.7)
+
+        utc_time_no_tz = utc_time.replace(tzinfo=None)
+        assert loader.convert_to_p1_time(utc_time_no_tz, assume_utc=True) == pytest.approx(53.7)
+
+        current_tz = datetime.utcnow().astimezone().tzinfo
+        if current_tz != timezone.utc:
+            utc_time_no_tz = utc_time.replace(tzinfo=None)
+            assert loader.convert_to_p1_time(utc_time_no_tz, assume_utc=False) != pytest.approx(53.7)
+
+        local_time = datetime.fromtimestamp(Y2K_POSIX_SEC + 53.7, tz=None)
+        assert loader.convert_to_p1_time(local_time) == pytest.approx(53.7)
 
     def test_timestamp_to_p1(self, data_path):
         self._generate_data(data_path=str(data_path))


### PR DESCRIPTION
# Fixes
- Apply `assume_utc` to both `float` values and `datetime` objects where no timezone is specified (`tzinfo`)
- Added `ShutdownRequest` to message type dictionary