### PR TITLE
Read a max of 1 MB when searching for t0.

### DIFF
--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -244,6 +244,7 @@ class DataLoader(object):
 
         @param max_messages If set, read up to the specified maximum number of messages. Applies across all message
                types. If negative, read the last N messages.
+        @param max_bytes If set, read up to the specified maximum number of bytes.
         @param require_p1_time If `True`, omit messages that do not contain valid P1 timestamps.
         @param require_system_time If `True`, omit messages that do not contain valid system timestamps.
 
@@ -279,7 +280,8 @@ class DataLoader(object):
              time_range: TimeRange = None,
              show_progress: bool = False,
              ignore_cache: bool = False, disable_index_generation: bool = False,
-             max_messages: int = None, require_p1_time: bool = False, require_system_time: bool = False,
+             max_messages: int = None, max_bytes: int = None,
+              require_p1_time: bool = False, require_system_time: bool = False,
              return_in_order: bool = False, return_bytes: bool = False,
              return_numpy: bool = False, keep_messages: bool = False, remove_nan_times: bool = True,
              time_align: TimeAlignmentMode = TimeAlignmentMode.NONE,
@@ -305,6 +307,7 @@ class DataLoader(object):
         params = {
             'time_range': time_range,
             'max_messages': max_messages,
+            'max_bytes': max_bytes,
             'require_p1_time': require_p1_time,
             'require_system_time': require_system_time,
             'return_bytes': return_bytes,
@@ -395,6 +398,7 @@ class DataLoader(object):
             self.reader.rewind()
             self.reader.set_generate_index(self._generate_index and not disable_index_generation)
             self.reader.set_show_progress(show_progress)
+            self.reader.set_max_bytes(max_bytes)
 
         # If we need to establish t0 (either P1 time or system time), we will wait to apply the user's filter criteria.
         # We can get t0 from any message type.

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -180,15 +180,15 @@ class DataLoader(object):
             if self.t0 is None:
                 self.logger.warning('Unable to set t0 - no P1 timestamps found in index file.')
         else:
-            self.read(require_p1_time=True, max_messages=1, disable_index_generation=True, show_progress=False,
-                      ignore_cache=True)
+            self.read(require_p1_time=True, max_messages=1, max_bytes=1 * 1024 * 1024,
+                      disable_index_generation=True, ignore_cache=True, show_progress=False)
 
         # Similarly, we also set the system t0 based on the first system-stamped (typically POSIX) message to appear in
         # the log, if any (profiling data, etc.). Unlike P1 time, since the index file does not contain system
         # timestamps, we have to do a read() even if an index exists. read() will use the index to at least speed up the
         # read operation.
-        self.read(require_system_time=True, max_messages=1, disable_index_generation=True, show_progress=False,
-                  ignore_cache=True)
+        self.read(require_system_time=True, max_messages=1, max_bytes=1 * 1024 * 1024,
+                  disable_index_generation=True, ignore_cache=True, show_progress=False)
 
     def close(self):
         """!

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -183,6 +183,15 @@ class MixedLogReader(object):
     def set_show_progress(self, show_progress):
         self.show_progress = show_progress
 
+    def set_max_bytes(self, max_bytes):
+        if max_bytes is None:
+            self.max_bytes = sys.maxsize
+        else:
+            self.max_bytes = max_bytes
+            if self.index_builder is not None:
+                self.logger.debug('Max bytes specified. Disabling index generation.')
+                self.set_generate_index(False)
+
     def get_bytes_read(self):
         return self.total_bytes_read
 


### PR DESCRIPTION
# Changes
- Added `max_bytes` option to data loader reads
- Read a max of 1 MB when searching for t0 to prevent silently reading for VERY long times on large logs that do not have any messages with P1 and/or system time