### PR TITLE
Minor p1_print improvements.

### DIFF
--- a/python/bin/p1_print
+++ b/python/bin/p1_print
@@ -196,10 +196,12 @@ other types of data.
     first_p1_time_sec = None
     last_p1_time_sec = None
     newest_p1_time = None
+    newest_p1_message_type = None
 
     first_system_time_sec = None
     last_system_time_sec = None
     newest_system_time_sec = None
+    newest_system_message_type = None
 
     total_messages = 0
     bytes_decoded = 0
@@ -223,16 +225,20 @@ other types of data.
                             first_p1_time_sec = float(p1_time)
                             last_p1_time_sec = float(p1_time)
                             newest_p1_time = p1_time
+                            newest_p1_message_type = header.message_type
                         else:
                             # For P1 time, we allow a small tolerance to account for normal latency between measurements
                             # and computed data like pose solutions.
-                            dt_sec = float(newest_p1_time - p1_time)
+                            dt_sec = float(p1_time - newest_p1_time)
                             if dt_sec < -0.2:
                                 _logger.warning(
-                                    'P1 time restart detected after %s. [message=%s, p1_time=%s, offset=%d B]' %
-                                    (str(newest_p1_time), header.get_type_string(), str(p1_time), offset_bytes))
+                                    'Backwards/restarted P1 time detected after %s (%s). [new_message=%s, '
+                                    'new_p1_time=%s, offset=%d B]' %
+                                    (str(newest_p1_time), str(newest_p1_message_type), header.get_type_string(),
+                                     str(p1_time), offset_bytes))
                             last_p1_time_sec = max(last_p1_time_sec, float(p1_time))
                             newest_p1_time = p1_time
+                            newest_p1_message_type = header.message_type
 
                     system_time_sec = message.get_system_time_sec()
                     if system_time_sec is not None:
@@ -240,16 +246,19 @@ other types of data.
                             first_system_time_sec = system_time_sec
                             last_system_time_sec = system_time_sec
                             newest_system_time_sec = system_time_sec
+                            newest_system_message_type = header.message_type
                         else:
                             if system_time_sec < newest_system_time_sec:
                                 _logger.warning(
-                                    'System time restart detected after %s. [message=%s, system_time=%s, offset=%d B]' %
+                                    'Backwards/restarted system time detected after %s (%s). [new_message=%s, '
+                                    'new_system_time=%s, offset=%d B]' %
                                     (system_time_to_str(newest_system_time_sec, is_seconds=True),
-                                     header.get_type_string(),
+                                     str(newest_system_message_type), header.get_type_string(),
                                      system_time_to_str(system_time_sec, is_seconds=True),
                                      offset_bytes))
                             last_system_time_sec = max(last_system_time_sec, system_time_sec)
                             newest_system_time_sec = system_time_sec
+                            newest_system_message_type = header.message_type
             else:
                 print_message(header, message, offset_bytes, format=options.format)
     except (BrokenPipeError, KeyboardInterrupt) as e:

--- a/python/fusion_engine_client/messages/device.py
+++ b/python/fusion_engine_client/messages/device.py
@@ -46,7 +46,7 @@ class SystemStatusMessage(MessagePayload):
 
     def __str__(self):
         return f"""\
-System Status Message @ %{self.p1_time}
+System Status Message @ {self.p1_time}
   GNSS Temperature: {self.gnss_temperature_degc:.1f} deg C"""
 
     @classmethod

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -5,15 +5,6 @@
 
 #pragma once
 
-// If we are compiling under MSVC, disable warning C4200:
-//   nonstandard extension used: zero-sized array in struct/union
-// Zero-sized arrays are supported by MSVC, GCC, and Clang, and we use them as
-// convenience placeholders for variable sized message payloads.
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable : 4200)
-#endif
-
 #include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/data_version.h"
 #include "point_one/fusion_engine/messages/defs.h"
@@ -2295,7 +2286,3 @@ struct P1_ALIGNAS(4) InterfaceConfigSubmessage {
 } // namespace messages
 } // namespace fusion_engine
 } // namespace point_one
-
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -2233,8 +2233,8 @@ struct P1_ALIGNAS(4) PlatformStorageDataMessage {
   DataVersion data_version;
   /** Number of bytes in data contents. */
   uint32_t data_length_bytes = 0;
-
   /**
+
    * This in then followed by an array of data_length_bytes bytes for the data
    * contents.
    */

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1270,12 +1270,12 @@ struct P1_ALIGNAS(4) HardwareTickConfig {
 /**
  * @brief Heading bias horizontal/vertical configuration settings.
  * @ingroup config_and_ctrl_messages
- * 
+ *
  * @note
  * Both HeadingBias values must be set for the system to use them.
  * If one value is NOT set, the system will not output the corrected
  * heading message.
- * 
+ *
  * @ref HeadingOutput
  */
 struct P1_ALIGNAS(4) HeadingBias {

--- a/src/point_one/fusion_engine/messages/control.h
+++ b/src/point_one/fusion_engine/messages/control.h
@@ -5,15 +5,6 @@
 
 #pragma once
 
-// If we are compiling under MSVC, disable warning C4200:
-//   nonstandard extension used: zero-sized array in struct/union
-// Zero-sized arrays are supported by MSVC, GCC, and Clang, and we use them as
-// convenience placeholders for variable sized message payloads.
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable : 4200)
-#endif
-
 #include "point_one/fusion_engine/common/portability.h"
 #include "point_one/fusion_engine/messages/defs.h"
 
@@ -606,7 +597,3 @@ struct P1_ALIGNAS(4) StartupRequest : public MessagePayload {
 } // namespace messages
 } // namespace fusion_engine
 } // namespace point_one
-
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif


### PR DESCRIPTION
# Changes
- Include the previous message type in the warning message when a backwards time jump is detected
- Removed deprecated MSVC warning disable for zero-length array members (removed in v1.21.0)