### PR TITLE
Added command/response logging support to `EventNotificationMessage`.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1577,20 +1577,20 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             return
 
         # Read the data.
-        result = self.reader.read(message_types=[EventNotificationMessage], remove_nan_times=False, **self.params)
-        data = result[EventNotificationMessage.MESSAGE_TYPE]
+        messages = self.reader.read(message_types=[EventNotificationMessage], remove_nan_times=False,
+                                    return_in_order=True, **self.params)
 
-        if len(data.messages) == 0:
+        if len(messages) == 0:
             self.logger.info('No event notification data available.')
             return
 
         table_columns = ['Relative Time (s)', 'System Time (s)', 'Event', 'Flags', 'Description']
         table_data = [[], [], [], [], []]
-        table_data[0] = [f'{(m.system_time_ns - self.reader.get_system_t0_ns()) / 1e9:.3f}' for m in data.messages]
-        table_data[1] = [f'{(m.system_time_ns) / 1e9:.3f}' for m in data.messages]
-        table_data[2] = [str(m.action) for m in data.messages]
-        table_data[3] = [f'0x{m.event_flags:016X}' for m in data.messages]
-        table_data[4] = [m.event_description.decode('utf-8') for m in data.messages]
+        table_data[0] = [f'{(m.system_time_ns - self.reader.get_system_t0_ns()) / 1e9:.3f}' for m in messages]
+        table_data[1] = [f'{(m.system_time_ns) / 1e9:.3f}' for m in messages]
+        table_data[2] = [str(m.action) for m in messages]
+        table_data[3] = [f'0x{m.event_flags:016X}' for m in messages]
+        table_data[4] = [m.event_description.decode('utf-8') for m in messages]
 
         table_html = _data_to_table(table_columns, table_data)
         body_html = f"""\

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1588,7 +1588,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
         table_data = [[], [], [], [], []]
         table_data[0] = [f'{(m.system_time_ns - self.reader.get_system_t0_ns()) / 1e9:.3f}' for m in messages]
         table_data[1] = [f'{(m.system_time_ns) / 1e9:.3f}' for m in messages]
-        table_data[2] = [str(m.action) for m in messages]
+        table_data[2] = [str(m.event_type) for m in messages]
         table_data[3] = [f'0x{m.event_flags:016X}' for m in messages]
         table_data[4] = [m.event_description.decode('utf-8') for m in messages]
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -55,7 +55,11 @@ def _data_to_table(col_titles: List[str], values: List[List[Any]], row_major: bo
     else:
         col_values = values
 
-    table_html = '<table><tr style="background-color: #a2c4fa">'
+    table_html = '''\
+<table>
+  <tbody style="vertical-align: top">
+    <tr style="background-color: #a2c4fa">
+'''
     for title in col_titles:
         table_html += f'<th>{title}</th>'
     table_html += '</tr>'
@@ -71,7 +75,10 @@ def _data_to_table(col_titles: List[str], values: List[List[Any]], row_major: bo
                 table_html += f'<td>{col_data[row_idx]}</td>'
 
         table_html += '</tr>'
-    table_html += '</table>'
+    table_html += '''\
+  </tbody>
+</table>
+'''
     return table_html
 
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1577,20 +1577,21 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             return
 
         # Read the data.
-        messages = self.reader.read(message_types=[EventNotificationMessage], remove_nan_times=False,
-                                    return_in_order=True, **self.params)
+        result = self.reader.read(message_types=[EventNotificationMessage],
+                                  remove_nan_times=False, return_in_order=True, **self.params)
+        data = result[None]  # In-order reads return data with the key None.
 
-        if len(messages) == 0:
+        if len(data.messages) == 0:
             self.logger.info('No event notification data available.')
             return
 
         table_columns = ['Relative Time (s)', 'System Time (s)', 'Event', 'Flags', 'Description']
         table_data = [[], [], [], [], []]
-        table_data[0] = [f'{(m.system_time_ns - self.reader.get_system_t0_ns()) / 1e9:.3f}' for m in messages]
-        table_data[1] = [f'{(m.system_time_ns) / 1e9:.3f}' for m in messages]
-        table_data[2] = [str(m.event_type) for m in messages]
-        table_data[3] = [f'0x{m.event_flags:016X}' for m in messages]
-        table_data[4] = [m.event_description.decode('utf-8') for m in messages]
+        table_data[0] = [f'{(m.system_time_ns - self.reader.get_system_t0_ns()) / 1e9:.3f}' for m in data.messages]
+        table_data[1] = [f'{(m.system_time_ns) / 1e9:.3f}' for m in data.messages]
+        table_data[2] = [str(m.event_type) for m in data.messages]
+        table_data[3] = [f'0x{m.event_flags:016X}' for m in data.messages]
+        table_data[4] = [m.event_description.decode('utf-8') for m in data.messages]
 
         table_html = _data_to_table(table_columns, table_data)
         body_html = f"""\

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1622,7 +1622,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
                 f'{system_time_ns / 1e9:.3f}' if system_time_ns is not None else 'N/A',
                 event_type.to_string(include_value=True),
                 f'0x{flags:016X}' if flags is not None else 'N/A',
