### PR TITLE
Added reset recovery timing plot.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -391,9 +391,7 @@ class Analyzer(object):
                 except StopIteration:
                     break
 
-                if next_reset_index is not None and pose_index >= next_reset_index:
-                    break
-                elif invalid_p1_time is None:
+                if invalid_p1_time is None:
                     if message.solution_type == SolutionType.Invalid:
                         invalid_p1_time = message.get_p1_time()
                         invalid_p1_time_sec = float(invalid_p1_time)

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2505,7 +2505,7 @@ Load and display information stored in a FusionEngine binary file.
         '-m', '--measurements', action=ExtendedBooleanAction,
         help="Plot incoming measurement data (slow). Ignored if --plot is specified.")
     plot_group.add_argument(
-        '--time-axis', choices=('absolute', 'abs', 'relative', 'rel'), default='relative',
+        '--time-axis', choices=('absolute', 'abs', 'relative', 'rel'), default='absolute',
         help="Specify the way in which time will be plotted:"
              "\n- absolute, abs - Absolute P1 or system timestamps"
              "\n- relative, rel - Elapsed time since the start of the log")

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -622,6 +622,15 @@ class DataLoader(object):
         # Done.
         return result
 
+    def read_next(self, return_bytes: bool = False, return_message_index: bool = False):
+        header, payload, message_bytes, message_index = self.reader.read_next()
+        result = [header, payload]
+        if return_bytes:
+            result.append(message_bytes)
+        if return_message_index:
+            result.append(message_index)
+        return result
+
     def get_t0(self):
         return self.t0
 

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -631,8 +631,11 @@ class DataLoader(object):
     def get_system_t0_ns(self):
         return self.system_t0_ns
 
-    def get_index(self):
+    def get_index(self) -> FileIndex:
         return self.reader.get_index()
+
+    def get_log_reader(self) -> MixedLogReader:
+        return self.reader
 
     def get_input_path(self):
         return self.reader.input_file.name

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -1,5 +1,6 @@
 import string
 import struct
+from typing import Sequence
 
 from construct import (Struct, Int64ul, Int16ul, Int8ul, Padding, this, Bytes, PaddedString)
 
@@ -591,6 +592,15 @@ class EventNotificationMessage(MessagePayload):
                 return self.event_description.decode('utf-8')
             except UnicodeDecodeError:
                 return repr(self.event_description)
+
+    @classmethod
+    def to_numpy(cls, messages: Sequence['EventNotificationMessage']):
+        result = {
+            'system_time': np.array([m.system_time_ns * 1e-9 for m in messages]),
+            'event_type': np.array([int(m.event_type) for m in messages], dtype=int),
+            'event_flags': np.array([int(m.event_flags) for m in messages], dtype=np.uint64),
+        }
+        return result
 
     @classmethod
     def _populate_data_byte_string(cls, data: bytes, max_bytes: int = None):

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -158,6 +158,18 @@ class MixedLogReader(object):
         if self.index_builder is not None:
             self.index_builder = file_index.FileIndexBuilder()
 
+    def seek_to_message(self, message_index: int, is_filtered_index: bool = False):
+        if self.index is None:
+            raise NotImplemented('A file index is required to seek by message index.')
+
+        max_index = len(self.index) if is_filtered_index else len(self._original_index)
+        if message_index < 0 or message_index >= max_index:
+            raise ValueError('Invalid message index.')
+
+        if not is_filtered_index:
+            self.clear_filters()
+        self.next_index_elem = message_index
+
     def seek_to_eof(self):
         self._read_next(force_eof=True)
 

--- a/python/tests/test_file_index.py
+++ b/python/tests/test_file_index.py
@@ -16,6 +16,7 @@ RAW_DATA = [
     (Timestamp(3.0), MessageType.POSE, 50),
     (Timestamp(4.0), MessageType.POSE, 60),
 ]
+RAW_DATA = [(*entry, i) for i, entry in enumerate(RAW_DATA)]
 
 
 def _test_time(time, raw_data):
@@ -34,11 +35,13 @@ def test_index():
     assert np.sum(idx) == len(raw)
     assert _test_time(index.time[idx], raw)
     assert (index.offset[idx] == [e[2] for e in raw]).all()
