### PR TITLE
Fixed missing typedefs and incorrect include for Keil ARMCC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ FetchContent_Declare(
     GIT_TAG v1.15.2
 )
 FetchContent_Populate(fusion_engine_client)
-add_subdirectory(${fusion_engine_client_SOURCE_DIR})
+add_subdirectory(${fusion_engine_client_SOURCE_DIR}
+                 ${fusion_engine_client_BINARY_DIR})
 
 add_executable(example_app main.cc)
 target_link_libraries(example_app PUBLIC fusion_engine_client)

--- a/examples/external_cmake_project/CMakeLists.txt
+++ b/examples/external_cmake_project/CMakeLists.txt
@@ -49,7 +49,8 @@ FetchContent_Declare(
     GIT_TAG v1.16.0
 )
 FetchContent_Populate(fusion_engine_client)
-add_subdirectory(${fusion_engine_client_SOURCE_DIR})
+add_subdirectory(${fusion_engine_client_SOURCE_DIR}
+                 ${fusion_engine_client_BINARY_DIR})
 
 # Now we define an example application that uses the fusion-engine-client
 # library. In your own code, you can link any add_executable() or add_library()

--- a/src/point_one/fusion_engine/common/portability.h
+++ b/src/point_one/fusion_engine/common/portability.h
@@ -37,9 +37,9 @@
 
 // Support ARM CC quirks
 #ifdef __CC_ARM
-#  include "typedefs.h"
-// ARM CC bug http://www.keil.com/forum/60227/
-#  define __ESCAPE__(__x) (__x)
+// The cstdint included with Keil ARM CC does not appear to include stdint.h
+// or to define most of the stdint types (uint8_t, etc.), even though it should.
+#  include <stdint.h>
 #  define P1_HAVE_STD_FUNCTION 0
 #  define P1_HAVE_STD_OSTREAM 0
 #  define P1_HAVE_STD_SMART_PTR 0


### PR DESCRIPTION
# Fixes
- Fixed missing typedefs and incorrect include for Keil ARMCC
- Fixed missing binary dir specification in cmake external project instructions (required by newer versions of cmake)