### PR TITLE
Fixed truncation of non-time-dependent data, and other cleanup.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -1152,8 +1152,7 @@ class ImportDataMessage(MessagePayload):
         string = f'Import Data Command ({str(self.data_type)}, {len(self.data)} B)\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')
-            val = val.replace('  ', '\t')
-            string += f'\t{field}: {val}\n'
+            string += f'  {field}: {val}\n'
         return string.rstrip()
 
     def calcsize(self) -> int:
@@ -1192,8 +1191,7 @@ class ExportDataMessage(MessagePayload):
         string = f'Export data command ({str(self.data_type)})\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')
-            val = val.replace('  ', '\t')
-            string += f'\t{field}: {val}\n'
+            string += f'  {field}: {val}\n'
         return string.rstrip()
 
     @classmethod
@@ -1241,8 +1239,7 @@ class PlatformStorageDataMessage(MessagePayload):
         string = f'Platform Storage Data ({str(self.data_type)}, {len(self.data)} B)\n'
         for field in fields:
             val = str(self.__dict__[field]).replace('Container:', '')
-            val = val.replace('  ', '\t')
-            string += f'\t{field}: {val}\n'
+            string += f'  {field}: {val}\n'
         return string.rstrip()
 
     def calcsize(self) -> int:

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -437,7 +437,10 @@ class EventNotificationMessage(MessagePayload):
         fields = ['action', 'event_flags', 'event_description']
         string = f'Event Notification @ %s\n' % system_time_to_str(self.system_time_ns)
         for field in fields:
-            val = str(self.__dict__[field]).replace('Container:', '')
+            if field == 'event_flags':
+                val = '0x%016X' % self.__dict__[field]
+            else:
+                val = str(self.__dict__[field]).replace('Container:', '')
             string += f'  {field}: {val}\n'
         return string.rstrip()
 

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -437,7 +437,9 @@ class EventNotificationMessage(MessagePayload):
         fields = ['action', 'event_flags', 'event_description']
         string = f'Event Notification @ %s\n' % system_time_to_str(self.system_time_ns)
         for field in fields:
-            if field == 'event_flags':
+            if field == 'action':
+                val = EventNotificationMessage.Action(self.__dict__[field]).to_string(include_value=True)
+            elif field == 'event_flags':
                 val = '0x%016X' % self.__dict__[field]
             else:
                 val = str(self.__dict__[field]).replace('Container:', '')

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -686,6 +686,12 @@ class CalibrationStatus(MessagePayload):
                 messages = messages[idx:]
 
         result = {
+            '__metadata__': {
+              'not_time_dependent': [
+                  'min_travel_distance_m',
+                  'mounting_angle_max_std_dev_deg',
+              ],
+            },
             'p1_time': np.array([float(m.p1_time) for m in messages]),
             'calibration_stage': np.array([int(m.calibration_stage) for m in messages], dtype=int),
             'ypr_deg': np.array([m.ypr_deg for m in messages]).T,


### PR DESCRIPTION
# Changes
- Added more detail to event notification printouts
- Made tabs vs spaces consistent in message `str()` operators

# Fixes
- Fixed truncation of non-time-dependent data (e.g., thresholds) if the size of the data happens to match the number of time elements