### PR TITLE
Added Python 3.6 and 3.7 compatibility.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,7 @@ FusionEngine message specification.
 * [Using A Python Virtual Environment](#using-a-python-virtual-environment)
 
 ### Requirements
-- Python 3.8 or later
+- Python 3.6 or later
 
 ### Directory Structure
   - `python/` - Python source files
@@ -74,7 +74,7 @@ FusionEngine message specification.
 
 #### Install From PyPI
 
-1. Install Python 3.8 (or later) and pip.
+1. Install Python (3.6 or later) and pip.
 2. Install the `fusione-engine-client` module, including all analysis and data processing tools:
    ```bash
    python3 -m pip install fusion-engine-client[all]
@@ -88,7 +88,7 @@ FusionEngine message specification.
 
 #### Install From Source (Use In Another Python Project)
 
-1. Install Python 3.8 (or later) and pip.
+1. Install Python (3.6 or later) and pip.
 2. Clone a copy of this repository:
    ```bash
    git clone https://github.com/PointOneNav/fusion-engine-client.git
@@ -107,7 +107,7 @@ FusionEngine message specification.
 
 #### Install From Source (Development)
 
-1. Install Python 3.8 (or later) and pip.
+1. Install Python (3.6 or later) and pip.
 2. Clone a copy of this repository:
    ```bash
    git clone https://github.com/PointOneNav/fusion-engine-client.git

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import re
 import struct
@@ -382,7 +380,7 @@ class MessagePayload:
 
     _UNSPECIFIED_VERSION = 0x100
 
-    message_type_to_class: Dict[MessageType, Type[MessagePayload]] = {}
+    message_type_to_class: Dict[MessageType, Type['MessagePayload']] = {}
     message_type_by_name: Dict[str, MessageType] = {}
 
     def __init__(self):
@@ -393,12 +391,12 @@ class MessagePayload:
         MessagePayload.message_type_by_name[cls.__name__] = cls.get_type()
 
     @classmethod
-    def get_message_class(cls, message_type: MessageType) -> Type[MessagePayload]:
+    def get_message_class(cls, message_type: MessageType) -> Type['MessagePayload']:
         return MessagePayload.message_type_to_class.get(message_type, None)
 
     @classmethod
     def find_matching_message_types(cls, pattern: Union[str, List[str]], return_class: bool = False) -> \
-        Union[Set[MessageType], Set[MessagePayload]]:
+        Union[Set[MessageType], Set['MessagePayload']]:
         """!
         @brief Find one or more @ref MessageType%s that match the specified pattern(s).
 

--- a/python/fusion_engine_client/parsers/file_index.py
+++ b/python/fusion_engine_client/parsers/file_index.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Union
 
 from collections import namedtuple
@@ -280,7 +278,7 @@ class FileIndex(object):
             raw_data.tofile(index_path)
 
     def get_time_range(self, start: Union[Timestamp, float] = None, stop: Union[Timestamp, float] = None,
-                       hint: str = None, time_range: TimeRange = None) -> FileIndex:
+                       hint: str = None, time_range: TimeRange = None) -> 'FileIndex':
         """!
         @brief Get a subset of the contents for a specified time range.
 

--- a/python/fusion_engine_client/utils/time_range.py
+++ b/python/fusion_engine_client/utils/time_range.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import copy
 import math
 from typing import Optional, Tuple, Union
@@ -141,7 +139,7 @@ class TimeRange(object):
         self._in_range_started = False
         self._in_range_ended = False
 
-    def make_absolute(self, p1_t0: Timestamp = None, in_place: bool = True) -> TimeRange:
+    def make_absolute(self, p1_t0: Timestamp = None, in_place: bool = True) -> 'TimeRange':
         if not in_place:
             return copy.deepcopy(self).make_absolute(p1_t0=p1_t0)
 
@@ -159,7 +157,7 @@ class TimeRange(object):
 
         return self
 
-    def intersect(self, other: TimeRange, in_place: bool = True) -> TimeRange:
+    def intersect(self, other: 'TimeRange', in_place: bool = True) -> 'TimeRange':
         if not in_place:
             return copy.copy(self).intersect(other)
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,7 +9,7 @@ colorama>=0.4.4
 palettable>=3.3.0
 plotly>=4.0.0
 pymap3d>=2.4.3
-scipy>=1.6.0
+scipy>=1.5.0
 
 # Required for development only.
-packaging>=23.0.0
+packaging>=21.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,7 @@ version = find_version('fusion_engine_client', '__init__.py')
 
 tools_requirements = set([
     'argparse-formatter>=1.4',
-    'scipy>=1.6.0',
+    'scipy>=1.5.0',
 ])
 
 display_requirements = set([
@@ -28,7 +28,7 @@ display_requirements = set([
 ]) | tools_requirements
 
 dev_requirements = set([
-    'packaging>=23.0.0',
+    'packaging>=21.0.0',
 ]) | tools_requirements
 
 all_requirements = tools_requirements | display_requirements | dev_requirements

--- a/python/setup.py
+++ b/python/setup.py
@@ -58,6 +58,8 @@ for the latest FusionEngine message specification.
         'Operating System :: POSIX',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -72,7 +74,7 @@ for the latest FusionEngine message specification.
         'bin/p1_extract',
         'bin/p1_print',
     ],
-    python_requires='>3.7',
+    python_requires='>=3.6',
     setup_requires=[
         'wheel>=0.36.2',
     ],


### PR DESCRIPTION
# Changes
- Lowered `scipy` and `packaging` requirements to versions available for Python 3.6
  - These older versions should be fine for the few features we use from these modules
- Removed the user of `__future__.annotations` (added in Python 3.7) and switched to old-style quoted type hints for self-references