### PR TITLE
Repurposed last_differential_time for leap second and corrections info.

### DIFF
--- a/examples/common/print_message.cc
+++ b/examples/common/print_message.cc
@@ -59,21 +59,30 @@ void PrintMessage(const MessageHeader& header, const void* payload_in) {
         contents.p1_time.seconds + (contents.p1_time.fraction_ns * 1e-9);
     double gps_time_sec =
         contents.gps_time.seconds + (contents.gps_time.fraction_ns * 1e-9);
-    double last_diff_time_sec =
-        contents.last_differential_time.seconds +
-        (contents.last_differential_time.fraction_ns * 1e-9);
 
     printf(
         "GNSS info message @ P1 time %.3f seconds. [sequence=%u, size=%zu B]\n",
         p1_time_sec, header.sequence_number, message_size);
     printf("  GPS time: %.3f\n", gps_time_sec);
     printf("  GPS time std dev: %.2e sec\n", contents.gps_time_std_sec);
+    printf("  Leap second: %d\n",
+           contents.leap_second == GNSSInfoMessage::INVALID_LEAP_SECOND
+               ? -1
+               : contents.leap_second);
+    printf("  # SVs: %d\n", contents.num_svs);
     printf("  Reference station: %s\n",
            contents.reference_station_id ==
                    GNSSInfoMessage::INVALID_REFERENCE_STATION
                ? "none"
                : std::to_string(contents.reference_station_id).c_str());
-    printf("  Last differential time: %.3f\n", last_diff_time_sec);
+    printf("  Corrections age: %.1f sec\n",
+           contents.corrections_age == GNSSInfoMessage::INVALID_AGE
+               ? NAN
+               : contents.leap_second * 0.1);
+    printf("  Baseline distance: %.2f km\n",
+           contents.baseline_distance == GNSSInfoMessage::INVALID_DISTANCE
+               ? NAN
+               : contents.baseline_distance * 0.01);
     printf("  GDOP: %.1f  PDOP: %.1f\n", contents.gdop, contents.pdop);
     printf("  HDOP: %.1f  VDOP: %.1f\n", contents.hdop, contents.vdop);
   } else if (header.message_type == MessageType::GNSS_SATELLITE) {

--- a/examples/generate_data/generate_data.cc
+++ b/examples/generate_data/generate_data.cc
@@ -3,6 +3,7 @@
 * @file
 ******************************************************************************/
 
+#include <cmath>
 #include <cstdio>
 #include <fstream>
 
@@ -106,9 +107,11 @@ Generate a binary file containing a fixed set of messages.
   gnss_info_message->gps_time.seconds = 1282677727;
   gnss_info_message->gps_time.fraction_ns = 200000000;
 
-  gnss_info_message->last_differential_time.seconds = 1282677727;
-  gnss_info_message->last_differential_time.fraction_ns = 200000000;
+  gnss_info_message->leap_second = 18;
+  gnss_info_message->num_svs = 22;
 
+  gnss_info_message->corrections_age = (uint16_t)std::lround(1.1 * 10.0);
+  gnss_info_message->baseline_distance = (uint16_t)std::lround(10300 / 10.0);
   gnss_info_message->reference_station_id = 4321;
 
   gnss_info_message->gdop = 1.6f;

--- a/python/examples/binary_message_decode.py
+++ b/python/examples/binary_message_decode.py
@@ -104,7 +104,8 @@ Payload: Reset Request [mask=0x01000fff]
 
                     if len(contents) >= min_message_size_bytes:
                         try:
-                            payload.unpack(buffer=contents, offset=header.calcsize())
+                            payload.unpack(buffer=contents, offset=header.calcsize(),
+                                           message_version=header.message_version)
                             logger.info("Decoded payload contents: %s" % str(payload))
                         except ValueError as e:
                             logger.warning(str(e))

--- a/python/examples/manual_message_decode.py
+++ b/python/examples/manual_message_decode.py
@@ -40,22 +40,22 @@ def decode_message(header, data, offset):
     # We do it explicitly here for sake of example.
     if header.message_type == PoseMessage.MESSAGE_TYPE:
         contents = PoseMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     elif header.message_type == GNSSInfoMessage.MESSAGE_TYPE:
         contents = GNSSInfoMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     elif header.message_type == GNSSSatelliteMessage.MESSAGE_TYPE:
         contents = GNSSSatelliteMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     elif header.message_type == ros.ROSPoseMessage.MESSAGE_TYPE:
         contents = ros.ROSPoseMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     elif header.message_type == ros.ROSGPSFixMessage.MESSAGE_TYPE:
         contents = ros.ROSGPSFixMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     elif header.message_type == ros.ROSIMUMessage.MESSAGE_TYPE:
         contents = ros.ROSIMUMessage()
-        contents.unpack(buffer=data, offset=offset)
+        contents.unpack(buffer=data, offset=offset, message_version=header.message_version)
     else:
         contents = None
 

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -735,7 +735,7 @@ class SetConfigMessage(MessagePayload):
         packed_data = self.SetConfigMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.SetConfigMessageConstruct.parse(buffer[offset:])
         if parsed.flags & self.FLAG_REVERT_TO_DEFAULT:
             self.config_object = _conf_gen.CONFIG_MAP[parsed.config_type].tuple_cls()
@@ -787,7 +787,7 @@ class GetConfigMessage(MessagePayload):
         packed_data = self.GetConfigMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.GetConfigMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -833,7 +833,7 @@ class SaveConfigMessage(MessagePayload):
         packed_data = self.SaveConfigMessageConstruct.build({"action": self.action})
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.SaveConfigMessageConstruct.parse(buffer[offset:])
         self.action = parsed.action
         return parsed._io.tell()
@@ -898,7 +898,7 @@ class ConfigResponseMessage(MessagePayload):
         packed_data = self.ConfigResponseMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.ConfigResponseMessageConstruct.parse(buffer[offset:])
 
         self.__dict__.update(parsed)
@@ -1002,7 +1002,7 @@ class SetMessageRate(MessagePayload):
         packed_data = self.SetMessageRateConstruct.build(self.__dict__)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.SetMessageRateConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -1061,7 +1061,7 @@ class GetMessageRate(MessagePayload):
         packed_data = self.GetMessageRateConstruct.build(self.__dict__)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.GetMessageRateConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -1141,7 +1141,7 @@ class MessageRateResponse(MessagePayload):
         packed_data = self.MessageRateResponseConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.MessageRateResponseConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -1217,7 +1217,7 @@ class ImportDataMessage(MessagePayload):
         packed_data = self.ImportDataMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.ImportDataMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -1260,7 +1260,7 @@ class ExportDataMessage(MessagePayload):
         packed_data = self.ExportDataMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.ExportDataMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -1311,7 +1311,7 @@ class PlatformStorageDataMessage(MessagePayload):
         packed_data = self.PlatformStorageDataMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.PlatformStorageDataMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -34,7 +34,7 @@ class CommandResponseMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         (self.source_sequence_num, self.response) = \
@@ -93,7 +93,7 @@ class MessageRequest(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         (message_type,) = self._STRUCT.unpack_from(buffer=buffer, offset=offset)
@@ -328,7 +328,7 @@ class ResetRequest(MessagePayload):
         else:
             return self.calcsize()
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         (self.reset_mask,) = \
@@ -386,7 +386,7 @@ class VersionInfoMessage(MessagePayload):
         packed_data = self.VersionInfoMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.VersionInfoMessageConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()
@@ -448,7 +448,7 @@ class EventNotificationMessage(MessagePayload):
         packed_data = self.EventNotificationConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.EventNotificationConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
 
@@ -544,7 +544,7 @@ class ShutdownRequest(MessagePayload):
         packed_data = self.ShutdownRequestConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.ShutdownRequestConstruct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -341,6 +341,8 @@ class MessagePayload:
     @brief Message payload API.
     """
 
+    _UNSPECIFIED_VERSION = 0x100
+
     message_type_to_class: Dict[MessageType, Type[MessagePayload]] = {}
     message_type_by_name: Dict[str, MessageType] = {}
 
@@ -405,7 +407,7 @@ class MessagePayload:
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         raise NotImplementedError('pack() not implemented.')
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = _UNSPECIFIED_VERSION) -> int:
         raise NotImplementedError('unpack() not implemented.')
 
     def get_p1_time(self) -> Timestamp:

--- a/python/fusion_engine_client/messages/fault_control.py
+++ b/python/fusion_engine_client/messages/fault_control.py
@@ -181,7 +181,7 @@ class FaultControlMessage(MessagePayload):
         packed_data = self.FaultControlMessageConstruct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.FaultControlMessageConstruct.parse(buffer[offset:])
         self.payload = _class_gen.TYPE_MAP[parsed.fault_type].parse(parsed.payload)
         return parsed._io.tell()

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -45,7 +45,7 @@ class IMUMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -159,7 +159,7 @@ class WheelSpeedMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.timestamps.unpack(buffer, offset)
@@ -267,7 +267,7 @@ class VehicleSpeedMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.timestamps.unpack(buffer, offset)
@@ -375,7 +375,7 @@ class WheelTickMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.timestamps.unpack(buffer, offset)
@@ -477,7 +477,7 @@ class VehicleTickMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.timestamps.unpack(buffer, offset)
@@ -599,7 +599,7 @@ class HeadingMeasurement(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.timestamps.unpack(buffer, offset)

--- a/python/fusion_engine_client/messages/ros.py
+++ b/python/fusion_engine_client/messages/ros.py
@@ -52,7 +52,7 @@ class ROSPoseMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -202,7 +202,7 @@ class ROSGPSFixMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -314,7 +314,7 @@ class ROSIMUMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -343,6 +343,24 @@ class GNSSInfoMessage(MessagePayload):
     def calcsize(self) -> int:
         return 2 * Timestamp.calcsize() + self._STRUCT.size
 
+    @classmethod
+    def to_numpy(cls, messages):
+        result = {
+            'p1_time': np.array([float(m.p1_time) for m in messages]),
+            'gps_time': np.array([float(m.gps_time) for m in messages]),
+            'gps_time_std_sec': np.array([m.baseline_distance_m for m in messages]),
+            'leap_second': np.array([int(m.leap_second) for m in messages], dtype=int),
+            'num_svs': np.array([int(m.num_svs) for m in messages], dtype=int),
+            'corrections_age_sec': np.array([m.corrections_age_sec for m in messages]),
+            'baseline_distance_m': np.array([m.baseline_distance_m for m in messages]),
+            'reference_station_id': np.array([int(m.reference_station_id) for m in messages], dtype=int),
+            'gdop': np.array([m.gdop for m in messages]),
+            'pdop': np.array([m.pdop for m in messages]),
+            'hdop': np.array([m.hdop for m in messages]),
+            'vdop': np.array([m.vdop for m in messages]),
+        }
+        return result
+
 
 class SatelliteInfo:
     """!

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -302,15 +302,25 @@ class GNSSInfoMessage(MessagePayload):
         offset += self.p1_time.unpack(buffer, offset)
         offset += self.gps_time.unpack(buffer, offset)
 
-        (self.leap_second, self.num_svs,
+        (leap_second, num_svs,
          corrections_age, baseline_distance, self.reference_station_id,
          self.gdop, self.pdop, self.hdop, self.vdop,
          self.gps_time_std_sec) = \
             self._STRUCT.unpack_from(buffer=buffer, offset=offset)
         offset += self._STRUCT.size
 
-        self.corrections_age_sec = np.nan if corrections_age == self.INVALID_AGE else (corrections_age * 0.1)
-        self.baseline_distance_m = np.nan if baseline_distance == self.INVALID_DISTANCE else (baseline_distance * 10.0)
+        # The following fields were added in message version 1.
+        if message_version >= 1:
+            self.leap_second = leap_second
+            self.num_svs = num_svs
+            self.corrections_age_sec = np.nan if corrections_age == self.INVALID_AGE else (corrections_age * 0.1)
+            self.baseline_distance_m = (np.nan if baseline_distance == self.INVALID_DISTANCE else
+                                        (baseline_distance * 10.0))
+        else:
+            self.leap_second = self.INVALID_LEAP_SECOND
+            self.num_svs = 0
+            self.corrections_age_sec = np.nan
+            self.baseline_distance_m = np.nan
 
         return offset - initial_offset
 

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -76,7 +76,7 @@ class PoseMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -196,7 +196,7 @@ class PoseAuxMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -296,7 +296,7 @@ class GNSSInfoMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -431,7 +431,7 @@ class GNSSSatelliteMessage(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -643,7 +643,7 @@ class CalibrationStatus(MessagePayload):
         else:
             return offset - initial_offset
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         initial_offset = offset
 
         offset += self.p1_time.unpack(buffer, offset)
@@ -783,7 +783,7 @@ class RelativeENUPositionMessage(MessagePayload):
         packed_data = self.Construct.build(values)
         return PackedDataToBuffer(packed_data, buffer, offset, return_buffer)
 
-    def unpack(self, buffer: bytes, offset: int = 0) -> int:
+    def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
         parsed = self.Construct.parse(buffer[offset:])
         self.__dict__.update(parsed)
         return parsed._io.tell()

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -250,7 +250,7 @@ class GNSSInfoMessage(MessagePayload):
         self.p1_time = Timestamp()
         self.gps_time = Timestamp()
 
-        self.leap_second = self.INVALID_LEAP_SECOND
+        self.leap_second = GNSSInfoMessage.INVALID_LEAP_SECOND
         self.num_svs = 0
 
         self.corrections_age_sec = np.nan
@@ -274,12 +274,12 @@ class GNSSInfoMessage(MessagePayload):
         offset += self.gps_time.pack(buffer, offset, return_buffer=False)
 
         if np.isnan(self.corrections_age_sec):
-            corrections_age = self.INVALID_AGE
+            corrections_age = GNSSInfoMessage.INVALID_AGE
         else:
             corrections_age = round(self.corrections_age_sec * 10.0)
 
         if np.isnan(self.baseline_distance_m):
-            baseline_distance = self.INVALID_DISTANCE
+            baseline_distance = GNSSInfoMessage.INVALID_DISTANCE
         else:
             baseline_distance = round(self.baseline_distance_m / 10.0)
 
@@ -313,11 +313,12 @@ class GNSSInfoMessage(MessagePayload):
         if message_version >= 1:
             self.leap_second = leap_second
             self.num_svs = num_svs
-            self.corrections_age_sec = np.nan if corrections_age == self.INVALID_AGE else (corrections_age * 0.1)
-            self.baseline_distance_m = (np.nan if baseline_distance == self.INVALID_DISTANCE else
+            self.corrections_age_sec = (np.nan if corrections_age == GNSSInfoMessage.INVALID_AGE else
+                                        (corrections_age * 0.1))
+            self.baseline_distance_m = (np.nan if baseline_distance == GNSSInfoMessage.INVALID_DISTANCE else
                                         (baseline_distance * 10.0))
         else:
-            self.leap_second = self.INVALID_LEAP_SECOND
+            self.leap_second = GNSSInfoMessage.INVALID_LEAP_SECOND
             self.num_svs = 0
             self.corrections_age_sec = np.nan
             self.baseline_distance_m = np.nan
@@ -328,7 +329,7 @@ class GNSSInfoMessage(MessagePayload):
         string = 'GNSS Info Message @ %s\n' % str(self.p1_time)
         string += '  GPS time: %s\n' % str(self.gps_time.as_gps())
         string += '  UTC leap second: %s\n' % \
-                  (self.leap_second if self.leap_second != self.INVALID_LEAP_SECOND else 'unknown')
+                  (self.leap_second if self.leap_second != GNSSInfoMessage.INVALID_LEAP_SECOND else 'unknown')
         string += '  # SVs used: %d\n' % self.num_svs
         string += ('  Reference station: %s\n' %
                    (str(self.reference_station_id)

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -323,7 +323,7 @@ class MixedLogReader(object):
                     if cls is not None:
                         try:
                             payload = cls()
-                            payload.unpack(buffer=payload_bytes, offset=0)
+                            payload.unpack(buffer=payload_bytes, offset=0, message_version=header.message_version)
                         except Exception as e:
                             self.logger.error("Error parsing %s message: %s" % (header.get_type_string(), str(e)))
                             payload = None

--- a/src/point_one/fusion_engine/messages/measurements.h
+++ b/src/point_one/fusion_engine/messages/measurements.h
@@ -443,7 +443,8 @@ struct alignas(4) VehicleTickMeasurement : public MessagePayload {
 
 /**
  * @brief The heading angle (in degrees) with respect to true north,
- *        pointing from the primary antenna to the secondary antenna.
+ *        pointing from the primary antenna to the secondary antenna (@ref
+          MessageType::HEADING_MEASUREMENT, version 1.0).
  * @ingroup solution_messages
  *
  * @note
@@ -454,7 +455,7 @@ struct alignas(4) VehicleTickMeasurement : public MessagePayload {
  */
 struct alignas(4) HeadingMeasurement : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::HEADING_MEASUREMENT;
-  static constexpr uint8_t MESSAGE_VERSION = 1;
+  static constexpr uint8_t MESSAGE_VERSION = 0;
 
   /** Measurement timestamps, if available. See @ref measurement_messages. */
   MeasurementTimestamps timestamps;


### PR DESCRIPTION
# Changes
- Repurposed `GNSSInfoMessage::last_differential_time` field to output:
  - UTC leap second
  - Number of SVs in use
  - GNSS corrections age
  - GNSS corrections baseline distance
- Added a GNSS corrections status plot
- Added `message_version` argument to `MessagePayload.unpack()` API

# Fixes
- Corrected message version number in C++ `HeadingMeasurement` class