### PR TITLE
Truncate the byte string displayed for command/response events.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1623,7 +1623,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
                 f'{system_time_ns / 1e9:.3f}' if system_time_ns is not None else 'N/A',
                 event_type.to_string(include_value=True),
                 f'0x{flags:016X}' if flags is not None else 'N/A',
-                description_str.replace('\n', '<br>'),
+                description_str.replace('<', '[').replace('>', ']').replace('\n', '<br>'),
             ])
 
         table_html = _data_to_table(table_columns, rows, row_major=True)

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1600,21 +1600,23 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
         table_columns = ['Relative Time (s)', 'System Time (s)', 'Event', 'Flags', 'Description']
         rows = []
         system_t0_ns = self.reader.get_system_t0_ns()
+        max_bytes = 128
         for message, message_bytes in zip(data.messages, data.messages_bytes):
             system_time_ns = message.get_system_time_ns()
             if isinstance(message, EventNotificationMessage):
                 event_type = message.event_type
                 flags = message.event_flags
-                description_str = message.event_description_to_string()
+                description_str = message.event_description_to_string(max_bytes=max_bytes)
             else:
                 flags = None
                 if message.get_type() in COMMAND_MESSAGES:
                     event_type = EventType.COMMAND
                 else:
                     event_type = EventType.COMMAND_RESPONSE
-                description_str = f'''\
-{repr(message)}
-Data ({len(message_bytes)} B): {" ".join("%02X" % b for b in message_bytes)}'''
+                description_str = "%s\n%s" % \
+                                  (repr(message),
+                                   EventNotificationMessage._populate_data_byte_string(message_bytes,
+                                                                                       max_bytes=max_bytes))
 
             rows.append([
                 f'{(system_time_ns - system_t0_ns) / 1e9:.3f}' if system_time_ns is not None else 'N/A',

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -864,10 +864,16 @@ class ConfigResponseMessage(MessagePayload):
 
     def unpack(self, buffer: bytes, offset: int = 0) -> int:
         parsed = self.ConfigResponseMessageConstruct.parse(buffer[offset:])
+
         self.__dict__.update(parsed)
         del self.__dict__['config_length_bytes']
         del self.__dict__['config_data']
-        self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].parse(parsed.config_data)
+
+        if parsed.config_length_bytes > 0:
+            self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].parse(parsed.config_data)
+        else:
+            self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].make_default()
+
         return parsed._io.tell()
 
     def __repr__(self):

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -1095,7 +1095,7 @@ class MessageRateResponse(MessagePayload):
     def __repr__(self):
         result = super().__repr__()[:-1]
         result += f', response={self.response}, interface={self.output_interface}, source={self.config_source}, ' \
-                  f'protocol={self.protocol}]'
+                  f'protocol={self.protocol}, num_entries={len(self.rates)}]'
         return result
 
     def __str__(self):

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -865,6 +865,8 @@ class ConfigResponseMessage(MessagePayload):
     def unpack(self, buffer: bytes, offset: int = 0) -> int:
         parsed = self.ConfigResponseMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
+        del self.__dict__['config_length_bytes']
+        del self.__dict__['config_data']
         self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].parse(parsed.config_data)
         return parsed._io.tell()
 

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -1013,7 +1013,7 @@ class GetMessageRate(MessagePayload):
 
     def __repr__(self):
         result = super().__repr__()[:-1]
-        result += f', interface={self.output_interface}, source={self.source}, protocol={self.protocol}, ' \
+        result += f', interface={self.output_interface}, source={self.request_source}, protocol={self.protocol}, ' \
                   f'message_id={self.message_id}]'
         return result
 
@@ -1094,7 +1094,7 @@ class MessageRateResponse(MessagePayload):
 
     def __repr__(self):
         result = super().__repr__()[:-1]
