### PR TITLE
Separate `AtmosphereDelayModelConfig` into two separate configs

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -575,9 +575,7 @@ class _ConfigClassGenerator:
         """!
         @brief Ionospheric delay model configuration.
         """
-        ##
-        # If not OFF -- the ionospheric delay model to be used. If set to AUTO, the device will select the best
-        # available option.
+        ## The ionospheric delay model to use.
         iono_delay_model: IonoDelayModel = IonoDelayModel.AUTO
 
     IonosphereConfigConstruct = Struct(
@@ -589,9 +587,7 @@ class _ConfigClassGenerator:
         """!
         @brief Tropospheric delay model configuration.
         """
-        ##
-        # If not OFF -- the tropospheric delay model to be used. If set to AUTO, the device will select the best
-        # available option.
+        ## The tropospheric delay model to use.
         tropo_delay_model: TropoDelayModel = TropoDelayModel.AUTO
 
     TroposphereConfigConstruct = Struct(

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1,12 +1,13 @@
 import pytest
 from fusion_engine_client.messages import (
-    AppliedSpeedType, AtmosphericDelayModelConfig, ConfigurationSource, ConfigResponseMessage, ConfigType,
+    AppliedSpeedType, ConfigurationSource, ConfigResponseMessage, ConfigType,
     InterfaceBaudRateConfig, ConfigResponseMessage, ConfigType, ConfigurationSource, DeviceCourseOrientationConfig,
     Direction, EnabledGNSSFrequencyBandsConfig,EnabledGNSSSystemsConfig, FrequencyBand, FrequencyBandMask,
-    GetConfigMessage, GNSSLeverArmConfig, HardwareTickConfig, IonoDelayModel, InterfaceConfigSubmessage, InterfaceID,
-    InterfaceConfigType, InvalidConfig, MessageRate, MessageRateResponse, RateResponseEntry, SatelliteType,
-    SatelliteTypeMask, SetConfigMessage,SteeringType, TickDirection, TickMode, TransportType, TropoDelayModel,
-    Uart1BaudConfig, VehicleDetailsConfig, VehicleModel, WheelConfig, WheelSensorType)
+    GetConfigMessage, GNSSLeverArmConfig, HardwareTickConfig, IonoDelayModel, IonosphereConfig,
+    InterfaceConfigSubmessage, InterfaceID, InterfaceConfigType, InvalidConfig, MessageRate, MessageRateResponse,
+    RateResponseEntry, SatelliteType, SatelliteTypeMask, SetConfigMessage,SteeringType, TickDirection, TickMode,
+    TransportType, TropoDelayModel, TroposphereConfig, Uart1BaudConfig, VehicleDetailsConfig, VehicleModel,
+    WheelConfig, WheelSensorType)
 from fusion_engine_client.messages.configuration import \
     _RateResponseEntryConstructRaw
 from fusion_engine_client.utils import trace as logging
@@ -32,7 +33,10 @@ def test_set_config():
     set_msg = SetConfigMessage(HardwareTickConfig(TickMode.OFF, TickDirection.OFF, 0.1))
     assert len(set_msg.pack()) == BASE_SIZE + 8
 
-    set_msg = SetConfigMessage(AtmosphericDelayModelConfig(IonoDelayModel.OFF, TropoDelayModel.OFF))
+    set_msg = SetConfigMessage(IonosphereConfig(IonoDelayModel.AUTO))
+    assert len(set_msg.pack()) == BASE_SIZE + 4
+
+    set_msg = SetConfigMessage(TroposphereConfig(TropoDelayModel.AUTO))
     assert len(set_msg.pack()) == BASE_SIZE + 4
 
     set_msg = SetConfigMessage(GNSSLeverArmConfig(1, 2, 3))

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1219,7 +1219,7 @@ struct alignas(4) HardwareTickConfig {
 };
 
 /**
- * @brief The ionospheric delay model to be used.
+ * @brief The ionospheric delay model to use.
  * @ingroup config_and_ctrl_messages
  */
 enum class IonoDelayModel : uint8_t {
@@ -1257,21 +1257,16 @@ inline std::ostream& operator<<(std::ostream& stream,
 /**
  * @brief Ionospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
- *
- * @note
- * If model is disabled (set to `OFF`), then that model will not be
- * used in downstream calculations. If set to `AUTO`, the device will select
- * the best available option.
  */
 struct alignas(4) IonosphereConfig {
-  /** If not OFF -- the ionospheric delay model to be used. */
+  /** The ionospheric delay model to use. */
   IonoDelayModel iono_delay_model = IonoDelayModel::AUTO;
 
   uint8_t reserved[3] = {0};
 };
 
 /**
- * @brief The troposhpheric delay model to be used.
+ * @brief The tropospheric delay model to use.
  * @ingroup config_and_ctrl_messages
  */
 enum class TropoDelayModel : uint8_t {
@@ -1279,7 +1274,7 @@ enum class TropoDelayModel : uint8_t {
   AUTO = 0,
   /** Tropospheric delay model disabled. */
   OFF = 1,
-  /** Use the Saastamoinen ionospheric model. */
+  /** Use the Saastamoinen tropospheric model. */
   SAASTAMOINEN = 2,
 };
 
@@ -1310,14 +1305,9 @@ inline std::ostream& operator<<(std::ostream& stream,
 /**
  * @brief Tropospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
- *
- * @note
- * If model is disabled (set to `OFF`), then that model will not be
- * used in downstream calculations. If set to `AUTO`, the device will select
- * the best available option.
  */
 struct alignas(4) TroposphereConfig {
-  /** If not OFF -- the ionospheric delay model to be used. */
+  /** The tropospheric delay model to use. */
   TropoDelayModel tropo_delay_model = TropoDelayModel::AUTO;
 
   uint8_t reserved[3] = {0};

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -142,11 +142,18 @@ enum class ConfigType : uint16_t {
   GPS_WEEK_ROLLOVER = 53,
 
   /**
-   * Information including ionospheric delay model and tropospheric delay model.
+   * Ionospheric delay model configuration.
    *
-   * Payload format: @ref AtmosphericDelayModelConfig
+   * Payload format: @ref IonosphereConfig
    */
-  ATMOSPHERIC_DELAY_MODEL = 54,
+  IONOSPHERE_CONFIG = 54,
+
+  /**
+   * Tropospheric delay model configuration.
+   *
+   * Payload format: @ref TroposphereConfig
+   */
+  TROPOSPHERE_CONFIG = 55,
 
   /**
    * Change a configuration setting for a specified output interface.
@@ -1216,14 +1223,18 @@ struct alignas(4) HardwareTickConfig {
  * @ingroup config_and_ctrl_messages
  */
 enum class IonoDelayModel : uint8_t {
+  /** Select the best available ionospheric delay model. */
+  AUTO = 0,
   /** Ionospheric delay model disabled. */
-  OFF = 0,
+  OFF = 1,
   /** Use the Klobuchar ionospheric model. */
-  KLOBUCHAR = 1,
+  KLOBUCHAR = 2,
 };
 
 P1_CONSTEXPR_FUNC const char* to_string(IonoDelayModel iono_delay_model) {
   switch (iono_delay_model) {
+    case IonoDelayModel::AUTO:
+      return "AUTO";
     case IonoDelayModel::OFF:
       return "OFF";
     case IonoDelayModel::KLOBUCHAR:
@@ -1244,18 +1255,38 @@ inline std::ostream& operator<<(std::ostream& stream,
 }
 
 /**
+ * @brief Ionospheric delay model configuration.
+ * @ingroup config_and_ctrl_messages
+ *
+ * @note
+ * If model is disabled (set to `OFF`), then that model will not be
+ * used in downstream calculations. If set to `AUTO`, the device will select
+ * the best available option.
+ */
+struct alignas(4) IonosphereConfig {
+  /** If not OFF -- the ionospheric delay model to be used. */
+  IonoDelayModel iono_delay_model = IonoDelayModel::AUTO;
+
+  uint8_t reserved[3] = {0};
+};
+
+/**
  * @brief The troposhpheric delay model to be used.
  * @ingroup config_and_ctrl_messages
  */
 enum class TropoDelayModel : uint8_t {
+  /** Select the best available tropospheric delay model. */
+  AUTO = 0,
   /** Tropospheric delay model disabled. */
-  OFF = 0,
+  OFF = 1,
   /** Use the Saastamoinen ionospheric model. */
-  SAASTAMOINEN = 1,
+  SAASTAMOINEN = 2,
 };
 
 P1_CONSTEXPR_FUNC const char* to_string(TropoDelayModel tropo_delay_model) {
   switch (tropo_delay_model) {
+    case TropoDelayModel::AUTO:
+      return "AUTO";
     case TropoDelayModel::OFF:
       return "OFF";
     case TropoDelayModel::SAASTAMOINEN:
@@ -1277,21 +1308,19 @@ inline std::ostream& operator<<(std::ostream& stream,
 }
 
 /**
- * @brief Ionospheric and tropospheric delay model configuration.
+ * @brief Tropospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
  *
  * @note
- * If either model is disabled (set to `OFF`), then that model will not be
- * used in downstream calculations.
+ * If model is disabled (set to `OFF`), then that model will not be
+ * used in downstream calculations. If set to `AUTO`, the device will select
+ * the best available option.
  */
-struct alignas(4) AtmosphericDelayModelConfig {
+struct alignas(4) TroposphereConfig {
   /** If not OFF -- the ionospheric delay model to be used. */
-  IonoDelayModel iono_delay_model = IonoDelayModel::KLOBUCHAR;
+  TropoDelayModel tropo_delay_model = TropoDelayModel::AUTO;
 
-  /** If not OFF -- the ionospheric delay model to be used. */
-  TropoDelayModel tropo_delay_model = TropoDelayModel::SAASTAMOINEN;
-
-  uint8_t reserved[2] = {0};
+  uint8_t reserved[3] = {0};
 };
 
 /** @} */


### PR DESCRIPTION
Modifications:
-
- Separated `AtmosphereDelayModelConfig` into `IonosphereConfig` and `TroposphereConfig`
- Added `AUTO` as the default entry for the two new configs