### PR TITLE
Add P1 time preceding reset to event log

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1883,7 +1883,13 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             self.logger.info('No event notification data available.')
             return
 
-        table_columns = ['Relative Time (s)', 'System Time (s)', 'Event', 'Flags', 'Description']
+        times_before_resets = self.extract_times_before_reset()
+        if (len(times_before_resets) > 0):
+            table_columns = ['Relative Time (s)', 'System Time (s)', 'Previous P1 Time (s)', 'Event', 'Flags',
+                             'Description']
+        else:
+            table_columns = ['Relative Time (s)', 'System Time (s)', 'Event', 'Flags', 'Description']
+
         rows = []
         system_t0_ns = self.reader.get_system_t0_ns()
         max_bytes = 128
@@ -1907,10 +1913,15 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             rows.append([
                 f'{(system_time_ns - system_t0_ns) / 1e9:.3f}' if system_time_ns is not None else 'N/A',
                 f'{system_time_ns / 1e9:.3f}' if system_time_ns is not None else 'N/A',
+                'N/A',
                 event_type.to_string(include_value=True),
                 f'0x{flags:016X}' if flags is not None else 'N/A',
                 description_str.replace('<', '[').replace('>', ']').replace('\n', '<br>'),
             ])
+
+            if isinstance(message, EventNotificationMessage) and message.event_type == EventType.RESET:
+                if system_time_ns in times_before_resets:
+                    rows[-1][2] = f'{(times_before_resets[system_time_ns]):.3f}'
 
         table_html = _data_to_table(table_columns, rows, row_major=True)
         body_html = f"""\
@@ -1919,6 +1930,30 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
 """
 
         self._add_page(name='event_log', html_body=body_html, title="Event Log")
+
+    def extract_times_before_reset(self):
+        # Iterate backwards over indices to extract resets and the P1 times before them.
+        curr_reset_time = None
+        get_time_before_reset = False
+
+        times_before_resets = {}
+        file_index = self.reader.get_index()
+        for entry in file_index[::-1]:
+            if entry.type == MessageType.EVENT_NOTIFICATION or get_time_before_reset:
+                # Parse entry at index for payload.
+                header, payload = self.reader.reader.parse_entry_at_index(entry)
+                system_time_ns = payload.get_system_time_ns()
+
+                if get_time_before_reset and payload.get_p1_time() is not None:
+                    times_before_resets[curr_reset_time] = payload.get_p1_time().seconds
+                    get_time_before_reset = False
+
+                # Check if event is a reset.
+                if entry.type == MessageType.EVENT_NOTIFICATION and payload.event_type == EventType.RESET:
+                    curr_reset_time = system_time_ns
+                    get_time_before_reset = True
+
+        return times_before_resets
 
     def generate_index(self, auto_open=True):
         """!

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -496,11 +496,15 @@ class MixedLogReader(object):
         header = MessageHeader()
         header.unpack(data, warn_on_unrecognized=False)
         payload_bytes = self.input_file.read(header.payload_size_bytes)
-        cls = message_type_to_class.get(header.message_type, None)
-        payload = cls()
-        payload.unpack(buffer=payload_bytes, offset=0, message_version=header.message_version)
 
-        return header, payload
+        try:
+            cls = message_type_to_class.get(header.message_type, None)
+            payload = cls()
+            payload.unpack(buffer=payload_bytes, offset=0, message_version=header.message_version)
+            return header, payload
+        # If class is not recognized, return payload_bytes.
+        except Exception as e:
+            return header, payload_bytes
 
     def clear_filters(self):
         self.filter_in_place(key=None, clear_existing=True)


### PR DESCRIPTION
# New Features
- Adds column to event log that displays the last valid P1 time (if available) before all resets