-        result += f', response={self.response}, interface={self.output_interface}, source={self.source}, ' \
+        result += f', response={self.response}, interface={self.output_interface}, source={self.config_source}, ' \
                   f'protocol={self.protocol}]'
         return result
 

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -296,7 +296,7 @@ class _ConfigClassGenerator:
         """!
         @brief Integer value specifier.
         """
-        value: int
+        value: int = 0
 
     # Construct to serialize different sized IntegerVal types.
     UInt64Construct = Struct(

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -1078,7 +1078,6 @@ class MessageRateResponse(MessagePayload):
         self.config_source = ConfigurationSource.ACTIVE
         self.response = Response.OK
         self.output_interface = InterfaceID(TransportType.INVALID, 0)
-        self.protocol = ProtocolType.INVALID
         self.rates: List[RateResponseEntry] = []
 
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
@@ -1095,7 +1094,7 @@ class MessageRateResponse(MessagePayload):
     def __repr__(self):
         result = super().__repr__()[:-1]
         result += f', response={self.response}, interface={self.output_interface}, source={self.config_source}, ' \
-                  f'protocol={self.protocol}, num_entries={len(self.rates)}]'
+                  f'num_entries={len(self.rates)}]'
         return result
 
     def __str__(self):

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -281,9 +281,9 @@ class _ConfigClassGenerator:
         """!
         @brief 3D coordinate specifier, stored as 32-bit float values.
         """
-        x: float = 0
-        y: float = 0
-        z: float = 0
+        x: float = math.nan
+        y: float = math.nan
+        z: float = math.nan
 
     # Construct to serialize Point3F.
     Point3FConstruct = Struct(
@@ -319,7 +319,7 @@ class _ConfigClassGenerator:
         """!
         @brief Bool value specifier.
         """
-        value: bool
+        value: bool = False
 
     # Construct to serialize 8 bit boolean types.
     BoolConstruct = Struct(
@@ -411,11 +411,11 @@ class _ConfigClassGenerator:
         """
         vehicle_model: VehicleModel = VehicleModel.UNKNOWN_VEHICLE
         ## The distance between the front axle and rear axle (in meters).
-        wheelbase_m: float = 0
+        wheelbase_m: float = math.nan
         ## The distance between the two front wheels (in meters).
-        front_track_width_m: float = 0
+        front_track_width_m: float = math.nan
         ## The distance between the two rear wheels (in meters).
-        rear_track_width_m: float = 0
+        rear_track_width_m: float = math.nan
 
     VehicleDetailsConstruct = Struct(
         "vehicle_model" / AutoEnum(Int16ul, VehicleModel),

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -330,8 +330,6 @@ class _ConfigClassGenerator:
         """!
         @brief Bitmask specifying enabled @ref SatelliteType%s.
         """
-        value: int
-
         def __new__(cls, *args, **kwargs):
             # Check if the user specified a single SatelliteType or a list of values, and convert to a mask.
             if len(args) == 1:
@@ -362,8 +360,6 @@ class _ConfigClassGenerator:
         """!
         @brief Bitmask specifying enabled @ref FrequencyBand%s.
         """
-        value: int
-
         def __new__(cls, *args, **kwargs):
             # Check if the user specified a single FrequencyBand or a list of values, and convert to a mask.
             if len(args) == 1:

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -512,7 +512,10 @@ class EventNotificationMessage(MessagePayload):
         elif isinstance(self.event_description, str):
             return self.event_description
         else:
-            return repr(self.event_description)
+            try:
+                return self.event_description.decode('utf-8')
+            except UnicodeDecodeError:
+                return repr(self.event_description)
 
     @classmethod
     def _populate_data_byte_string(cls, data: bytes, max_bytes: int = None):

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -487,7 +487,7 @@ class EventNotificationMessage(MessagePayload):
     def calcsize(self) -> int:
         return len(self.pack())
 
-    def event_description_to_string(self):
+    def event_description_to_string(self, max_bytes=None):
         # For commands and responses, the payload should contain the binary FusionEngine message. Try to decode the
         # message type.
         if self.event_type == EventType.COMMAND or self.event_type == EventType.COMMAND_RESPONSE:
@@ -507,13 +507,18 @@ class EventNotificationMessage(MessagePayload):
             else:
                 message_repr = '<Malformed>'
 
-            newline = '\n'
-            return f'{message_repr}{newline}' \
-                   f'Data ({len(self.event_description)} B): {" ".join("%02X" % b for b in self.event_description)}'
+            return "%s\n%s" % (message_repr,
+                               self._populate_data_byte_string(self.event_description, max_bytes=max_bytes))
         elif isinstance(self.event_description, str):
             return self.event_description
         else:
             return repr(self.event_description)
+
+    @classmethod
+    def _populate_data_byte_string(cls, data: bytes, max_bytes: int = None):
+        data_truncated = data if max_bytes is None else data[:max_bytes]
+        suffix = '' if len(data_truncated) == len(data) else '...'
+        return f'Data ({len(data)} B): {" ".join("%02X" % b for b in data_truncated)}{suffix}'
 
 
 class ShutdownRequest(MessagePayload):

--- a/python/fusion_engine_client/utils/construct_utils.py
+++ b/python/fusion_engine_client/utils/construct_utils.py
@@ -232,7 +232,7 @@ def construct_message_to_string(message: object, construct: Optional[Struct] = N
     string = f'{title}\n'
     newline = '\n'
     for field in fields:
-        value = message.__dict__[field]
+        value = getattr(message, field)
         to_string_func = value_to_string.get(field, _generic_value_to_string)
         string += f'  {field}: {to_string_func(value).replace(newline, newline + "    ")}\n'
     return string.rstrip()

--- a/python/fusion_engine_client/utils/construct_utils.py
+++ b/python/fusion_engine_client/utils/construct_utils.py
@@ -40,6 +40,9 @@ class NamedTupleAdapter(Adapter):
         super().__init__(*args)
         self.tuple_cls = tuple_cls
 
+    def make_default(self):
+        return self.tuple_cls()
+
     def _decode(self, obj, context, path):
         # skip _io member
         return self.tuple_cls(*list(obj.values())[1:])
@@ -83,6 +86,9 @@ class ClassAdapter(Adapter):
         super().__init__(*args)
         self.cls = cls
 
+    def make_default(self):
+        return self.cls()
+
     def _decode(self, obj, context, path):
         val = self.cls()
         val.__dict__.update(obj)
@@ -123,6 +129,9 @@ class EnumAdapter(Adapter):
         super().__init__(*args)
         self.enum_cls = enum_cls
         self.raise_on_unrecognized = kwargs.get('raise_on_unrecognized', True)
+
+    def make_default(self):
+        return self.enum_cls('UNKNOWN', raise_on_unrecognized=self.raise_on_unrecognized)
 
     def _decode(self, obj, context, path):
         return self.enum_cls(int(obj), raise_on_unrecognized=self.raise_on_unrecognized)

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -20,9 +20,7 @@ class DynamicEnumMeta(EnumMeta):
                     raise e from None
                 else:
                     used_values = {int(v) for v in cls}
-                    unused_value = -1
-                    while unused_value in used_values:
-                        unused_value -= 1
+                    unused_value = min(min(used_values), 0) - 1
                     extend_enum(cls, name, unused_value)
                     return cls[name]
         else:


### PR DESCRIPTION
# Changes
- Truncate the displayed byte string to max 128 B

# Fixes
- Fixed incorrect variable name in message rate repr strings
- Replace <> with [] for HTML output to fix missing interface type details
- Removed incorrect `protocol` field from Python `MessageRateResponse` class
- Fixed unexpected config response length/data member variables after unpack
- Handle config responses with no payload gracefully (these can happen on an `UNAVAILABLE` response)
- Fixed config struct default value mismatch between C++ and Python