### PR TITLE
Fixed exception when reading reserved message types in an index file, and fixed leap second download 404 error.

### DIFF
--- a/python/bin/p1_print
+++ b/python/bin/p1_print
@@ -202,8 +202,8 @@ other types of data.
                             newest_p1_time = p1_time
                             newest_p1_message_type = header.message_type
                         else:
-                            # For P1 time, we allow a small tolerance to account for normal latency between measurements
-                            # and computed data like pose solutions.
+                            # We allow a small tolerance to account for normal latency between measurements and computed
+                            # data like pose solutions, as well as latency between different types of measurements.
                             dt_sec = float(p1_time - newest_p1_time)
                             if dt_sec < -0.2:
                                 _logger.warning(
@@ -223,7 +223,10 @@ other types of data.
                             newest_system_time_sec = system_time_sec
                             newest_system_message_type = header.message_type
                         else:
-                            if system_time_sec < newest_system_time_sec:
+                            # We allow a small tolerance to account for normal latency between measurements and computed
+                            # data like pose solutions, as well as latency between different types of measurements.
+                            dt_sec = newest_system_time_sec - system_time_sec
+                            if dt_sec < -0.2:
                                 _logger.warning(
                                     'Backwards/restarted system time detected after %s (%s). [new_message=%s, '
                                     'new_system_time=%s, offset=%d B]' %

--- a/python/fusion_engine_client/parsers/file_index.py
+++ b/python/fusion_engine_client/parsers/file_index.py
@@ -26,7 +26,7 @@ class FileIndexIterator(object):
             raise StopIteration()
         else:
             entry = next(self.np_iterator)
-            return FileIndexEntry(time=Timestamp(entry[0]), type=self.enum_class(entry[1]),
+            return FileIndexEntry(time=Timestamp(entry[0]), type=self.enum_class(entry[1], raise_on_unrecognized=False),
                                   offset=entry[2], message_index=entry[3])
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,9 @@
 aenum>=3.1.1
-gpstime>=0.6.2
+# Note: Using the Point One fork of gpstime until the patch to download the leap
+# seconds file from alternate servers is merged:
+# https://gitlab.com/jrollins/gpstime/-/merge_requests/2
+git+https://github.com/PointOneNav/gpstime@1b39ea27698df36e08b9f9e8da7a57838d289191#egg=gpstime
+#gpstime>=0.6.2
 numpy>=1.16.0
 construct>=2.10.0
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -80,7 +80,11 @@ for the latest FusionEngine message specification.
     ],
     install_requires=[
         'aenum>=3.1.1',
-        'gpstime>=0.6.2',
+        # Note: Using the Point One fork of gpstime until the patch to download the leap
+        # seconds file from alternate servers is merged:
+        # https://gitlab.com/jrollins/gpstime/-/merge_requests/2
+        'gpstime @ git+https://github.com/PointOneNav/gpstime@1b39ea27698df36e08b9f9e8da7a57838d289191#egg=gpstime',
+        #'gpstime>=0.6.2',
         'numpy>=1.16.0',
         'construct>=2.10.0',
     ],


### PR DESCRIPTION
# Fixes
- Don't raise an exception if the index file contains unrecognized/reserved message types
- Allow a small ordering tolerance for system timestamps of incoming measurements in `p1_print` backwards check
- Switched `gpstime` library to P1 fork to resolve leap second file 404 error until https://gitlab.com/jrollins/gpstime/-/merge_requests/2 is merged upstream