### PR TITLE
Fixed binary decode example app and event description packing.

### DIFF
--- a/python/examples/binary_message_decode.py
+++ b/python/examples/binary_message_decode.py
@@ -107,10 +107,12 @@ Payload: Reset Request [mask=0x01000fff]
                             payload.unpack(buffer=contents, offset=header.calcsize())
                             logger.info("Decoded payload contents: %s" % str(payload))
                         except ValueError as e:
+                            logger.warning(str(e))
                             logger.warning("Unable to decode payload contents.")
                     else:
                         logger.warning("Not enough data to decode payload.")
             except ValueError as e:
+                logger.warning(str(e))
                 logger.warning("No valid FusionEngine messages decoded.")
 
         sys.exit(2)

--- a/python/examples/binary_message_decode.py
+++ b/python/examples/binary_message_decode.py
@@ -54,7 +54,7 @@ Payload: Reset Request [mask=0x01000fff]
     logger = logging.getLogger('point_one.fusion_engine')
 
     # Concatenate all hex characters and convert to bytes.
-    byte_str_array = [b if len(b) == 2 else f'0{b}' for b in options.contents]
+    byte_str_array = [b if len(b) % 2 == 0 else f'0{b}' for b in options.contents]
     contents_str = ''.join(byte_str_array).replace(' ', '')
     if len(contents_str) % 2 != 0:
         logger.error("Error: Contents must contain an even number of hex characters.")

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -422,6 +422,8 @@ class EventNotificationMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         values = dict(self.__dict__)
         values['event_description_len_bytes'] = len(self.event_description)
+        if isinstance(self.event_description, str):
+            values['event_description'] = self.event_description.encode('utf-8')
         packed_data = self.EventNotificationConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -219,4 +219,12 @@ fi
 
 # Tag the updated git commit.
 echo "Tagging commit ${COMMIT} as '${TAG}'."
-git tag -a ${TAG} ${COMMIT}
+cat <<EOF | git tag -a ${TAG} ${COMMIT} --edit -F -
+Release version ${VERSION}.
+
+New Features
+
+Changes
+
+Fixes
+EOF


### PR DESCRIPTION
# Changes
- Added a git message template for release tagging script

# Fixes
- Fixed `binary_message_decode.py` example if user string has bytes packed together (2e31 vs 2e 31)
- Fixed event notification packing if description is `str` and not `bytes`