### PR TITLE
Try to print the candidate header/payload in `binary_message_decode.py` example.

### DIFF
--- a/python/examples/binary_message_decode.py
+++ b/python/examples/binary_message_decode.py
@@ -54,7 +54,8 @@ Payload: Reset Request [mask=0x01000fff]
     logger = logging.getLogger('point_one.fusion_engine')
 
     # Concatenate all hex characters and convert to bytes.
-    contents_str = ''.join(options.contents).replace(' ', '')
+    byte_str_array = [b if len(b) == 2 else f'0{b}' for b in options.contents]
+    contents_str = ''.join(byte_str_array).replace(' ', '')
     if len(contents_str) % 2 != 0:
         logger.error("Error: Contents must contain an even number of hex characters.")
         sys.exit(1)

--- a/python/examples/binary_message_decode.py
+++ b/python/examples/binary_message_decode.py
@@ -8,7 +8,7 @@ import sys
 root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, root_dir)
 
-from fusion_engine_client.messages.core import MessageHeader, MessagePayload
+from fusion_engine_client.messages import MessageHeader, MessagePayload, message_type_to_class
 from fusion_engine_client.parsers import FusionEngineDecoder
 from fusion_engine_client.utils import trace as logging
 from fusion_engine_client.utils.argument_parser import ArgumentParser
@@ -86,6 +86,14 @@ Payload: Reset Request [mask=0x01000fff]
                     logger.warning('Warning: Specified byte string too small. [expected=%d B, got=%d B]' %
                                    (header.get_message_size(), len(contents)))
                     logger.warning("Header: " + str(header))
+
+                    payload = message_type_to_class.get(header.message_type, None)
+                    if payload is None:
+                        logger.warning("Unrecognized message type %s." % str(header.message_type))
+                    else:
+                        logger.warning("Minimum size for this message:")
+                        logger.warning("  Payload: %d B" % payload().calcsize())
+                        logger.warning("  Complete message: %d B" % (MessageHeader.calcsize() + payload().calcsize()))
             except ValueError as e:
                 logger.warning("No valid FusionEngine messages decoded.")
 


### PR DESCRIPTION
# Changes
- Print the payload size and contents if possible when decode fails

# Fixes
- Fixed handling of single-char user byte input (`2E A` vs `2E 0A`)