-                description_str,
+                description_str.replace('\n', '<br>'),
             ])
 
         table_html = _data_to_table(table_columns, rows, row_major=True)

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -218,7 +218,7 @@ class DataLoader(object):
                 self.data[MessageType.POSE] = prev_data
 
     def read(self, *args, **kwargs) \
-            -> Dict[MessageType, MessageData]:
+            -> Dict[Optional[MessageType], MessageData]:
         """!
         @brief Read data for one or more desired message types.
 
@@ -262,10 +262,10 @@ class DataLoader(object):
         @param aligned_message_types A list of message types for which time alignment will be performed. Any message
                types not present in the list will be left unmodified. If `None`, all message types will be aligned.
 
-        @return - `return_in_order == False`: A `dict`, keyed by @ref fusion_engine_client.messages.defs.MessageType
-                  "MessageType", containing @ref MessageData objects with the data read for each of the requested
-                  message types.
-                - `return_in_order == True`: A `list` containing each message in the order in which it was received.
+        @return - A `dict`, keyed by @ref fusion_engine_client.messages.defs.MessageType "MessageType", containing @ref
+                  MessageData objects with the data read for each of the requested message types. If
+                  `return_in_order == True`, the returned `dict` will contain a single entry with the key set to `None`.
+                  It will contain all message types in the order that they were recorded.
         """
         return self._read(*args, **kwargs)
 
@@ -524,10 +524,6 @@ class DataLoader(object):
                     data_cache[None].messages.append(entry[1])
                 else:
                     data_cache[entry[0].message_type].messages.append(entry[1])
-
-        # If returning data in-order, pull out the messages list.
-        if return_in_order:
-            result = data_cache[None].messages
 
         # Time-align the data if requested.
         if time_align != TimeAlignmentMode.NONE:

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -302,6 +302,7 @@ class DataLoader(object):
             'max_messages': max_messages,
             'require_p1_time': require_p1_time,
             'require_system_time': require_system_time,
+            'remove_nan_times': remove_nan_times,
         }
 
         # If the user requested output in the order that it was logged, we need to ignore cached data since that data

--- a/python/fusion_engine_client/messages/__init__.py
+++ b/python/fusion_engine_client/messages/__init__.py
@@ -2,53 +2,7 @@ from .core import *
 from .fault_control import *
 from . import ros
 
-message_type_to_class = {
-    # Navigation solution messages.
-    PoseMessage.MESSAGE_TYPE: PoseMessage,
-    PoseAuxMessage.MESSAGE_TYPE: PoseAuxMessage,
-    GNSSInfoMessage.MESSAGE_TYPE: GNSSInfoMessage,
-    GNSSSatelliteMessage.MESSAGE_TYPE: GNSSSatelliteMessage,
-    CalibrationStatus.MESSAGE_TYPE: CalibrationStatus,
-    RelativeENUPositionMessage.MESSAGE_TYPE: RelativeENUPositionMessage,
-
-    # Sensor measurement messages.
-    IMUMeasurement.MESSAGE_TYPE: IMUMeasurement,
-    HeadingMeasurement.MESSAGE_TYPE: HeadingMeasurement,
-
-    # Vehicle measurement messages.
-    WheelSpeedMeasurement.MESSAGE_TYPE: WheelSpeedMeasurement,
-    VehicleSpeedMeasurement.MESSAGE_TYPE: VehicleSpeedMeasurement,
-    WheelTickMeasurement.MESSAGE_TYPE: WheelTickMeasurement,
-    VehicleTickMeasurement.MESSAGE_TYPE: VehicleTickMeasurement,
-
-    # ROS messages.
-    ros.ROSPoseMessage.MESSAGE_TYPE: ros.ROSPoseMessage,
-    ros.ROSGPSFixMessage.MESSAGE_TYPE: ros.ROSGPSFixMessage,
-    ros.ROSIMUMessage.MESSAGE_TYPE: ros.ROSIMUMessage,
-
-    # Command and control messages.
-    CommandResponseMessage.MESSAGE_TYPE: CommandResponseMessage,
-    MessageRequest.MESSAGE_TYPE: MessageRequest,
-    ResetRequest.MESSAGE_TYPE: ResetRequest,
-    VersionInfoMessage.MESSAGE_TYPE: VersionInfoMessage,
-    EventNotificationMessage.MESSAGE_TYPE: EventNotificationMessage,
-    ShutdownRequest.MESSAGE_TYPE: ShutdownRequest,
-    FaultControlMessage.MESSAGE_TYPE: FaultControlMessage,
-
-    SetConfigMessage.MESSAGE_TYPE: SetConfigMessage,
-    GetConfigMessage.MESSAGE_TYPE: GetConfigMessage,
-    SaveConfigMessage.MESSAGE_TYPE: SaveConfigMessage,
-    ConfigResponseMessage.MESSAGE_TYPE: ConfigResponseMessage,
-
-    ExportDataMessage.MESSAGE_TYPE: ExportDataMessage,
-    ImportDataMessage.MESSAGE_TYPE: ImportDataMessage,
-    PlatformStorageDataMessage.MESSAGE_TYPE: PlatformStorageDataMessage,
-
-    SetMessageRate.MESSAGE_TYPE: SetMessageRate,
-    GetMessageRate.MESSAGE_TYPE: GetMessageRate,
-    MessageRateResponse.MESSAGE_TYPE: MessageRateResponse,
-}
+message_type_to_class = MessagePayload.message_type_to_class
+message_type_by_name = MessagePayload.message_type_by_name
 
 messages_with_system_time = [t for t, c in message_type_to_class.items() if hasattr(c(), 'system_time_ns')]
