### PR TITLE
Add FusionEngine message for turning off or modifying atmospheric delay models

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -570,9 +570,7 @@ class _ConfigClassGenerator:
 
     class AtmosphericDelayModelConfig(NamedTuple):
         """!
-        @brief Atmospheric delay model configuration settings.
-
-        See @ref VehicleTickMeasurement.
+        @brief Ionospheric and tropospheric delay model configuration.
         """
 
         ## If not OFF -- the ionospheric delay model to be used.

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -33,6 +33,7 @@ class ConfigType(IntEnum):
     ENABLED_GNSS_FREQUENCY_BANDS = 51
     LEAP_SECOND = 52
     GPS_WEEK_ROLLOVER = 53
+    ATMOSPHERIC_DELAY_MODEL = 54
     INTERFACE_CONFIG = 200
     UART1_BAUD = 256
     UART2_BAUD = 257
@@ -207,6 +208,13 @@ class NmeaMessageType(IntEnum):
     PQTMVER_SUB = 1204
     PQTMTXT = 1205
 
+class IonoDelayModel(IntEnum):
+    OFF = 0
+    KLOBUCHAR = 1
+
+class TropoDelayModel(IntEnum):
+    OFF = 0
+    SAASTAMOINEN = 1
 
 def get_message_type_string(protocol: ProtocolType, message_id: int):
     if message_id == ALL_MESSAGES_ID:
@@ -560,6 +568,24 @@ class _ConfigClassGenerator:
         "wheel_ticks_to_m" / Float32l,
     )
 
+    class AtmosphericDelayModelConfig(NamedTuple):
+        """!
+        @brief Atmospheric delay model configuration settings.
+
+        See @ref VehicleTickMeasurement.
+        """
+
+        ## If not OFF -- the ionospheric delay model to be used.
+        iono_delay_model: IonoDelayModel = IonoDelayModel.KLOBUCHAR
+        ## If not OFF -- the tropospheric delay model to be used.
+        tropo_delay_model: TropoDelayModel = TropoDelayModel.SAASTAMOINEN
+
+    AtmosphericDelayModelConfigConstruct = Struct(
+        "iono_delay_model" / AutoEnum(Int8ul, IonoDelayModel),
+        "tropo_delay_model" / AutoEnum(Int8ul, TropoDelayModel),
+        Padding(2),
+    )
+
     class Empty(NamedTuple):
         """!
         @brief Dummy specifier for empty config.
@@ -642,6 +668,14 @@ class GPSWeekRolloverConfig(_conf_gen.IntegerVal):
     """
     def __new__(cls, value: int = -1):
         return super().__new__(cls, value)
+
+
+@_conf_gen.create_config_class(ConfigType.ATMOSPHERIC_DELAY_MODEL, _conf_gen.AtmosphericDelayModelConfigConstruct)
+class AtmosphericDelayModelConfig(_conf_gen.AtmosphericDelayModelConfig):
+    """!
+    @brief Information including ionospheric delay model and troposheric delay model.
+    """
+    pass
 
 
 @_conf_gen.create_config_class(ConfigType.UART1_BAUD, _conf_gen.UInt32Construct)

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1,14 +1,12 @@
 import pytest
 from fusion_engine_client.messages import (
-    ConfigurationSource, ConfigResponseMessage, ConfigType, SetConfigMessage,
-    AppliedSpeedType, InterfaceBaudRateConfig, ConfigResponseMessage, ConfigType,
-    ConfigurationSource, DeviceCourseOrientationConfig, Direction, EnabledGNSSFrequencyBandsConfig,
-    EnabledGNSSSystemsConfig, FrequencyBand, FrequencyBandMask, GetConfigMessage,
-    GNSSLeverArmConfig, HardwareTickConfig, InterfaceConfigSubmessage, InterfaceID,
-    InterfaceConfigType, InvalidConfig, MessageRate, MessageRateResponse,
-    RateResponseEntry, SatelliteType, SatelliteTypeMask, SetConfigMessage,
-    SteeringType, TickDirection, TickMode, TransportType, Uart1BaudConfig,
-    VehicleDetailsConfig, VehicleModel, WheelConfig, WheelSensorType)
+    AppliedSpeedType, AtmosphericDelayModelConfig, ConfigurationSource, ConfigResponseMessage, ConfigType,
+    InterfaceBaudRateConfig, ConfigResponseMessage, ConfigType, ConfigurationSource, DeviceCourseOrientationConfig,
+    Direction, EnabledGNSSFrequencyBandsConfig,EnabledGNSSSystemsConfig, FrequencyBand, FrequencyBandMask,
+    GetConfigMessage, GNSSLeverArmConfig, HardwareTickConfig, IonoDelayModel, InterfaceConfigSubmessage, InterfaceID,
+    InterfaceConfigType, InvalidConfig, MessageRate, MessageRateResponse, RateResponseEntry, SatelliteType,
+    SatelliteTypeMask, SetConfigMessage,SteeringType, TickDirection, TickMode, TransportType, TropoDelayModel,
+    Uart1BaudConfig, VehicleDetailsConfig, VehicleModel, WheelConfig, WheelSensorType)
 from fusion_engine_client.messages.configuration import \
     _RateResponseEntryConstructRaw
 from fusion_engine_client.utils import trace as logging