+    assert (index.message_index[idx] == [e[3] for e in raw]).all()
 
     raw = [e for e in RAW_DATA if e[1] == MessageType.VERSION_INFO]
     idx = index.type == MessageType.VERSION_INFO
     assert _test_time(index.time[idx], raw)
     assert (index.offset[idx] == [e[2] for e in raw]).all()
+    assert (index.message_index[idx] == [e[3] for e in raw]).all()
 
 
 def test_iterator():
@@ -54,11 +57,13 @@ def test_type_slice():
     raw = [e for e in RAW_DATA if e[1] == MessageType.POSE]
     assert len(pose_index) == len(raw)
     assert (pose_index.offset == [e[2] for e in raw]).all()
+    assert (pose_index.message_index == [e[3] for e in raw]).all()
 
     pose_index = index[(MessageType.POSE, MessageType.GNSS_INFO)]
     raw = [e for e in RAW_DATA if e[1] == MessageType.POSE or e[1] == MessageType.GNSS_INFO]
     assert len(pose_index) == len(raw)
     assert (pose_index.offset == [e[2] for e in raw]).all()
+    assert (pose_index.message_index == [e[3] for e in raw]).all()
 
 
 def test_index_slice():
@@ -69,36 +74,42 @@ def test_index_slice():
     raw = [RAW_DATA[3]]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access to the end.
     sliced_index = index[3:]
     raw = RAW_DATA[3:]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access from the beginning.
     sliced_index = index[:3]
     raw = RAW_DATA[:3]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access a range.
     sliced_index = index[2:4]
     raw = RAW_DATA[2:4]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access individual indices.
     sliced_index = index[(2, 3, 5)]
     raw = [RAW_DATA[i] for i in (2, 3, 5)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Pass empty set -- remove all elements.
     sliced_index = index[set()]
     raw = []
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
 
 def test_time_slice():
@@ -112,24 +123,28 @@ def test_time_slice():
     raw = RAW_DATA[_lower_bound(2.0):]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access from the beginning.
     sliced_index = index[:3.0]
     raw = RAW_DATA[:_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access a range.
     sliced_index = index[2.0:3.0]
     raw = RAW_DATA[_lower_bound(2.0):_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access by Timestamp.
     sliced_index = index[Timestamp(2.0):Timestamp(3.0)]
     raw = RAW_DATA[_lower_bound(2.0):_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
 
 def test_time_range_slice():
@@ -143,30 +158,35 @@ def test_time_range_slice():
     raw = RAW_DATA[_lower_bound(2.0):]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access from the beginning.
     sliced_index = index[TimeRange(end=3.0, absolute=True)]
     raw = RAW_DATA[:_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Access a range.
     sliced_index = index[TimeRange(start=2.0, end=3.0, absolute=True)]
     raw = RAW_DATA[_lower_bound(2.0):_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Relative time range, assuming the first P1 time is 1.0.
     sliced_index = index[TimeRange(start=1.0, end=2.0, absolute=False)]
     raw = RAW_DATA[_lower_bound(2.0):_lower_bound(3.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
     # Relative time range with an explicit t0 that differs from the actual index data: use the t0 in the range.
     sliced_index = index[TimeRange(start=1.0, end=2.0, absolute=False, p1_t0=Timestamp(0.0))]
     raw = RAW_DATA[_lower_bound(1.0):_lower_bound(2.0)]
     assert _test_time(sliced_index.time, raw)
     assert (sliced_index.offset == [e[2] for e in raw]).all()
+    assert (sliced_index.message_index == [e[3] for e in raw]).all()
 
 
 def test_time_slice_no_p1_time():


### PR DESCRIPTION
# New Features
- Added plot of reset recovery timing (time until reacquisition and navigation)
- Added `return_message_index` option to report the location of each message within the file
- Added `MixedLogReader` option to seek to a specific message by index

# Changes
- Allow multiple instances of `p1_display --plot NAME` argument
- Use `--time-axis=absolute` to display absolute P1/system time by default instead of relative time