### PR TITLE
Fixed broken pipe handling in `p1_print`.

### DIFF
--- a/python/bin/p1_print
+++ b/python/bin/p1_print
@@ -18,7 +18,7 @@ from fusion_engine_client.utils import trace as logging
 from fusion_engine_client.utils.argument_parser import ArgumentParser, ExtendedBooleanAction
 from fusion_engine_client.utils.log import locate_log, DEFAULT_LOG_BASE_DIR
 from fusion_engine_client.utils.time_range import TimeRange
-from fusion_engine_client.utils.trace import HighlightFormatter
+from fusion_engine_client.utils.trace import HighlightFormatter, BrokenPipeStreamHandler
 
 _logger = logging.getLogger('point_one.fusion_engine.applications.print_contents')
 
@@ -129,6 +129,7 @@ other types of data.
         logging.basicConfig(level=logging.INFO, format='%(message)s', stream=sys.stdout)
 
     HighlightFormatter.install(color=True, standoff_level=logging.WARNING)
+    BrokenPipeStreamHandler.install()
 
     # Locate the input file and set the output directory.
     input_path, log_id = locate_log(input_path=options.log, log_base_dir=options.log_base_dir, return_log_id=True,
@@ -243,7 +244,7 @@ other types of data.
                 entry['count'] += 1
             else:
                 print_message(header, message, offset_bytes, format=options.format)
-    except (BrokenPipeError, KeyboardInterrupt):
+    except (BrokenPipeError, KeyboardInterrupt) as e:
         sys.exit(1)
 
     # Print the data summary.


### PR DESCRIPTION
This prevents a flood of errors when `p1_print` is piped to another program that exits early (e.g., `p1_print | less`, and then hitting 'q').