### PR TITLE
Set text=auto git attribute to ignore line endings in mixed-OS setups.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Specifically, for Windows users who clone the repo in Windows (converts to Windows CRLF line endings by default), and then _also_ access the repo in Linux through WSL, all files in the repository will showed up as modified if this is not set.