### PR TITLE
Skip sync byte validation by default in `MessageHeader.unpack()`.

### DIFF
--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -304,7 +304,7 @@ class MessageHeader:
         else:
             return self.calcsize()
 
-    def unpack(self, buffer: bytes, offset: int = 0, validate_crc: bool = False,
+    def unpack(self, buffer: bytes, offset: int = 0, validate_sync: bool = False, validate_crc: bool = False,
                warn_on_unrecognized: bool = True) -> int:
         """!
         @brief Deserialize a message header and validate its sync bytes and CRC.
@@ -314,6 +314,7 @@ class MessageHeader:
 
         @param buffer A byte buffer containing a serialized message.
         @param offset The offset into the buffer (in bytes) at which the message header begins.
+        @param validate_sync If `True`, validate the sync bytes contained in the data buffer.
         @param validate_crc If `True`, validate the deserialized CRC against the data in the buffer.
         @param warn_on_unrecognized If `True`, print a warning if the message type is not listed in @ref MessageType.
 
@@ -325,7 +326,7 @@ class MessageHeader:
          self.sequence_number, self.payload_size_bytes, self.source_identifier) = \
             struct.unpack_from(MessageHeader._FORMAT, buffer, offset)
 
-        if sync0 != MessageHeader.SYNC0 or sync1 != MessageHeader.SYNC1:
+        if validate_sync and (sync0 != MessageHeader.SYNC0 or sync1 != MessageHeader.SYNC1):
             raise ValueError('Received invalid sync bytes. [sync0=0x%02x, sync1=0x%02x]' % (sync0, sync1))
 
         # Validate the CRC, assuming the message payload follows in the buffer.

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -213,10 +213,10 @@ def is_response(message_type: MessageType) -> bool:
 class MessageHeader:
     INVALID_SOURCE_ID = 0xFFFFFFFF
 
-    _SYNC0 = 0x2E  # '.'
-    _SYNC1 = 0x31  # '1'
+    SYNC0 = 0x2E  # '.'
+    SYNC1 = 0x31  # '1'
 
-    SYNC = bytes((_SYNC0, _SYNC1))
+    SYNC = bytes((SYNC0, SYNC1))
 
     _FORMAT = '<BB2xIBBHIII'
     _SIZE: int = struct.calcsize(_FORMAT)
@@ -287,7 +287,7 @@ class MessageHeader:
         if payload is not None:
             self.calculate_crc(payload)
 
-        args = (MessageHeader._SYNC0, MessageHeader._SYNC1, self.crc, self.protocol_version, self.message_version,
+        args = (MessageHeader.SYNC0, MessageHeader.SYNC1, self.crc, self.protocol_version, self.message_version,
                 int(self.message_type), self.sequence_number, self.payload_size_bytes, self.source_identifier)
         if buffer is None:
             buffer = struct.pack(MessageHeader._FORMAT, *args)
@@ -325,7 +325,7 @@ class MessageHeader:
          self.sequence_number, self.payload_size_bytes, self.source_identifier) = \
             struct.unpack_from(MessageHeader._FORMAT, buffer, offset)
 
-        if sync0 != MessageHeader._SYNC0 or sync1 != MessageHeader._SYNC1:
+        if sync0 != MessageHeader.SYNC0 or sync1 != MessageHeader.SYNC1:
             raise ValueError('Received invalid sync bytes. [sync0=0x%02x, sync1=0x%02x]' % (sync0, sync1))
 
         # Validate the CRC, assuming the message payload follows in the buffer.

--- a/python/fusion_engine_client/parsers/decoder.py
+++ b/python/fusion_engine_client/parsers/decoder.py
@@ -144,11 +144,11 @@ class FusionEngineDecoder:
             elif self._header is None:
                 # Explicitly check for the first two sync bytes to be a bit more efficient than doing it inside the @ref
                 # MessageHeader.unpack() with an exception.
-                if self._buffer[0] != MessageHeader._SYNC0:
+                if self._buffer[0] != MessageHeader.SYNC0:
                     self._buffer.pop(0)
                     self._bytes_processed += 1
                     continue
-                if self._buffer[1] != MessageHeader._SYNC1:
+                elif self._buffer[1] != MessageHeader.SYNC1:
                     self._buffer.pop(0)
                     self._bytes_processed += 1
                     continue

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -417,14 +417,14 @@ class MixedLogReader(object):
                     byte0 = self.input_file.read(1)[0]
                     self.total_bytes_read += 1
                     while True:
-                        if byte0 == MessageHeader._SYNC0:
+                        if byte0 == MessageHeader.SYNC0:
                             if self.total_bytes_read + 1 >= self.max_bytes:
                                 self.logger.debug('Max read length exceeded (%d B).' % self.max_bytes)
                                 return False
 
                             byte1 = self.input_file.read(1)[0]
                             self.total_bytes_read += 1
-                            if byte1 == MessageHeader._SYNC1:
+                            if byte1 == MessageHeader.SYNC1:
                                 self.input_file.seek(-2, os.SEEK_CUR)
                                 self.total_bytes_read -= 2
                                 if self.logger.isEnabledFor(logging.getTraceLevel(depth=3)):


### PR DESCRIPTION
This is typically not needed since the data is almost always read by a decoder, which already performs sync.