-
-message_type_by_name = {c.__name__: t for t, c in message_type_to_class.items()}

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -711,6 +711,11 @@ class SetConfigMessage(MessagePayload):
         self.flags = parsed.flags
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', flags=0x{self.flags:02X}, type={self.config_object.GetType()}]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(
             message=self, construct=self.SetConfigMessageConstruct,
@@ -754,6 +759,11 @@ class GetConfigMessage(MessagePayload):
         self.__dict__.update(parsed)
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', source={self.request_source}, type={self.config_type}]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(
             message=self, construct=self.GetConfigMessageConstruct,
@@ -794,6 +804,11 @@ class SaveConfigMessage(MessagePayload):
         parsed = self.SaveConfigMessageConstruct.parse(buffer[offset:])
         self.action = parsed.action
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', action={self.action}]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(message=self, construct=self.SaveConfigMessageConstruct,
@@ -852,6 +867,11 @@ class ConfigResponseMessage(MessagePayload):
         self.__dict__.update(parsed)
         self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].parse(parsed.config_data)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', response={self.response}, source={self.config_source}, type={self.config_object.GetType()}]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(
@@ -932,6 +952,12 @@ class SetMessageRate(MessagePayload):
         self.__dict__.update(parsed)
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', interface={self.output_interface}, flags=0x{self.flags:02X}, protocol={self.protocol}, ' \
+                  f'message_id={self.message_id}, rate={self.rate}]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(
             message=self, construct=self.SetMessageRateConstruct,
@@ -984,6 +1010,12 @@ class GetMessageRate(MessagePayload):
         parsed = self.GetMessageRateConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', interface={self.output_interface}, source={self.source}, protocol={self.protocol}, ' \
+                  f'message_id={self.message_id}]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(
@@ -1060,6 +1092,12 @@ class MessageRateResponse(MessagePayload):
         self.__dict__.update(parsed)
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', response={self.response}, interface={self.output_interface}, source={self.source}, ' \
+                  f'protocol={self.protocol}]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(
             message=self, construct=self.MessageRateResponseConstruct,
@@ -1130,6 +1168,12 @@ class ImportDataMessage(MessagePayload):
         self.__dict__.update(parsed)
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', type={self.data_type}, source={self.source}, version={self.data_version}, ' \
+                  f'size={len(self.data)} B]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(
             message=self, construct=self.ImportDataMessageConstruct,
@@ -1166,6 +1210,11 @@ class ExportDataMessage(MessagePayload):
         parsed = self.ExportDataMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', type={self.data_type}, source={self.source}]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(
@@ -1212,6 +1261,12 @@ class PlatformStorageDataMessage(MessagePayload):
         parsed = self.PlatformStorageDataMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', response={self.response}, type={self.data_type}, source={self.source}, ' \
+                  f'version={self.data_version}, size={len(self.data)} B]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -52,6 +52,11 @@ class CommandResponseMessage(MessagePayload):
     def calcsize(cls) -> int:
         return cls._STRUCT.size
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', response={self.response}, seq_num={self.source_sequence_num}]'
+        return result
+
     def __str__(self):
         string = f'Command Response\n'
         string += f'  Sequence #: {self.source_sequence_num}\n'
@@ -99,7 +104,9 @@ class MessageRequest(MessagePayload):
         return offset - initial_offset
 
     def __repr__(self):
-        return '%s' % self.MESSAGE_TYPE.name
+        result = super().__repr__()[:-1]
+        result += f', message_type={self.message_type}]'
+        return result
 
     def __str__(self):
         return 'Transmission request for message %s.' % MessageType.get_type_string(self.message_type)
@@ -334,6 +341,11 @@ class ResetRequest(MessagePayload):
     def calcsize(cls) -> int:
         return cls._STRUCT.size
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', mask=0x{self.reset_mask:08X}]'
+        return result
+
     def __str__(self):
         return 'Reset Request [mask=0x%08x]' % self.reset_mask
 
@@ -378,6 +390,12 @@ class VersionInfoMessage(MessagePayload):
         parsed = self.VersionInfoMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', fw={self.fw_version_str}, engine={self.engine_version_str}, hw={self.hw_version_str} ' \
+                  f'rx={self.rx_version_str}]'
+        return result
 
     def __str__(self):
         string = f'Version Info @ %s\n' % system_time_to_str(self.system_time_ns)
@@ -447,7 +465,14 @@ class EventNotificationMessage(MessagePayload):
         return parsed._io.tell()
 
     def __repr__(self):
