### PR TITLE
Fixed issues with UTC and system time extraction.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2033,19 +2033,13 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             # Log summary.
             str(self.reader.t0),
             system_time_to_str(self.reader.get_system_t0(), is_seconds=True).replace(' time', ':'),
-            # Note: Temporarily replacing <br> so it doesn't get stripped by _data_to_table().
-            self._gps_sec_to_string(t0_gps) \
-                .replace('<br>', (' (approximated)' if t0_is_approx else '') + '<brbak>') \
-                .replace('<brbak>', '<br>'),
+            self._gps_sec_to_string(t0_gps, is_approx=t0_is_approx),
             log_duration_sec,
             '',
             # Processed data summary.
             str(processed_t0),
             system_time_to_str(processed_system_t0, is_seconds=True).replace(' time', ':'),
-            # Note: Temporarily replacing <br> so it doesn't get stripped by _data_to_table().
-            self._gps_sec_to_string(t0_gps) \
-                .replace('<br>', (' (approximated)' if t0_is_approx else '') + '<brbak>') \
-                .replace('<brbak>', '<br>'),
+            self._gps_sec_to_string(t0_gps, is_approx=t0_is_approx),
             '%.1f seconds' % processing_duration_sec,
         ]
         time_table = _data_to_table(['Description', 'Time'], [descriptions, times])
@@ -2190,7 +2184,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
         return selected_type
 
     @classmethod
-    def _gps_sec_to_string(cls, gps_time_sec):
+    def _gps_sec_to_string(cls, gps_time_sec, is_approx: bool = False):
         if isinstance(gps_time_sec, Timestamp):
             gps_time_sec = float(gps_time_sec)
 
@@ -2201,8 +2195,10 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             week = int(gps_time_sec / SECS_PER_WEEK)
             tow_sec = gps_time_sec - week * SECS_PER_WEEK
             utc_time = gpstime.fromgps(gps_time_sec)
-            return "GPS: %d:%.3f (%.3f sec)<br>UTC: %s" %\
-                   (week, tow_sec, gps_time_sec, datetime_to_string(utc_time, decimals=3))
+            approx_str = ' (approximated)' if is_approx else ''
+            return "GPS: %d:%.3f (%.3f sec)%s<br>UTC: %s%s" %\
+                   (week, tow_sec, gps_time_sec, approx_str,
+                    datetime_to_string(utc_time, decimals=3), approx_str)
 
     @classmethod
     def _get_measurement_time(cls, data, time_source: SystemTimeSource) -> np.ndarray:

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -543,7 +543,7 @@ class MessagePayload:
         measurement_details = getattr(self, 'details', None)
         if isinstance(measurement_details, MeasurementDetails):
             if measurement_details.measurement_time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
-                return float(measurement_details.measurement_time)
+                return float(measurement_details.measurement_time) * 1e9
             else:
                 return np.nan
         else:

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -355,13 +355,11 @@ class GNSSInfoMessage(MessagePayload):
         string = 'GNSS Info Message @ %s\n' % str(self.p1_time)
         if self.gps_time:
             gps_str = f'{str(self.gps_time).replace("GPS: ", "")}'
-        else:
-            gps_str = 'None'
-        string += '  GPS time: %s\n' % gps_str
-        if self.utc_time:
             utc_str = f'{datetime_to_string(self.gps_time.as_utc())}'
         else:
+            gps_str = 'None'
             utc_str = 'None'
+        string += '  GPS time: %s\n' % gps_str
         string += '  UTC time: %s\n' % utc_str
         string += '  UTC leap second: %s\n' % \
                   (self.leap_second if self.leap_second != GNSSInfoMessage.INVALID_LEAP_SECOND else 'unknown')


### PR DESCRIPTION
# Fixes
- Fixed UTC time access in GNSSInfoMessage `str()` operator
- Fixed system time units for timestamped-on-reception measurements
- Mark both GPS and UTC times as approximate on `p1_display` index if applicable