@@ -33,6 +31,9 @@ def test_set_config():
 
     set_msg = SetConfigMessage(HardwareTickConfig(TickMode.OFF, TickDirection.OFF, 0.1))
     assert len(set_msg.pack()) == BASE_SIZE + 8
+
+    set_msg = SetConfigMessage(AtmosphericDelayModelConfig(IonoDelayModel.OFF, TropoDelayModel.OFF))
+    assert len(set_msg.pack()) == BASE_SIZE + 4
 
     set_msg = SetConfigMessage(GNSSLeverArmConfig(1, 2, 3))
     assert len(set_msg.pack()) == BASE_SIZE + 12

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -142,6 +142,13 @@ enum class ConfigType : uint16_t {
   GPS_WEEK_ROLLOVER = 53,
 
   /**
+   * Information including ionospheric delay model and tropospheric delay model.
+   *
+   * Payload format: @ref AtmosphericDelayModelConfig
+   */
+  ATMOSPHERIC_DELAY_MODEL = 54,
+
+  /**
    * Change a configuration setting for a specified output interface.
    *
    * Payload format: `InterfaceConfigSubmessage`
@@ -1202,6 +1209,89 @@ struct alignas(4) HardwareTickConfig {
    * @ref WheelSensorType::TICK_RATE.
    */
   float wheel_ticks_to_m = NAN;
+};
+
+/**
+ * @brief The ionospheric delay model to be used.
+ * @ingroup config_and_ctrl_messages
+ */
+enum class IonoDelayModel : uint8_t {
+  /** Ionospheric delay model disabled. */
+  OFF = 0,
+  /** Use the Klobuchar ionospheric model. */
+  KLOBUCHAR = 1,
+};
+
+P1_CONSTEXPR_FUNC const char* to_string(IonoDelayModel iono_delay_model) {
+  switch (iono_delay_model) {
+    case IonoDelayModel::OFF:
+      return "OFF";
+    case IonoDelayModel::KLOBUCHAR:
+      return "KLOBUCHAR";
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+/**
+ * @brief @ref IonoDelayModel stream operator.
+ * @ingroup config_and_ctrl_messages
+ */
+inline std::ostream& operator<<(std::ostream& stream,
+                                IonoDelayModel iono_delay_model) {
+  stream << to_string(iono_delay_model) << " (" << (int)iono_delay_model << ")";
+  return stream;
+}
+
+/**
+ * @brief The troposhpheric delay model to be used.
+ * @ingroup config_and_ctrl_messages
+ */
+enum class TropoDelayModel : uint8_t {
+  /** Tropospheric delay model disabled. */
+  OFF = 0,
+  /** Use the Saastamoinen ionospheric model. */
+  SAASTAMOINEN = 1,
+};
+
+P1_CONSTEXPR_FUNC const char* to_string(TropoDelayModel tropo_delay_model) {
+  switch (tropo_delay_model) {
+    case TropoDelayModel::OFF:
+      return "OFF";
+    case TropoDelayModel::SAASTAMOINEN:
+      return "SAASTAMOINEN";
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+/**
+ * @brief @ref TropoDelayModel stream operator.
+ * @ingroup config_and_ctrl_messages
+ */
+inline std::ostream& operator<<(std::ostream& stream,
+                                TropoDelayModel tropo_delay_model) {
+  stream << to_string(tropo_delay_model) << " (" << (int)tropo_delay_model
+         << ")";
+  return stream;
+}
+
+/**
+ * @brief Atmospheric delay model configuration settings.
+ * @ingroup config_and_ctrl_messages
+ *
+ * @note
+ * If either model is disabled (set to `OFF`), then that model will not be
+ * used in downstream calculations.
+ */
+struct alignas(4) AtmosphericDelayModelConfig {
+  /** If not OFF -- the ionospheric delay model to be used. */
+  IonoDelayModel iono_delay_model = IonoDelayModel::KLOBUCHAR;
+
+  /** If not OFF -- the ionospheric delay model to be used. */
+  TropoDelayModel tropo_delay_model = TropoDelayModel::SAASTAMOINEN;
+
+  uint8_t reserved[2] = {0};
 };
 
 /** @} */

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1277,7 +1277,7 @@ inline std::ostream& operator<<(std::ostream& stream,
 }
 
 /**
- * @brief Atmospheric delay model configuration settings.
+ * @brief Ionospheric and tropospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
  *
  * @note


### PR DESCRIPTION
Modifications
-
- Added `AtmosphericDelayModelConfig`, which contains parameters for the ionospheric model (`iono_delay_model`) and the tropospheric model (`tropo_delay_model`)