### PR TITLE
Updated cmake install action.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -134,7 +134,7 @@ jobs:
 
     # Compile.
     - name: Install CMake 3.16.x
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.14.1
       with:
         cmake-version: '3.16.x'
 
@@ -249,7 +249,7 @@ jobs:
         key: doxygen-source-${{ matrix.doxygen }}
 
     - name: Install CMake 3.16.x
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.14.1
       with:
         cmake-version: '3.16.x'
 


### PR DESCRIPTION
As of 9/26/2023, the old version can no longer install CMake 3.16.x and gives the following error:

```
Run jwlawson/actions-setup-cmake@v1.4
  with:
    cmake-version: 3.16.x
    github-api-token: ***
Error: Unable to find version matching 3.16.x
```