### PR TITLE
[FUS-1268] Add portibility defintions for armcc.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -130,4 +130,7 @@ cc_library(
         "src/point_one/fusion_engine/messages/data_version.h",
     ],
     includes = ["src"],
+    deps = [
+        ":common",
+    ],
 )

--- a/Doxyfile
+++ b/Doxyfile
@@ -2165,7 +2165,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2173,7 +2173,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2205,7 +2205,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = P1_ALIGNAS(N)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/point_one/fusion_engine/common/logging.h
+++ b/src/point_one/fusion_engine/common/logging.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "point_one/fusion_engine/common/portability.h"
+
 // Use Google Logging Library (glog).
 #if P1_HAVE_GLOG && !P1_NO_LOGGING
 #  include <glog/logging.h>
@@ -26,8 +28,6 @@
 // Disable logging support at compile time.
 #else // Logging disabled
 
-#  include <ostream>
-
 #  if !P1_NO_LOGGING
 #    undef P1_NO_LOGGING
 #    define P1_NO_LOGGING 1
@@ -37,9 +37,11 @@ namespace point_one {
 namespace fusion_engine {
 namespace common {
 
-class NullStream : public std::ostream {
+class NullStream : public p1_ostream {
  public:
-  NullStream() : std::ostream(nullptr) {}
+#  if P1_HAVE_STD_OSTREAM
+  NullStream() : p1_ostream(nullptr) {}
+#  endif
 };
 
 template <class T>

--- a/src/point_one/fusion_engine/common/logging.h
+++ b/src/point_one/fusion_engine/common/logging.h
@@ -28,6 +28,8 @@
 // Disable logging support at compile time.
 #else // Logging disabled
 
+#  include <stdlib.h> // For abort().
+
 #  if !P1_NO_LOGGING
 #    undef P1_NO_LOGGING
 #    define P1_NO_LOGGING 1
@@ -68,7 +70,9 @@ class NullMessage {
 #  define COMPACT_GOOGLE_LOG_INFO P1_NULL_MESSAGE
 #  define COMPACT_GOOGLE_LOG_WARNING P1_NULL_MESSAGE
 #  define COMPACT_GOOGLE_LOG_ERROR P1_NULL_MESSAGE
-#  define COMPACT_GOOGLE_LOG_FATAL P1_NULL_MESSAGE
+#  define COMPACT_GOOGLE_LOG_FATAL \
+    abort();                       \
+    P1_NULL_MESSAGE
 
 #  define LOG(severity) COMPACT_GOOGLE_LOG_##severity.stream()
 #  define LOG_IF(severity, condition) COMPACT_GOOGLE_LOG_##severity.stream()

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -14,8 +14,6 @@
 #  pragma warning(disable : 4200)
 #endif
 
-#include <ostream>
-
 #include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/data_version.h"
 #include "point_one/fusion_engine/messages/defs.h"
@@ -329,7 +327,7 @@ P1_CONSTEXPR_FUNC const char* to_string(ConfigType type) {
  * @brief @ref ConfigType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, ConfigType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, ConfigType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -428,8 +426,7 @@ P1_CONSTEXPR_FUNC const char* to_string(InterfaceConfigType type) {
  * @brief @ref InterfaceConfigType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                InterfaceConfigType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, InterfaceConfigType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -469,8 +466,7 @@ P1_CONSTEXPR_FUNC const char* to_string(ConfigurationSource source) {
  * @brief @ref ConfigurationSource stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                ConfigurationSource source) {
+inline p1_ostream& operator<<(p1_ostream& stream, ConfigurationSource source) {
   stream << to_string(source) << " (" << (int)source << ")";
   return stream;
 }
@@ -516,7 +512,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SaveAction action) {
  * @brief @ref SaveAction stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, SaveAction action) {
+inline p1_ostream& operator<<(p1_ostream& stream, SaveAction action) {
   stream << to_string(action) << " (" << (int)action << ")";
   return stream;
 }
@@ -526,11 +522,11 @@ inline std::ostream& operator<<(std::ostream& stream, SaveAction action) {
  *        version 1.0).
  * @ingroup config_and_ctrl_messages
  *
- * The format of the parameter value, @ref config_change_data, is defined by the
- * the specified @ref config_type (@ref ConfigType). For example, an antenna
- * lever arm definition may require three 32-bit `float` values, one for each
- * axis, while a serial port baud rate may be specified as single 32-bit
- * unsigned integer (`uint32_t`).
+ * The format of the parameter value is defined by the the specified @ref
+ * config_type (@ref ConfigType). For example, an antenna lever arm definition
+ * may require three 32-bit `float` values, one for each axis, while a serial
+ * port baud rate may be specified as single 32-bit unsigned integer
+ * (`uint32_t`).
  *
  * Not all parameters defined in @ref ConfigType are supported on all devices.
  *
@@ -543,7 +539,7 @@ inline std::ostream& operator<<(std::ostream& stream, SaveAction action) {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) SetConfigMessage : public MessagePayload {
+struct P1_ALIGNAS(4) SetConfigMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SET_CONFIG;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -556,8 +552,8 @@ struct alignas(4) SetConfigMessage : public MessagePayload {
    * included unless the config_type is @ref ConfigType::INTERFACE_CONFIG. In
    * that case the @ref config_length_bytes should be
    * `sizeof(InterfaceConfigSubmessage)` with a an @ref
-   * InterfaceConfigSubmessage as the @ref config_change_data without any
-   * further payload.
+   * InterfaceConfigSubmessage as the parameter value without any further
+   * payload.
    */
   static constexpr uint8_t FLAG_REVERT_TO_DEFAULT = 0x02;
 
@@ -569,7 +565,7 @@ struct alignas(4) SetConfigMessage : public MessagePayload {
 
   uint8_t reserved[1] = {0};
 
-  /** The size of the parameter value, @ref config_change_data (in bytes). */
+  /** The size of the parameter value (in bytes). */
   uint32_t config_length_bytes = 0;
 
   /**
@@ -578,7 +574,7 @@ struct alignas(4) SetConfigMessage : public MessagePayload {
    * The size and format of the contents is specified by the @ref config_type.
    * See @ref ConfigType.
    */
-  uint8_t config_change_data[0];
+  // uint8_t config_change_data[0];
 };
 
 /**
@@ -591,7 +587,7 @@ struct alignas(4) SetConfigMessage : public MessagePayload {
  * requested parameter value or an error @ref Response value if the request did
  * not succeed.
  */
-struct alignas(4) GetConfigMessage : public MessagePayload {
+struct P1_ALIGNAS(4) GetConfigMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::GET_CONFIG;
   static constexpr uint8_t MESSAGE_VERSION = 1;
 
@@ -608,7 +604,7 @@ struct alignas(4) GetConfigMessage : public MessagePayload {
    * InterfaceConfigSubmessage must be added to the end of this message with
    * empty @ref InterfaceConfigSubmessage::config_data.
    */
-  uint8_t optional_submessage_header[0];
+  //uint8_t optional_submessage_header[0];
 };
 
 /**
@@ -620,7 +616,7 @@ struct alignas(4) GetConfigMessage : public MessagePayload {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) SaveConfigMessage : public MessagePayload {
+struct P1_ALIGNAS(4) SaveConfigMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SAVE_CONFIG;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -651,7 +647,7 @@ struct alignas(4) SaveConfigMessage : public MessagePayload {
  * rejected requests, will receive a @ref ConfigResponseMessage, not a
  * @ref CommandResponseMessage.
  */
-struct alignas(4) ConfigResponseMessage : public MessagePayload {
+struct P1_ALIGNAS(4) ConfigResponseMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::CONFIG_RESPONSE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -675,7 +671,7 @@ struct alignas(4) ConfigResponseMessage : public MessagePayload {
 
   uint8_t reserved[3] = {0};
 
-  /** The size of the parameter value, @ref config_change_data (in bytes). */
+  /** The size of the parameter value (in bytes). */
   uint32_t config_length_bytes = 0;
 
   /**
@@ -684,7 +680,7 @@ struct alignas(4) ConfigResponseMessage : public MessagePayload {
    * The size and format of the contents is specified by the @ref config_type.
    * See @ref ConfigType.
    */
-  uint8_t config_change_data[0];
+  //uint8_t config_change_data[0];
 };
 
 /**************************************************************************/ /**
@@ -695,7 +691,7 @@ struct alignas(4) ConfigResponseMessage : public MessagePayload {
 /**
  * @brief A 3-dimensional vector (used for lever arms, etc.).
  */
-struct alignas(4) Point3f {
+struct P1_ALIGNAS(4) Point3f {
   float x = NAN;
   float y = NAN;
   float z = NAN;
@@ -714,7 +710,7 @@ struct alignas(4) Point3f {
  *   IMU pointed vertically upward, with the top of the IMU pointed towards the
  *   trunk)
  */
-struct alignas(4) CoarseOrientation {
+struct P1_ALIGNAS(4) CoarseOrientation {
   enum class Direction : uint8_t {
     FORWARD = 0, ///< Aligned with vehicle +x axis.
     BACKWARD = 1, ///< Aligned with vehicle -x axis.
@@ -826,8 +822,7 @@ P1_CONSTEXPR_FUNC const char* to_string(VehicleModel vehicle_model) {
  * @brief @ref VehicleModel stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                VehicleModel vehicle_model) {
+inline p1_ostream& operator<<(p1_ostream& stream, VehicleModel vehicle_model) {
   stream << to_string(vehicle_model) << " (" << (int)vehicle_model << ")";
   return stream;
 }
@@ -836,7 +831,7 @@ inline std::ostream& operator<<(std::ostream& stream,
  * @brief Information about the vehicle including model and dimensions.
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) VehicleDetails {
+struct P1_ALIGNAS(4) VehicleDetails {
   VehicleModel vehicle_model = VehicleModel::UNKNOWN_VEHICLE;
   uint8_t reserved[10] = {0};
 
@@ -915,8 +910,8 @@ P1_CONSTEXPR_FUNC const char* to_string(WheelSensorType wheel_sensor_type) {
  * @brief @ref WheelSensorType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                WheelSensorType wheel_sensor_type) {
+inline p1_ostream& operator<<(p1_ostream& stream,
+                              WheelSensorType wheel_sensor_type) {
   stream << to_string(wheel_sensor_type) << " (" << (int)wheel_sensor_type
          << ")";
   return stream;
@@ -975,8 +970,8 @@ P1_CONSTEXPR_FUNC const char* to_string(AppliedSpeedType applied_speed_type) {
  * @brief @ref AppliedSpeedType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                AppliedSpeedType applied_speed_type) {
+inline p1_ostream& operator<<(p1_ostream& stream,
+                              AppliedSpeedType applied_speed_type) {
   stream << to_string(applied_speed_type) << " (" << (int)applied_speed_type
          << ")";
   return stream;
@@ -1024,8 +1019,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SteeringType steering_type) {
  * @brief @ref SteeringType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                SteeringType steering_type) {
+inline p1_ostream& operator<<(p1_ostream& stream, SteeringType steering_type) {
   stream << to_string(steering_type) << " (" << (int)steering_type << ")";
   return stream;
 }
@@ -1053,7 +1047,7 @@ inline std::ostream& operator<<(std::ostream& stream,
  * - @ref WheelTickInput
  * - @ref VehicleTickInput
  */
-struct alignas(4) WheelConfig {
+struct P1_ALIGNAS(4) WheelConfig {
   /**
    * The type of vehicle/wheel speed measurements produced by the vehicle.
    */
@@ -1158,7 +1152,7 @@ P1_CONSTEXPR_FUNC const char* to_string(TickMode tick_mode) {
  * @brief @ref TickMode stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, TickMode tick_mode) {
+inline p1_ostream& operator<<(p1_ostream& stream, TickMode tick_mode) {
   stream << to_string(tick_mode) << " (" << (int)tick_mode << ")";
   return stream;
 }
@@ -1200,8 +1194,8 @@ P1_CONSTEXPR_FUNC const char* to_string(TickDirection tick_direction) {
  * @brief @ref TickDirection stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                TickDirection tick_direction) {
+inline p1_ostream& operator<<(p1_ostream& stream,
+                              TickDirection tick_direction) {
   stream << to_string(tick_direction) << " (" << (int)tick_direction << ")";
   return stream;
 }
@@ -1227,7 +1221,7 @@ inline std::ostream& operator<<(std::ostream& stream,
  *
  * See also @ref VehicleTickInput.
  */
-struct alignas(4) HardwareTickConfig {
+struct P1_ALIGNAS(4) HardwareTickConfig {
   /**
    * If enabled -- tick mode is not @ref TickMode::OFF -- the device will
    * accumulate ticks received on the I/O pin, and use them as an indication of
@@ -1271,7 +1265,7 @@ struct alignas(4) HardwareTickConfig {
  * 
  * @ref HeadingOutput
  */
-struct alignas(4) HeadingBias {
+struct P1_ALIGNAS(4) HeadingBias {
   /**
    * The offset between the heading measured by a secondary GNSS device and the
    * vehicle's direction of motion in the horizontal plane (defined by the
@@ -1332,8 +1326,8 @@ P1_CONSTEXPR_FUNC const char* to_string(IonoDelayModel iono_delay_model) {
  * @brief @ref IonoDelayModel stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                IonoDelayModel iono_delay_model) {
+inline p1_ostream& operator<<(p1_ostream& stream,
+                              IonoDelayModel iono_delay_model) {
   stream << to_string(iono_delay_model) << " (" << (int)iono_delay_model << ")";
   return stream;
 }
@@ -1342,7 +1336,7 @@ inline std::ostream& operator<<(std::ostream& stream,
  * @brief Ionospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) IonosphereConfig {
+struct P1_ALIGNAS(4) IonosphereConfig {
   /** The ionospheric delay model to use. */
   IonoDelayModel iono_delay_model = IonoDelayModel::AUTO;
 
@@ -1379,8 +1373,8 @@ P1_CONSTEXPR_FUNC const char* to_string(TropoDelayModel tropo_delay_model) {
  * @brief @ref TropoDelayModel stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream,
-                                TropoDelayModel tropo_delay_model) {
+inline p1_ostream& operator<<(p1_ostream& stream,
+                              TropoDelayModel tropo_delay_model) {
   stream << to_string(tropo_delay_model) << " (" << (int)tropo_delay_model
          << ")";
   return stream;
@@ -1390,7 +1384,7 @@ inline std::ostream& operator<<(std::ostream& stream,
  * @brief Tropospheric delay model configuration.
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) TroposphereConfig {
+struct P1_ALIGNAS(4) TroposphereConfig {
   /** The tropospheric delay model to use. */
   TropoDelayModel tropo_delay_model = TropoDelayModel::AUTO;
 
@@ -1449,7 +1443,7 @@ P1_CONSTEXPR_FUNC const char* to_string(ProtocolType val) {
  * @brief @ref ProtocolType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, ProtocolType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, ProtocolType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -1521,7 +1515,7 @@ P1_CONSTEXPR_FUNC const char* to_string(TransportType val) {
  * @brief @ref TransportType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, TransportType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, TransportType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -1535,7 +1529,7 @@ inline std::ostream& operator<<(std::ostream& stream, TransportType val) {
  * On most devices, serial ports (UARTs) use 1-based numbering: the first serial
  * port is typically index 1 (UART1).
  */
-struct alignas(4) InterfaceID {
+struct P1_ALIGNAS(4) InterfaceID {
   /** The interface's transport type. **/
   TransportType type = TransportType::INVALID;
   /** An identifier for the instance of this transport. */
@@ -1580,7 +1574,7 @@ struct alignas(4) InterfaceID {
  * @brief @ref InterfaceID stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, InterfaceID val) {
+inline p1_ostream& operator<<(p1_ostream& stream, InterfaceID val) {
   stream << "[type=" << val.type << ", index=" << (int)val.index << "]";
   return stream;
 }
@@ -1674,7 +1668,7 @@ P1_CONSTEXPR_FUNC const char* to_string(NmeaMessageType value) {
  * @brief @ref NmeaMessageType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, NmeaMessageType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, NmeaMessageType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -1816,7 +1810,7 @@ P1_CONSTEXPR_FUNC const char* to_string(MessageRate value) {
  * @brief @ref MessageRate stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, MessageRate val) {
+inline p1_ostream& operator<<(p1_ostream& stream, MessageRate val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -1914,7 +1908,7 @@ inline std::ostream& operator<<(std::ostream& stream, MessageRate val) {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) SetMessageRate : public MessagePayload {
+struct P1_ALIGNAS(4) SetMessageRate : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SET_MESSAGE_RATE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -1970,7 +1964,7 @@ struct alignas(4) SetMessageRate : public MessagePayload {
  * requested values or an error @ref Response value if the request did not
  * succeed.
  */
-struct alignas(4) GetMessageRate : public MessagePayload {
+struct P1_ALIGNAS(4) GetMessageRate : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::GET_MESSAGE_RATE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -2004,7 +1998,7 @@ struct alignas(4) GetMessageRate : public MessagePayload {
  * @brief An element of a @ref MessageRateResponse message.
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) MessageRateResponseEntry {
+struct P1_ALIGNAS(4) MessageRateResponseEntry {
   /**
    * Flag to indicate the active value for this configuration differs from the
    * value saved to persistent memory.
@@ -2042,7 +2036,7 @@ struct alignas(4) MessageRateResponseEntry {
  *        MessageType::MESSAGE_RATE_RESPONSE, version 1.1).
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) MessageRateResponse : public MessagePayload {
+struct P1_ALIGNAS(4) MessageRateResponse : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::MESSAGE_RATE_RESPONSE;
   static constexpr uint8_t MESSAGE_VERSION = 1;
@@ -2098,7 +2092,7 @@ P1_CONSTEXPR_FUNC const char* to_string(DataType type) {
  * @brief @ref DataType stream operator.
  * @ingroup config_and_ctrl_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, DataType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, DataType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -2112,7 +2106,7 @@ inline std::ostream& operator<<(std::ostream& stream, DataType val) {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) ImportDataMessage {
+struct P1_ALIGNAS(4) ImportDataMessage {
   static constexpr MessageType MESSAGE_TYPE = MessageType::IMPORT_DATA;
   static constexpr uint8_t MESSAGE_VERSION = 0;
   /**
@@ -2146,7 +2140,7 @@ struct alignas(4) ImportDataMessage {
  * # Expected Response
  * The device will respond with a @ref PlatformStorageDataMessage.
  */
-struct alignas(4) ExportDataMessage {
+struct P1_ALIGNAS(4) ExportDataMessage {
   static constexpr MessageType MESSAGE_TYPE = MessageType::EXPORT_DATA;
   static constexpr uint8_t MESSAGE_VERSION = 0;
   /**
@@ -2173,7 +2167,7 @@ struct alignas(4) ExportDataMessage {
  * - Version 2: Changed data_validity to a @ref Response enum and added
  *              @ref source field.
  */
-struct alignas(4) PlatformStorageDataMessage {
+struct P1_ALIGNAS(4) PlatformStorageDataMessage {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::PLATFORM_STORAGE_DATA;
   static constexpr uint8_t MESSAGE_VERSION = 2;
@@ -2226,7 +2220,7 @@ struct alignas(4) PlatformStorageDataMessage {
  * }
  * ```
  */
-struct alignas(4) InterfaceConfigSubmessage {
+struct P1_ALIGNAS(4) InterfaceConfigSubmessage {
   /**
    * The interface ID to target.
    *
@@ -2249,7 +2243,7 @@ struct alignas(4) InterfaceConfigSubmessage {
    * The size and format of the contents is specified by the @ref subtype.
    * See @ref InterfaceConfigType.
    */
-  uint8_t config_data[0];
+  //uint8_t config_data[0];
 };
 
 /** @} */

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -48,7 +48,7 @@ namespace messages {
  *        MessageType::COMMAND_RESPONSE, version 1.0).
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) CommandResponseMessage : public MessagePayload {
+struct P1_ALIGNAS(4) CommandResponseMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::COMMAND_RESPONSE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -79,7 +79,7 @@ struct alignas(4) CommandResponseMessage : public MessagePayload {
  * # Expected Response
  * The requested message type, or @ref CommandResponseMessage on error.
  */
-struct alignas(4) MessageRequest : public MessagePayload {
+struct P1_ALIGNAS(4) MessageRequest : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::MESSAGE_REQUEST;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -101,7 +101,7 @@ struct alignas(4) MessageRequest : public MessagePayload {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) ResetRequest : public MessagePayload {
+struct P1_ALIGNAS(4) ResetRequest : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::RESET_REQUEST;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -341,7 +341,7 @@ struct alignas(4) ResetRequest : public MessagePayload {
  *  "OS Version", "Receiver Version"}
  * ```
  */
-struct alignas(4) VersionInfoMessage : public MessagePayload {
+struct P1_ALIGNAS(4) VersionInfoMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::VERSION_INFO;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -374,7 +374,7 @@ struct alignas(4) VersionInfoMessage : public MessagePayload {
    *     message.engine_version_length);
    * ```
    */
-  char fw_version_str[0];
+  //char fw_version_str[0];
 };
 
 /**
@@ -422,7 +422,7 @@ P1_CONSTEXPR_FUNC const char* to_string(DeviceType val) {
  * @brief @ref DeviceType stream operator.
  * @ingroup measurement_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, DeviceType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, DeviceType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -447,7 +447,7 @@ inline std::ostream& operator<<(std::ostream& stream, DeviceType val) {
  * {MessageHeader, VersionInfoMessage, "HW ID", "User ID", "Receiver ID"}
  * ```
  */
-struct alignas(4) DeviceIDMessage : public MessagePayload {
+struct P1_ALIGNAS(4) DeviceIDMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::DEVICE_ID;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -479,7 +479,7 @@ struct alignas(4) DeviceIDMessage : public MessagePayload {
    *     hw_id_data + message.hw_id_length + message.user_id_length);
    * ```
    */
-  uint8_t hw_id_data[0];
+  //uint8_t hw_id_data[0];
 };
 
 /**
@@ -487,7 +487,7 @@ struct alignas(4) DeviceIDMessage : public MessagePayload {
  *        MessageType::EVENT_NOTIFICATION, version 1.0).
  * @ingroup config_and_ctrl_messages
  */
-struct alignas(4) EventNotificationMessage : public MessagePayload {
+struct P1_ALIGNAS(4) EventNotificationMessage : public MessagePayload {
   enum class EventType : uint8_t {
     /**
      * Event containing a logged message string from the device.
@@ -553,7 +553,7 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
   /** A bitmask of flags associated with the event. */
   uint64_t event_flags = 0;
 
-  /** The number of bytes in the @ref event_description string. */
+  /** The number of bytes in the event description string. */
   uint16_t event_description_len_bytes = 0;
 
   uint8_t reserved2[2] = {0};
@@ -564,7 +564,7 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
    * This is used for populating string describing the event, or other binary
    * content where applicable.
    */
-  char* event_description[0];
+  //char* event_description[0];
 };
 
 /**
@@ -576,7 +576,7 @@ struct alignas(4) EventNotificationMessage : public MessagePayload {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) ShutdownRequest : public MessagePayload {
+struct P1_ALIGNAS(4) ShutdownRequest : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SHUTDOWN_REQUEST;
   static constexpr uint8_t MESSAGE_VERSION = 0;
   /** A bitmask of flags associated with the event. */
@@ -593,7 +593,7 @@ struct alignas(4) ShutdownRequest : public MessagePayload {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) StartupRequest : public MessagePayload {
+struct P1_ALIGNAS(4) StartupRequest : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::STARTUP_REQUEST;
   static constexpr uint8_t MESSAGE_VERSION = 0;
   /** A bitmask of flags associated with the event. */

--- a/src/point_one/fusion_engine/messages/data_version.cc
+++ b/src/point_one/fusion_engine/messages/data_version.cc
@@ -7,7 +7,11 @@ namespace fusion_engine {
 namespace messages {
 
 p1_ostream& operator<<(p1_ostream& stream, const DataVersion& ver) {
-  return stream << ToString(ver);
+  if (ver.IsValid()) {
+    return stream << (int)ver.major_version << "." << ver.minor_version;
+  } else {
+    return stream << "<invalid>";
+  }
 }
 
 std::string ToString(const DataVersion& ver) {

--- a/src/point_one/fusion_engine/messages/data_version.cc
+++ b/src/point_one/fusion_engine/messages/data_version.cc
@@ -6,18 +6,17 @@ namespace point_one {
 namespace fusion_engine {
 namespace messages {
 
-std::ostream& operator<<(std::ostream& stream, const DataVersion& ver) {
-  if (ver.IsValid()) {
-    return stream << (int)ver.major_version << "." << ver.minor_version;
-  } else {
-    return stream << "<invalid>";
-  }
+p1_ostream& operator<<(p1_ostream& stream, const DataVersion& ver) {
+  return stream << ToString(ver);
 }
 
 std::string ToString(const DataVersion& ver) {
-  std::stringstream ss;
-  ss << ver;
-  return ss.str();
+  if (ver.IsValid()) {
+    return std::to_string(ver.major_version) + "." +
+           std::to_string(ver.minor_version);
+  } else {
+    return "<invalid>";
+  }
 }
 
 DataVersion FromString(const char* str) {

--- a/src/point_one/fusion_engine/messages/data_version.h
+++ b/src/point_one/fusion_engine/messages/data_version.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <iostream>
 #include <string>
+
+#include "point_one/fusion_engine/common/portability.h"
 
 namespace point_one {
 namespace fusion_engine {
@@ -19,7 +20,7 @@ namespace messages {
  * The version is considered invalid if @ref major_version is 0xFF and @ref minor_version is
  * 0xFFFF.
  */
-struct alignas(4) DataVersion {
+struct P1_ALIGNAS(4) DataVersion {
   // The reserved bytes must be 0xFF for backward compatibility.
   uint8_t reserved = 0xFF;
   uint8_t major_version = 0xFF;
@@ -79,7 +80,7 @@ inline constexpr bool operator>=(const DataVersion& a, const DataVersion& b) {
  * // Ver: 3.2
  * ```
  */
-std::ostream& operator<<(std::ostream& stream, const DataVersion& ver);
+p1_ostream& operator<<(p1_ostream& stream, const DataVersion& ver);
 
 std::string ToString(const DataVersion& ver);
 

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -7,7 +7,6 @@
 
 #include <cmath> // For NAN
 #include <cstdint>
-#include <ostream>
 #include <string>
 
 #include "point_one/fusion_engine/common/portability.h"
@@ -269,7 +268,7 @@ P1_CONSTEXPR_FUNC const char* to_string(MessageType type) {
  * @brief @ref MessageType stream operator.
  * @ingroup enum_definitions
  */
-inline std::ostream& operator<<(std::ostream& stream, MessageType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, MessageType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -408,7 +407,7 @@ P1_CONSTEXPR_FUNC const char* to_string(Response val) {
 /**
  * @brief @ref Response stream operator.
  */
-inline std::ostream& operator<<(std::ostream& stream, Response val) {
+inline p1_ostream& operator<<(p1_ostream& stream, Response val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -487,7 +486,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SolutionType type) {
  * @brief @ref SolutionType stream operator.
  * @ingroup enum_definitions
  */
-inline std::ostream& operator<<(std::ostream& stream, SolutionType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, SolutionType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -501,7 +500,7 @@ inline std::ostream& operator<<(std::ostream& stream, SolutionType type) {
  * to the start of the device), UNIX times (referenced to January 1, 1970), or
  * GPS times (referenced to January 6, 1980).
  */
-struct alignas(4) Timestamp {
+struct P1_ALIGNAS(4) Timestamp {
   static constexpr uint32_t INVALID = 0xFFFFFFFF;
 
   /**
@@ -521,7 +520,7 @@ struct alignas(4) Timestamp {
  * The header is followed immediately in the binary stream by the message
  * payload specified by @ref message_type.
  */
-struct alignas(4) MessageHeader {
+struct P1_ALIGNAS(4) MessageHeader {
   static constexpr uint8_t SYNC0 = 0x2E; // '.'
   static constexpr uint8_t SYNC1 = 0x31; // '1'
 

--- a/src/point_one/fusion_engine/messages/device.h
+++ b/src/point_one/fusion_engine/messages/device.h
@@ -37,7 +37,7 @@ namespace messages {
  * SystemStatusMessage) may be associated using their @ref p1_time values.
  */
 
-struct alignas(4) SystemStatusMessage : public MessagePayload {
+struct P1_ALIGNAS(4) SystemStatusMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::SYSTEM_STATUS;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 

--- a/src/point_one/fusion_engine/messages/fault_control.h
+++ b/src/point_one/fusion_engine/messages/fault_control.h
@@ -134,7 +134,7 @@ P1_CONSTEXPR_FUNC const char* to_string(FaultType type) {
  * @brief @ref ConfigurationSource stream operator.
  * @ingroup fault_control_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, FaultType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, FaultType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -181,7 +181,7 @@ P1_CONSTEXPR_FUNC const char* to_string(CoComType type) {
  * @brief @ref CoComType stream operator.
  * @ingroup fault_control_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, CoComType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, CoComType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -204,7 +204,7 @@ inline std::ostream& operator<<(std::ostream& stream, CoComType type) {
  * The device will respond with a @ref CommandResponseMessage indicating whether
  * or not the request succeeded.
  */
-struct alignas(4) FaultControlMessage : public MessagePayload {
+struct P1_ALIGNAS(4) FaultControlMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::FAULT_CONTROL;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 

--- a/src/point_one/fusion_engine/messages/gnss_corrections.h
+++ b/src/point_one/fusion_engine/messages/gnss_corrections.h
@@ -29,7 +29,7 @@ namespace messages {
  * @brief L-Band frame contents (@ref MessageType::LBAND_FRAME, version 1.0).
  * @ingroup gnss_corrections
  */
-struct alignas(4) LBandFrameMessage : public MessagePayload {
+struct P1_ALIGNAS(4) LBandFrameMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::LBAND_FRAME;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -57,9 +57,9 @@ struct alignas(4) LBandFrameMessage : public MessagePayload {
   float doppler_hz = 0;
 
   /**
-   * A pointer to the beginning of the demodulated L-Band frame data.
+   * The beginning of the demodulated L-Band frame data.
    */
-  uint8_t data_payload[0];
+  // uint8_t data_payload[0];
 };
 
 #pragma pack(pop)

--- a/src/point_one/fusion_engine/messages/measurements.h
+++ b/src/point_one/fusion_engine/messages/measurements.h
@@ -83,7 +83,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SensorDataSource val) {
  * @brief @ref SensorDataSource stream operator.
  * @ingroup measurement_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, SensorDataSource val) {
+inline p1_ostream& operator<<(p1_ostream& stream, SensorDataSource val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -144,7 +144,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SystemTimeSource val) {
  * @brief @ref SystemTimeSource stream operator.
  * @ingroup measurement_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, SystemTimeSource val) {
+inline p1_ostream& operator<<(p1_ostream& stream, SystemTimeSource val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -190,7 +190,7 @@ inline std::ostream& operator<<(std::ostream& stream, SystemTimeSource val) {
  * synchronization of the P1 time clock model. This is intended for internal
  * use only.
  */
-struct alignas(4) MeasurementDetails {
+struct P1_ALIGNAS(4) MeasurementDetails {
   /**
    * The measurement time of applicability, if available, in a user-specified
    * time base. The source of this value is specified in @ref
@@ -243,7 +243,7 @@ struct alignas(4) MeasurementDetails {
  *
  * See also @ref RawIMUOutput.
  */
-struct alignas(4) IMUOutput : public MessagePayload {
+struct P1_ALIGNAS(4) IMUOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::IMU_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -286,7 +286,7 @@ struct alignas(4) IMUOutput : public MessagePayload {
  *
  * See also @ref IMUOutput.
  */
-struct alignas(4) RawIMUOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawIMUOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::RAW_IMU_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -365,7 +365,7 @@ P1_CONSTEXPR_FUNC const char* to_string(GearType val) {
  * @brief @ref GearType stream operator.
  * @ingroup measurement_messages
  */
-inline std::ostream& operator<<(std::ostream& stream, GearType val) {
+inline p1_ostream& operator<<(p1_ostream& stream, GearType val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -394,7 +394,7 @@ inline std::ostream& operator<<(std::ostream& stream, GearType val) {
  *
  * See also @ref WheelSpeedOutput for measurement output.
  */
-struct alignas(4) WheelSpeedInput : public MessagePayload {
+struct P1_ALIGNAS(4) WheelSpeedInput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::WHEEL_SPEED_INPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -472,7 +472,7 @@ struct alignas(4) WheelSpeedInput : public MessagePayload {
  *
  * See also @ref WheelSpeedInput and @ref RawWheelSpeedOutput.
  */
-struct alignas(4) WheelSpeedOutput : public MessagePayload {
+struct P1_ALIGNAS(4) WheelSpeedOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::WHEEL_SPEED_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -526,7 +526,7 @@ struct alignas(4) WheelSpeedOutput : public MessagePayload {
  *
  * See @ref WheelSpeedOutput for more details. See also @ref WheelSpeedInput.
  */
-struct alignas(4) RawWheelSpeedOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawWheelSpeedOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::RAW_WHEEL_SPEED_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -610,7 +610,7 @@ struct alignas(4) RawWheelSpeedOutput : public MessagePayload {
  *
  * See also @ref VehicleSpeedOutput for measurement output.
  */
-struct alignas(4) VehicleSpeedInput : public MessagePayload {
+struct P1_ALIGNAS(4) VehicleSpeedInput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::VEHICLE_SPEED_INPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -669,7 +669,7 @@ struct alignas(4) VehicleSpeedInput : public MessagePayload {
  *
  * See also @ref VehicleSpeedInput and @ref RawVehicleSpeedOutput.
  */
-struct alignas(4) VehicleSpeedOutput : public MessagePayload {
+struct P1_ALIGNAS(4) VehicleSpeedOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::VEHICLE_SPEED_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -718,7 +718,7 @@ struct alignas(4) VehicleSpeedOutput : public MessagePayload {
  * See @ref VehicleSpeedOutput for more details. See also @ref
  * VehicleSpeedInput.
  */
-struct alignas(4) RawVehicleSpeedOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawVehicleSpeedOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::RAW_VEHICLE_SPEED_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -784,7 +784,7 @@ struct alignas(4) RawVehicleSpeedOutput : public MessagePayload {
  *
  * See also @ref RawWheelTickOutput for measurement output.
  */
-struct alignas(4) WheelTickInput : public MessagePayload {
+struct P1_ALIGNAS(4) WheelTickInput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::WHEEL_TICK_INPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -842,7 +842,7 @@ struct alignas(4) WheelTickInput : public MessagePayload {
  *
  * See also @ref WheelTickInput.
  */
-struct alignas(4) RawWheelTickOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawWheelTickOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::RAW_WHEEL_TICK_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -917,7 +917,7 @@ struct alignas(4) RawWheelTickOutput : public MessagePayload {
  *
  * See also @ref RawVehicleTickOutput for measurement output.
  */
-struct alignas(4) VehicleTickInput : public MessagePayload {
+struct P1_ALIGNAS(4) VehicleTickInput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::VEHICLE_TICK_INPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -957,7 +957,7 @@ struct alignas(4) VehicleTickInput : public MessagePayload {
  *
  * See also @ref VehicleTickInput.
  */
-struct alignas(4) RawVehicleTickOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawVehicleTickOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::RAW_VEHICLE_TICK_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -1000,7 +1000,7 @@ struct alignas(4) RawVehicleTickOutput : public MessagePayload {
  * future. It should not used for new development. See @ref WheelSpeedInput and
  * @ref WheelSpeedOutput instead.
  */
-struct alignas(4) DeprecatedWheelSpeedMeasurement : public MessagePayload {
+struct P1_ALIGNAS(4) DeprecatedWheelSpeedMeasurement : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::DEPRECATED_WHEEL_SPEED_MEASUREMENT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -1051,7 +1051,7 @@ struct alignas(4) DeprecatedWheelSpeedMeasurement : public MessagePayload {
  * future. It should not used for new development. See @ref VehicleSpeedInput
  * and @ref VehicleSpeedOutput instead.
  */
-struct alignas(4) DeprecatedVehicleSpeedMeasurement : public MessagePayload {
+struct P1_ALIGNAS(4) DeprecatedVehicleSpeedMeasurement : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::DEPRECATED_VEHICLE_SPEED_MEASUREMENT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
@@ -1097,7 +1097,7 @@ struct alignas(4) DeprecatedVehicleSpeedMeasurement : public MessagePayload {
  *
  * See also @ref HeadingOutput.
  */
-struct alignas(4) RawHeadingOutput : public MessagePayload {
+struct P1_ALIGNAS(4) RawHeadingOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::RAW_HEADING_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -1162,7 +1162,7 @@ struct alignas(4) RawHeadingOutput : public MessagePayload {
  * 
  * See also @ref RawHeadingOutput and @ref SolutionType::Invalid.
  */
-struct alignas(4) HeadingOutput : public MessagePayload {
+struct P1_ALIGNAS(4) HeadingOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::HEADING_OUTPUT;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 

--- a/src/point_one/fusion_engine/messages/ros.h
+++ b/src/point_one/fusion_engine/messages/ros.h
@@ -40,7 +40,7 @@ namespace ros {
  *
  * See http://docs.ros.org/api/geometry_msgs/html/msg/Pose.html.
  */
-struct alignas(4) PoseMessage : public MessagePayload {
+struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::ROS_POSE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -77,7 +77,7 @@ struct alignas(4) PoseMessage : public MessagePayload {
  *
  * See http://docs.ros.org/api/gps_common/html/msg/GPSFix.html.
  */
-struct alignas(4) GPSFixMessage : public MessagePayload {
+struct P1_ALIGNAS(4) GPSFixMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::ROS_GPS_FIX;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -266,7 +266,7 @@ struct alignas(4) GPSFixMessage : public MessagePayload {
  * frame from the original IMU orientation using the FusionEngine sensor
  * calibration data.
  */
-struct alignas(4) IMUMessage : public MessagePayload {
+struct P1_ALIGNAS(4) IMUMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::ROS_IMU;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 

--- a/src/point_one/fusion_engine/messages/signal_defs.h
+++ b/src/point_one/fusion_engine/messages/signal_defs.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <ostream>
 
 #include "point_one/fusion_engine/common/portability.h"
 
@@ -89,7 +88,7 @@ P1_CONSTEXPR_FUNC const char* to_string(SatelliteType type) {
  * @brief @ref SatelliteType stream operator.
  * @ingroup enum_definitions
  */
-inline std::ostream& operator<<(std::ostream& stream, SatelliteType type) {
+inline p1_ostream& operator<<(p1_ostream& stream, SatelliteType type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }
@@ -269,7 +268,7 @@ P1_CONSTEXPR_FUNC const char* to_string(FrequencyBand type) {
  * @brief @ref FrequencyBand stream operator.
  * @ingroup enum_definitions
  */
-inline std::ostream& operator<<(std::ostream& stream, FrequencyBand type) {
+inline p1_ostream& operator<<(p1_ostream& stream, FrequencyBand type) {
   stream << to_string(type) << " (" << (int)type << ")";
   return stream;
 }

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -37,7 +37,7 @@ namespace messages {
  * GNSSInfoMessage, @ref GNSSSatelliteMessage, etc.) may be associated using
  * their @ref p1_time values.
  */
-struct alignas(4) PoseMessage : public MessagePayload {
+struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::POSE;
   static constexpr uint8_t MESSAGE_VERSION = 1;
   static constexpr int16_t INVALID_UNDULATION = INT16_MIN;
@@ -159,7 +159,7 @@ struct alignas(4) PoseMessage : public MessagePayload {
  *        version 1.0).
  * @ingroup solution_messages
  */
-struct alignas(4) PoseAuxMessage : public MessagePayload {
+struct P1_ALIGNAS(4) PoseAuxMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::POSE_AUX;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -208,7 +208,7 @@ struct alignas(4) PoseAuxMessage : public MessagePayload {
  * @ref corrections_age, and @ref baseline_distance fields. Attempting to use
  * those fields on version 0 messages will result in undefined behavior.
  */
-struct alignas(4) GNSSInfoMessage : public MessagePayload {
+struct P1_ALIGNAS(4) GNSSInfoMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::GNSS_INFO;
   static constexpr uint8_t MESSAGE_VERSION = 1;
 
@@ -286,7 +286,7 @@ struct alignas(4) GNSSInfoMessage : public MessagePayload {
  * {MessageHeader, GNSSSatelliteMessage, SatelliteInfo, SatelliteInfo, ...}
  * ```
  */
-struct alignas(4) GNSSSatelliteMessage : public MessagePayload {
+struct P1_ALIGNAS(4) GNSSSatelliteMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::GNSS_SATELLITE;
   static constexpr uint8_t MESSAGE_VERSION = 0;
 
@@ -310,7 +310,7 @@ struct alignas(4) GNSSSatelliteMessage : public MessagePayload {
  * tracked by the receiver but not used for navigation, or may just be expected
  * according to available ephemeris data.
  */
-struct alignas(4) SatelliteInfo {
+struct P1_ALIGNAS(4) SatelliteInfo {
   /**
    * @defgroup satellite_usage Bit definitions for the satellite usage bitmask
    *           (@ref SatelliteInfo::usage).
@@ -391,7 +391,7 @@ P1_CONSTEXPR_FUNC const char* to_string(CalibrationStage val) {
 /**
  * @brief @ref CalibrationStage stream operator.
  */
-inline std::ostream& operator<<(std::ostream& stream, CalibrationStage val) {
+inline p1_ostream& operator<<(p1_ostream& stream, CalibrationStage val) {
   stream << to_string(val) << " (" << (int)val << ")";
   return stream;
 }
@@ -402,7 +402,7 @@ inline std::ostream& operator<<(std::ostream& stream, CalibrationStage val) {
  * @brief
  * @ingroup solution_messages
  */
-struct alignas(4) CalibrationStatusMessage : public MessagePayload {
+struct P1_ALIGNAS(4) CalibrationStatusMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::CALIBRATION_STATUS;
   static constexpr uint8_t MESSAGE_VERSION = 1;
 
@@ -501,7 +501,7 @@ struct alignas(4) CalibrationStatusMessage : public MessagePayload {
  * PoseMessage, @ref GNSSSatelliteMessage, etc.) may be associated using
  * their @ref p1_time values.
  */
-struct alignas(4) RelativeENUPositionMessage : public MessagePayload {
+struct P1_ALIGNAS(4) RelativeENUPositionMessage : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE =
       MessageType::RELATIVE_ENU_POSITION;
   static constexpr uint8_t MESSAGE_VERSION = 1;

--- a/src/point_one/fusion_engine/parsers/fusion_engine_framer.cc
+++ b/src/point_one/fusion_engine/parsers/fusion_engine_framer.cc
@@ -63,22 +63,22 @@ p1_ostream& operator<<(p1_ostream& stream,
 
 /**
  * @brief Wrap an integer so it will be output to a stream as its hex
- * representation.
+ *        representation.
  *
  * For example:
  *
  * ```cpp
- *   std::cout << PrintableValue((int16_t)-255) << std::endl;
- *   std::cout << PrintableValue((uint32_t)255) << std::endl;
- *   std::cout << PrintableValue((uint8_t)48) << std::endl;
+ * std::cout << HexPrintableValue((int16_t)-255) << std::endl;
+ * std::cout << HexPrintableValue((uint32_t)255) << std::endl;
+ * std::cout << HexPrintableValue((uint8_t)48) << std::endl;
  * ```
  *
  * generates the following output:
  *
  * ```
- *   0xff01
- *   0x000000ff
- *   0x30 ('0')
+ * 0xff01
+ * 0x000000ff
+ * 0x30 ('0')
  * ```
  *
  * @tparam T The type of the value parameter (inferred implicitly).

--- a/src/point_one/fusion_engine/parsers/fusion_engine_framer.h
+++ b/src/point_one/fusion_engine/parsers/fusion_engine_framer.h
@@ -44,6 +44,13 @@ namespace parsers {
  */
 class FusionEngineFramer {
  public:
+#if P1_HAVE_STD_FUNCTION
+  using MessageCallback =
+      std::function<void(const messages::MessageHeader&, const void*)>;
+#else
+  using MessageCallback = void (*)(const messages::MessageHeader&, const void*);
+#endif
+
   /**
    * @brief Construct a framer instance with no buffer allocated.
    *
@@ -103,11 +110,7 @@ class FusionEngineFramer {
    * @param callback The function to be called with the message header and a
    *        pointer to the message payload.
    */
-  void SetMessageCallback(
-      std::function<void(const messages::MessageHeader&, const void*)>
-          callback) {
-    callback_ = callback;
-  }
+  void SetMessageCallback(MessageCallback callback) { callback_ = callback; }
 
   /**
    * @brief Reset the framer and discard all pending data.
@@ -133,11 +136,16 @@ class FusionEngineFramer {
     DATA = 3,
   };
 
-  std::function<void(const messages::MessageHeader&, const void*)> callback_;
+#if P1_HAVE_STD_FUNCTION
+  MessageCallback callback_;
+#else
+  MessageCallback callback_ = nullptr;
+#endif
 
   bool warn_on_error_ = true;
-
+#if P1_HAVE_STD_SMART_PTR
   std::unique_ptr<uint8_t[]> managed_buffer_;
+#endif
   uint8_t* buffer_{nullptr};
   uint32_t capacity_bytes_{0};
 


### PR DESCRIPTION
This is a series of changes to allow the fusion engine client code to be built in armcc.

Some quirks of armcc:
- `NAN` macro bug
- no `alignsas` support
- no `std::function` support
- not `#include <typetraits>`
- No support for glibc file operations.
- `#include <ostream>` brings in fopen.
- `#include <iomanip>` brings in fopen.
- No smart pointers
- `std::vector` brings in fopen
- Doesn’t like `uint8_t test[0];`