-        return '%s @ %s' % (self.MESSAGE_TYPE.name, system_time_to_str(self.system_time_ns))
+        result = super().__repr__()[:-1]
+        result += f', type={self.event_type}, flags=0x{self.event_flags:X}'
+        if self.event_type == EventType.COMMAND or self.event_type == EventType.COMMAND_RESPONSE:
+            result += f', data={len(self.event_description)} B'
+        else:
+            result += f', description={self.event_description}'
+        result += ']'
+        return result
 
     def __str__(self):
         return construct_message_to_string(
@@ -506,6 +531,11 @@ class ShutdownRequest(MessagePayload):
         parsed = self.ShutdownRequestConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', flags=0x{self.shutdown_flags:016X}]'
+        return result
 
     def __str__(self):
         return 'Shutdown Request [flags=0x%016x]' % self.shutdown_flags

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -391,6 +391,14 @@ class VersionInfoMessage(MessagePayload):
         return len(self.pack())
 
 
+class EventType(IntEnum):
+    LOG = 0
+    RESET = 1
+    CONFIG_CHANGE = 2
+    COMMAND = 3
+    COMMAND_RESPONSE = 4
+
+
 class EventNotificationMessage(MessagePayload):
     """!
     @brief Notification of a system event for logging purposes.
@@ -398,15 +406,8 @@ class EventNotificationMessage(MessagePayload):
     MESSAGE_TYPE = MessageType.EVENT_NOTIFICATION
     MESSAGE_VERSION = 0
 
-    class Action(IntEnum):
-        LOG = 0
-        RESET = 1
-        CONFIG_CHANGE = 2
-        COMMAND = 3
-        COMMAND_RESPONSE = 4
-
     EventNotificationConstruct = Struct(
-        "action" / AutoEnum(Int8ul, Action),
+        "event_type" / AutoEnum(Int8ul, EventType),
         Padding(3),
         "system_time_ns" / Int64ul,
         "event_flags" / Int64ul,
@@ -416,7 +417,7 @@ class EventNotificationMessage(MessagePayload):
     )
 
     def __init__(self):
-        self.action = self.Action.LOG
+        self.event_type = EventType.LOG
         self.system_time_ns = 0
         self.event_flags = 0
         self.event_description = bytes()
@@ -441,7 +442,7 @@ class EventNotificationMessage(MessagePayload):
         return construct_message_to_string(
             message=self, construct=self.EventNotificationConstruct,
             title=f'Event Notification @ %s' % system_time_to_str(self.system_time_ns),
-            fields=['action', 'event_flags', 'event_description'],
+            fields=['event_type', 'event_flags', 'event_description'],
             value_to_string={'event_flags': lambda x: '0x%016X' % x})
 
     def calcsize(self) -> int:

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -402,6 +402,8 @@ class EventNotificationMessage(MessagePayload):
         LOG = 0
         RESET = 1
         CONFIG_CHANGE = 2
+        COMMAND = 3
+        COMMAND_RESPONSE = 4
 
     EventNotificationConstruct = Struct(
         "action" / AutoEnum(Int8ul, Action),

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -299,7 +299,7 @@ class MessageHeader:
             if warn_on_unrecognized:
                 _logger.log(logging.WARNING if message_type_int < int(MessageType.RESERVED) else logging.DEBUG,
                             'Unrecognized message type %d.' % message_type_int)
-            self.message_type = message_type_int
+            self.message_type = MessageType(message_type_int, raise_on_unrecognized=False)
 
         return MessageHeader._SIZE
 

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import inspect
 import math
 import struct
-from typing import Union
+from typing import Dict, Type, Union
 from zlib import crc32
 
 import numpy as np
@@ -338,8 +340,19 @@ class MessagePayload:
     @brief Message payload API.
     """
 
+    message_type_to_class: Dict[MessageType, Type[MessagePayload]] = {}
+    message_type_by_name: Dict[str, MessageType] = {}
+
     def __init__(self):
         pass
+
+    def __init_subclass__(cls, **kwargs):
+        MessagePayload.message_type_to_class[cls.get_type()] = cls
+        MessagePayload.message_type_by_name[cls.__name__] = cls.get_type()
+
+    @classmethod
+    def get_message_class(cls, message_type: MessageType) -> Type[MessagePayload]:
+        return MessagePayload.message_type_to_class.get(message_type, None)
 
     @classmethod
     def get_type(cls) -> MessageType:

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -267,7 +267,7 @@ class MessageHeader:
             return self.calcsize()
 
     def unpack(self, buffer: bytes, offset: int = 0, validate_crc: bool = False,
-               warn_on_unrecognized: bool = True) -> int:
+               warn_on_unrecognized: bool = True, ignore_sync: bool = False) -> int:
         """!
         @brief Deserialize a message header and validate its sync bytes and CRC.
 
@@ -286,7 +286,7 @@ class MessageHeader:
          self.sequence_number, self.payload_size_bytes, self.source_identifier) = \
             struct.unpack_from(MessageHeader._FORMAT, buffer, offset)
 
-        if sync0 != MessageHeader._SYNC0 or sync1 != MessageHeader._SYNC1:
+        if (sync0 != MessageHeader._SYNC0 or sync1 != MessageHeader._SYNC1) and not ignore_sync:
             raise ValueError('Received invalid sync bytes. [sync0=0x%02x, sync1=0x%02x]' % (sync0, sync1))
 
         # Validate the CRC, assuming the message payload follows in the buffer.

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -432,10 +432,19 @@ class MessagePayload:
             return system_time_ns * 1e-9
 
     def __repr__(self):
-        try:
-            return '%s message' % MessageType.get_type_string(self.get_type())
-        except NotImplementedError:
-            return 'Unknown message payload.'
+        result = f'[{self.get_type().to_string(include_value=True)}'
+
+        p1_time = self.get_p1_time()
+        if p1_time is not None:
+            result += f', p1_time={float(p1_time):.3f} sec'
+
+        system_time_sec = self.get_system_time_sec()
+        if system_time_sec is not None:
+            result += f', system_time={system_time_sec:.3f} sec'
+
+        result += ']'
+
+        return result
 
     def __str__(self):
         return repr(self)

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -142,6 +142,36 @@ class MessageType(IntEnum):
                 return string_name
 
 
+COMMAND_MESSAGES = {
+    MessageType.MESSAGE_REQUEST,
+    MessageType.RESET_REQUEST,
+    MessageType.SHUTDOWN_REQUEST,
+    MessageType.FAULT_CONTROL,
+    MessageType.SET_CONFIG,
+    MessageType.GET_CONFIG,
+    MessageType.SAVE_CONFIG,
+    MessageType.IMPORT_DATA,
+    MessageType.EXPORT_DATA,
+    MessageType.SET_MESSAGE_RATE,
+    MessageType.GET_MESSAGE_RATE,
+}
+
+
+def is_command(message_type: MessageType) -> bool:
+    return message_type in COMMAND_MESSAGES
+
+
+RESPONSE_MESSAGES = {
+    MessageType.COMMAND_RESPONSE,
+    MessageType.CONFIG_RESPONSE,
+    MessageType.MESSAGE_RATE_RESPONSE,
+}
+
+
+def is_response(message_type: MessageType) -> bool:
+    return message_type in RESPONSE_MESSAGES
+
+
 class MessageHeader:
     INVALID_SOURCE_ID = 0xFFFFFFFF
 

--- a/python/fusion_engine_client/messages/fault_control.py
+++ b/python/fusion_engine_client/messages/fault_control.py
@@ -186,6 +186,11 @@ class FaultControlMessage(MessagePayload):
         self.payload = _class_gen.TYPE_MAP[parsed.fault_type].parse(parsed.payload)
         return parsed._io.tell()
 
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', fault_type={self.payload.GetType() if self.payload is not None else "None"}]'
+        return result
+
     def __str__(self):
         return construct_message_to_string(message=self, title='Fault Control Command')
 

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -106,6 +106,12 @@ class PoseMessage(MessagePayload):
         return offset - initial_offset
 
     def __repr__(self):
+        result = super().__repr__()[:-1]
+        lla_str = '(%.6f, %.6f, %.3f)' % tuple(self.lla_deg)
+        result += f', solution_type={self.solution_type}, position={lla_str}]'
+        return result
+
+    def __repr__(self):
         return '%s @ %s' % (self.MESSAGE_TYPE.name, self.p1_time)
 
     def __str__(self):
@@ -205,9 +211,6 @@ class PoseAuxMessage(MessagePayload):
 
         return offset - initial_offset
 
-    def __repr__(self):
-        return '%s @ %s' % (self.MESSAGE_TYPE.name, self.p1_time)
-
     def __str__(self):
         return 'Pose Aux Message @ %s' % str(self.p1_time)
 
@@ -293,9 +296,6 @@ class GNSSInfoMessage(MessagePayload):
         offset += self._STRUCT.size
 
         return offset - initial_offset
-
-    def __repr__(self):
-        return '%s @ %s' % (self.MESSAGE_TYPE.name, self.p1_time)
 
     def __str__(self):
         string = 'GNSS Info Message @ %s\n' % str(self.p1_time)
@@ -428,7 +428,9 @@ class GNSSSatelliteMessage(MessagePayload):
         return offset - initial_offset
 
     def __repr__(self):
-        return '%s @ %s [%d SVs]' % (self.MESSAGE_TYPE.name, self.p1_time, len(self.svs))
+        result = super().__repr__()[:-1]
+        result += f', num_svs={len(self.svs)}]'
+        return result
 
     def __str__(self):
         string = 'GNSS Satellite Message @ %s\n' % str(self.p1_time)
@@ -648,9 +650,9 @@ class CalibrationStatus(MessagePayload):
         return offset - initial_offset
 
     def __repr__(self):
-        return '%s @ %s [stage=%s, mounting_angle=%.1f%%]' % (self.MESSAGE_TYPE.name, self.p1_time,
-                                                              str(self.calibration_stage),
-                                                              self.mounting_angle_percent_complete)
+        result = super().__repr__()[:-1]
+        result += f', stage={self.calibration_stage}, mounting_angle={self.mounting_angle_percent_complete:.1f}%]'
+        return result
 
     def __str__(self):
         string = 'Calibration Status Message @ %s\n' % str(self.p1_time)
@@ -764,6 +766,11 @@ class RelativeENUPositionMessage(MessagePayload):
         parsed = self.Construct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
+
+    def __repr__(self):
+        result = super().__repr__()[:-1]
+        result += f', solution_type={self.solution_type}]'
+        return result
 
     def __str__(self):
         return construct_message_to_string(

--- a/python/fusion_engine_client/utils/construct_utils.py
+++ b/python/fusion_engine_client/utils/construct_utils.py
@@ -221,8 +221,9 @@ def construct_message_to_string(message: object, construct: Optional[Struct] = N
                     value_to_string[subcon.name] = to_string
 
     string = f'{title}\n'
+    newline = '\n'
     for field in fields:
         value = message.__dict__[field]
         to_string_func = value_to_string.get(field, _generic_value_to_string)
-        string += f'  {field}: {to_string_func(value)}\n'
+        string += f'  {field}: {to_string_func(value).replace(newline, newline + "    ")}\n'
     return string.rstrip()

--- a/src/point_one/fusion_engine/common/portability.h
+++ b/src/point_one/fusion_engine/common/portability.h
@@ -44,3 +44,17 @@ typedef int64_t p1_ssize_t;
 #  include <sys/types.h> // For ssize_t
 typedef ssize_t p1_ssize_t;
 #endif
+
+// Support for multi-statement constexpr functions was not added until C++14.
+// When compiling with C++11, we'll simply use inline instead.
+#ifndef P1_HAVE_MULTILINE_CONSTEXPR_FUNC
+#  define P1_HAVE_MULTILINE_CONSTEXPR_FUNC (__cplusplus >= 201402L)
+#endif
+
+#ifndef P1_CONSTEXPR_FUNC
+#  if P1_HAVE_MULTILINE_CONSTEXPR_FUNC
+#    define P1_CONSTEXPR_FUNC constexpr
+#  else
+#    define P1_CONSTEXPR_FUNC inline
+#  endif
+#endif

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -16,6 +16,7 @@
 
 #include <ostream>
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/data_version.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
@@ -158,7 +159,7 @@ enum class ConfigType : uint16_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(ConfigType type) {
+P1_CONSTEXPR_FUNC const char* to_string(ConfigType type) {
   switch (type) {
     case ConfigType::INVALID:
       return "Invalid";
@@ -231,7 +232,7 @@ enum class ConfigurationSource : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(ConfigurationSource source) {
+P1_CONSTEXPR_FUNC const char* to_string(ConfigurationSource source) {
   switch (source) {
     case ConfigurationSource::ACTIVE:
       return "Active";
@@ -275,7 +276,7 @@ enum class SaveAction : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(SaveAction action) {
+P1_CONSTEXPR_FUNC const char* to_string(SaveAction action) {
   switch (action) {
     case SaveAction::SAVE:
       return "Save";
@@ -550,7 +551,7 @@ enum class VehicleModel : uint16_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(VehicleModel vehicle_model) {
+P1_CONSTEXPR_FUNC const char* to_string(VehicleModel vehicle_model) {
   switch (vehicle_model) {
     case VehicleModel::UNKNOWN_VEHICLE:
       return "UNKNOWN";
@@ -652,7 +653,7 @@ enum class WheelSensorType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(WheelSensorType wheel_sensor_type) {
+P1_CONSTEXPR_FUNC const char* to_string(WheelSensorType wheel_sensor_type) {
   switch (wheel_sensor_type) {
     case WheelSensorType::NONE: {
       return "None";
@@ -715,7 +716,7 @@ enum class AppliedSpeedType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(AppliedSpeedType applied_speed_type) {
+P1_CONSTEXPR_FUNC const char* to_string(AppliedSpeedType applied_speed_type) {
   switch (applied_speed_type) {
     case AppliedSpeedType::NONE: {
       return "None";
@@ -770,7 +771,7 @@ enum class SteeringType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(SteeringType steering_type) {
+P1_CONSTEXPR_FUNC const char* to_string(SteeringType steering_type) {
   switch (steering_type) {
     case SteeringType::UNKNOWN: {
       return "Unknown Steering";
@@ -908,7 +909,7 @@ enum class TickMode : uint8_t {
   FALLING_EDGE = 2,
 };
 
-inline const char* to_string(TickMode tick_mode) {
+P1_CONSTEXPR_FUNC const char* to_string(TickMode tick_mode) {
   switch (tick_mode) {
     case TickMode::OFF:
       return "OFF";
@@ -950,7 +951,7 @@ enum class TickDirection : uint8_t {
   FORWARD_ACTIVE_LOW = 2,
 };
 
-inline const char* to_string(TickDirection tick_direction) {
+P1_CONSTEXPR_FUNC const char* to_string(TickDirection tick_direction) {
   switch (tick_direction) {
     case TickDirection::OFF:
       return "OFF";
@@ -1058,7 +1059,7 @@ constexpr uint16_t ALL_MESSAGES_ID = 0xFFFF;
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(ProtocolType val) {
+P1_CONSTEXPR_FUNC const char* to_string(ProtocolType val) {
   switch (val) {
     case ProtocolType::INVALID:
       return "Invalid";
@@ -1113,7 +1114,7 @@ enum class TransportType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(TransportType val) {
+P1_CONSTEXPR_FUNC const char* to_string(TransportType val) {
   switch (val) {
     case TransportType::INVALID:
       return "Invalid";
@@ -1234,7 +1235,7 @@ enum class NmeaMessageType : uint16_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(NmeaMessageType value) {
+P1_CONSTEXPR_FUNC const char* to_string(NmeaMessageType value) {
   switch (value) {
     case NmeaMessageType::INVALID:
       return "INVALID";
@@ -1374,7 +1375,7 @@ enum class MessageRate : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(MessageRate value) {
+P1_CONSTEXPR_FUNC const char* to_string(MessageRate value) {
   switch (value) {
     case MessageRate::OFF:
       return "OFF";
@@ -1675,7 +1676,7 @@ enum class DataType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(DataType type) {
+P1_CONSTEXPR_FUNC const char* to_string(DataType type) {
   switch (type) {
     case DataType::CALIBRATION_STATE:
       return "CalibrationState";

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -14,6 +14,7 @@
 #  pragma warning(disable : 4200)
 #endif
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
 namespace point_one {
@@ -411,7 +412,7 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
     COMMAND_RESPONSE = 4,
   };
 
-  static const char* to_string(EventType type) {
+  static P1_CONSTEXPR_FUNC const char* to_string(EventType type) {
     switch (type) {
       case EventType::LOG:
         return "Log";

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -383,9 +383,32 @@ struct alignas(4) VersionInfoMessage : public MessagePayload {
  */
 struct alignas(4) EventNotificationMessage : public MessagePayload {
   enum class EventType : uint8_t {
+    /**
+     * Event containing a logged message string from the device.
+     */
     LOG = 0,
+    /**
+     * Event indicating a device reset occurred. The event flags will be set to
+     * the requested reset bitmask, if applicable (see @ref ResetRequest). The
+     * payload will contain a string describing the cause of the reset.
+     */
     RESET = 1,
+    /**
+     * Notification that the user configuration has been changed. Intended for
+     * diagnostic purposes.
+     */
     CONFIG_CHANGE = 2,
+    /**
+     * Notification that the user performed a command (e.g., configuration
+     * request, fault injection enable/disable).
+     */
+    COMMAND = 3,
+    /**
+     * Record containing the response to a user command. Response events are not
+     * output on the interface on which the command was received; that interface
+     * will receive the response itself.
+     */
+    COMMAND_RESPONSE = 4,
   };
 
   static const char* to_string(EventType type) {
@@ -398,6 +421,12 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
 
       case EventType::CONFIG_CHANGE:
         return "Config Change";
+
+      case EventType::COMMAND:
+        return "Command";
+
+      case EventType::COMMAND_RESPONSE:
+        return "Command Response";
 
       default:
         return "Unknown";
@@ -426,7 +455,8 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
   /**
    * This is a dummy entry to provide a pointer to this offset.
    *
-   * This is used for populating string describing the event, where applicable.
+   * This is used for populating string describing the event, or other binary
+   * content where applicable.
    */
   char* event_description[0];
 };

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <string>
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/signal_defs.h"
 
 namespace point_one {
@@ -208,6 +209,56 @@ P1_CONSTEXPR_FUNC const char* to_string(MessageType type) {
 inline std::ostream& operator<<(std::ostream& stream, MessageType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
+}
+
+/**
+ * @brief Check if the specified message type is a user command.
+ * @ingroup messages
+ *
+ * See also @ref IsResponse().
+ *
+ * @param message_type The message type in question.
+ *
+ * @return `true` if the message is a FusionEngine command.
+ */
+P1_CONSTEXPR_FUNC bool IsCommand(MessageType message_type) {
+  switch (message_type) {
+    case MessageType::MESSAGE_REQUEST:
+    case MessageType::RESET_REQUEST:
+    case MessageType::SHUTDOWN_REQUEST:
+    case MessageType::FAULT_CONTROL:
+    case MessageType::SET_CONFIG:
+    case MessageType::GET_CONFIG:
+    case MessageType::SAVE_CONFIG:
+    case MessageType::IMPORT_DATA:
+    case MessageType::EXPORT_DATA:
+    case MessageType::SET_MESSAGE_RATE:
+    case MessageType::GET_MESSAGE_RATE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Check if the specified message type is a response to a user command.
+ * @ingroup messages
+ *
+ * See also @ref IsCommand().
+ *
+ * @param message_type The message type in question.
+ *
+ * @return `true` if the message is a FusionEngine command response.
+ */
+P1_CONSTEXPR_FUNC bool IsResponse(MessageType message_type) {
+  switch (message_type) {
+    case MessageType::COMMAND_RESPONSE:
+    case MessageType::CONFIG_RESPONSE:
+    case MessageType::MESSAGE_RATE_RESPONSE:
+      return true;
+    default:
+      return false;
+  }
 }
 
 /** @brief Command response status indicators. */
@@ -453,6 +504,34 @@ struct alignas(4) MessageHeader {
   /** Identifies the source of the serialized data. */
   uint32_t source_identifier = INVALID_SOURCE_ID;
 };
+
+/**
+ * @brief Check if the specified message is a user command.
+ * @ingroup messages
+ *
+ * See @ref IsCommand() for details.
+ *
+ * @param header Header of a received FusionEngine message.
+ *
+ * @return `true` if the message is a FusionEngine command.
+ */
+P1_CONSTEXPR_FUNC bool IsCommand(const MessageHeader& header) {
+  return IsCommand(header.message_type);
+}
+
+/**
+ * @brief Check if the specified message type is a response to a user command.
+ * @ingroup messages
+ *
+ * See @ref IsResponse() for details.
+ *
+ * @param header Header of a received FusionEngine message.
+ *
+ * @return `true` if the message is a FusionEngine command response.
+ */
+P1_CONSTEXPR_FUNC bool IsResponse(const MessageHeader& header) {
+  return IsResponse(header.message_type);
+}
 
 /**
  * @brief The base class for all message payloads.

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -91,7 +91,7 @@ enum class MessageType : uint16_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(MessageType type) {
+P1_CONSTEXPR_FUNC const char* to_string(MessageType type) {
   switch (type) {
     case MessageType::INVALID:
       return "Invalid";
@@ -264,7 +264,7 @@ enum class Response : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(Response val) {
+P1_CONSTEXPR_FUNC const char* to_string(Response val) {
   switch (val) {
     case Response::OK:
       return "Ok";
@@ -338,7 +338,7 @@ enum class SolutionType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(SolutionType type) {
+P1_CONSTEXPR_FUNC const char* to_string(SolutionType type) {
   switch (type) {
     case SolutionType::Invalid:
       return "Invalid";

--- a/src/point_one/fusion_engine/messages/fault_control.h
+++ b/src/point_one/fusion_engine/messages/fault_control.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
 namespace point_one {
@@ -104,7 +105,7 @@ enum class FaultType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(FaultType type) {
+P1_CONSTEXPR_FUNC const char* to_string(FaultType type) {
   switch (type) {
     case FaultType::CLEAR_ALL:
       return "Clear Faults";
@@ -161,7 +162,7 @@ enum class CoComType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(CoComType type) {
+P1_CONSTEXPR_FUNC const char* to_string(CoComType type) {
   switch (type) {
     case CoComType::NONE:
       return "No Limit";

--- a/src/point_one/fusion_engine/messages/measurements.h
+++ b/src/point_one/fusion_engine/messages/measurements.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
 namespace point_one {
@@ -59,7 +60,7 @@ enum class SystemTimeSource : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(SystemTimeSource val) {
+P1_CONSTEXPR_FUNC const char* to_string(SystemTimeSource val) {
   switch (val) {
     case SystemTimeSource::INVALID:
       return "Invalid";
@@ -210,7 +211,7 @@ enum class GearType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(GearType val) {
+P1_CONSTEXPR_FUNC const char* to_string(GearType val) {
   switch (val) {
     case GearType::UNKNOWN:
       return "Unknown";
@@ -491,7 +492,7 @@ struct alignas(4) HeadingMeasurement : public MessagePayload {
   /**
    * The heading angle (in degrees) with respect to true north, pointing from
    * the primary antenna to the secondary antenna.
-   * 
+   *
    * @note
    * Reported in the range [0, 360).
    */

--- a/src/point_one/fusion_engine/messages/signal_defs.h
+++ b/src/point_one/fusion_engine/messages/signal_defs.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <ostream>
 
+#include "point_one/fusion_engine/common/portability.h"
+
 namespace point_one {
 namespace fusion_engine {
 namespace messages {
@@ -46,7 +48,7 @@ enum class SatelliteType : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(SatelliteType type) {
+P1_CONSTEXPR_FUNC const char* to_string(SatelliteType type) {
   switch (type) {
     case SatelliteType::UNKNOWN:
       return "Unknown";
@@ -241,7 +243,7 @@ enum class FrequencyBand : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(FrequencyBand type) {
+P1_CONSTEXPR_FUNC const char* to_string(FrequencyBand type) {
   switch (type) {
     case FrequencyBand::UNKNOWN:
       return "Unknown";

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
 namespace point_one {
@@ -335,7 +336,7 @@ enum class CalibrationStage : uint8_t {
  *
  * @return The corresponding string name.
  */
-inline const char* to_string(CalibrationStage val) {
+P1_CONSTEXPR_FUNC const char* to_string(CalibrationStage val) {
   switch (val) {
     case CalibrationStage::UNKNOWN:
       return "Unknown";


### PR DESCRIPTION
# New Features
- Added new `EventType` enums to capture commands and responses
- Display commands and responses on the `p1_display` events table
- Added `IsCommand()` and `IsResponse()` helper functions
- Added `return_in_order` option to `DataLoader.read()` to return a single list of all message types in the order they were recorded
- Added `return_bytes` option to `DataLoader.read()` to return the original binary header+payload for each message

# Changes
- Made `to_string()` functions `constexpr` where possible (requires C++14; functions set as `inline` for C++11)
- Added consistent `repr()` formatting for all message classes
- Added auto-registration of `MessagePayload` subclasses instead of explicitly managed dict