### PR TITLE
Speed up CSV generation examples.

### DIFF
--- a/python/examples/extract_vehicle_speed_data.py
+++ b/python/examples/extract_vehicle_speed_data.py
@@ -61,8 +61,8 @@ Extract wheel speed data.
         logger.warning('No speed data found in log file.')
         sys.exit(2)
 
-    wheel_speed_data = result[WheelSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for corrected wheel speed data.
+    wheel_speed_data = result[WheelSpeedOutput.MESSAGE_TYPE]
     if len(wheel_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'wheel_speed_data.csv')
         logger.info("Generating '%s'." % path)
@@ -75,12 +75,12 @@ Extract wheel speed data.
                                     wheel_speed_data.front_right_speed_mps,
                                     wheel_speed_data.rear_left_speed_mps,
                                     wheel_speed_data.rear_right_speed_mps,
-                                    wheel_speed_data.gear], axis=1), fmt='%.6f')
+                                    wheel_speed_data.gear], axis=1), fmt=['%.6f'] * 6 + ['%d'])
     else:
         logger.info("No corrected wheel speed data.")
 
-    raw_wheel_speed_data = result[RawWheelSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for raw wheel speed data.
+    raw_wheel_speed_data = result[RawWheelSpeedOutput.MESSAGE_TYPE]
     if len(raw_wheel_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'raw_wheel_speed_data.csv')
         logger.info("Generating '%s'." % path)
@@ -93,12 +93,12 @@ Extract wheel speed data.
                                     raw_wheel_speed_data.front_right_speed_mps,
                                     raw_wheel_speed_data.rear_left_speed_mps,
                                     raw_wheel_speed_data.rear_right_speed_mps,
-                                    raw_wheel_speed_data.gear], axis=1), fmt='%.6f')
+                                    raw_wheel_speed_data.gear], axis=1), fmt=['%.6f'] * 6 + ['%d'])
     else:
         logger.info("No raw wheel speed data.")
 
-    vehicle_speed_data = result[VehicleSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for corrected vehicle speed data.
+    vehicle_speed_data = result[VehicleSpeedOutput.MESSAGE_TYPE]
     if len(vehicle_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'vehicle_speed_data.csv')
         logger.info("Generating '%s'." % path)
@@ -108,12 +108,12 @@ Extract wheel speed data.
             np.savetxt(path, np.stack([vehicle_speed_data.p1_time,
                                        gps_time,
                                        vehicle_speed_data.vehicle_speed_mps,
-                                       vehicle_speed_data.gear], axis=1), fmt='%.6f')
+                                       vehicle_speed_data.gear], axis=1), fmt=['%.6f'] * 3 + ['%d'])
     else:
         logger.info("No corrected vehicle speed data.")
 
-    raw_vehicle_speed_data = result[RawVehicleSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for raw vehicle speed data.
+    raw_vehicle_speed_data = result[RawVehicleSpeedOutput.MESSAGE_TYPE]
     if len(raw_vehicle_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'raw_vehicle_speed_data.csv')
         logger.info("Generating '%s'." % path)
@@ -123,7 +123,7 @@ Extract wheel speed data.
             np.savetxt(path, np.stack([raw_vehicle_speed_data.p1_time,
                                        gps_time,
                                        raw_vehicle_speed_data.vehicle_speed_mps,
-                                       raw_vehicle_speed_data.gear], axis=1), fmt='%.6f')
+                                       raw_vehicle_speed_data.gear], axis=1), fmt=['%.6f'] * 3 + ['%d'])
     else:
         logger.info("No raw vehicle speed data.")
 

--- a/python/examples/extract_vehicle_speed_data.py
+++ b/python/examples/extract_vehicle_speed_data.py
@@ -55,87 +55,75 @@ Extract wheel speed data.
             RawWheelSpeedOutput,
             VehicleSpeedOutput,
             RawVehicleSpeedOutput],
-        show_progress=True)
-    if all(len(d.messages) == 0 for d in result.values()):
+        show_progress=True,
+        return_numpy=True)
+    if all(len(d.p1_time) == 0 for d in result.values()):
         logger.warning('No speed data found in log file.')
         sys.exit(2)
 
     wheel_speed_data = result[WheelSpeedOutput.MESSAGE_TYPE]
-    raw_wheel_speed_data = result[RawWheelSpeedOutput.MESSAGE_TYPE]
-    vehicle_speed_data = result[VehicleSpeedOutput.MESSAGE_TYPE]
-    raw_vehicle_speed_data = result[RawVehicleSpeedOutput.MESSAGE_TYPE]
-
     # Generate a CSV file for corrected wheel speed data.
-    if len(wheel_speed_data.messages) != 0:
+    if len(wheel_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'wheel_speed_data.csv')
         logger.info("Generating '%s'." % path)
+        gps_time = reader.convert_to_gps_time(wheel_speed_data.p1_time)
         with open(path, 'w') as f:
             f.write('P1 Time (sec), GPS Time (sec), Front Left Speed (m/s), Front Right Speed (m/s), Back Left Speed (m/s), Back Right Speed (m/s), Gear\n')
-            for message in wheel_speed_data.messages:
-                gps_time = reader.convert_to_gps_time(message.p1_time)
-                f.write(
-                    '%.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %d\n' %
-                    (float(message.p1_time),
-                     float(gps_time),
-                     message.front_left_speed_mps,
-                     message.front_right_speed_mps,
-                     message.rear_left_speed_mps,
-                     message.rear_right_speed_mps,
-                     message.gear))
+            np.savetxt(f, np.stack([wheel_speed_data.p1_time,
+                                    gps_time,
+                                    wheel_speed_data.front_left_speed_mps,
+                                    wheel_speed_data.front_right_speed_mps,
+                                    wheel_speed_data.rear_left_speed_mps,
+                                    wheel_speed_data.rear_right_speed_mps,
+                                    wheel_speed_data.gear], axis=1), fmt='%.6f')
     else:
         logger.info("No corrected wheel speed data.")
 
+    raw_wheel_speed_data = result[RawWheelSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for raw wheel speed data.
-    if len(raw_wheel_speed_data.messages) != 0:
+    if len(raw_wheel_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'raw_wheel_speed_data.csv')
         logger.info("Generating '%s'." % path)
+        gps_time = reader.convert_to_gps_time(raw_wheel_speed_data.p1_time)
         with open(path, 'w') as f:
             f.write('P1 Time (sec), GPS Time (sec), Front Left Speed (m/s), Front Right Speed (m/s), Back Left Speed (m/s), Back Right Speed (m/s), Gear\n')
-            for message in wheel_speed_data.messages:
-                gps_time = reader.convert_to_gps_time(message.p1_time)
-                f.write(
-                    '%.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %d\n' %
-                    (float(message.p1_time),
-                     float(gps_time),
-                     message.front_left_speed_mps,
-                     message.front_right_speed_mps,
-                     message.rear_left_speed_mps,
-                     message.rear_right_speed_mps,
-                     message.gear))
+            np.savetxt(f, np.stack([raw_wheel_speed_data.p1_time,
+                                    gps_time,
+                                    raw_wheel_speed_data.front_left_speed_mps,
+                                    raw_wheel_speed_data.front_right_speed_mps,
+                                    raw_wheel_speed_data.rear_left_speed_mps,
+                                    raw_wheel_speed_data.rear_right_speed_mps,
+                                    raw_wheel_speed_data.gear], axis=1), fmt='%.6f')
     else:
         logger.info("No raw wheel speed data.")
 
+    vehicle_speed_data = result[VehicleSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for corrected vehicle speed data.
-    if len(vehicle_speed_data.messages) != 0:
+    if len(vehicle_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'vehicle_speed_data.csv')
         logger.info("Generating '%s'." % path)
+        gps_time = reader.convert_to_gps_time(vehicle_speed_data.p1_time)
         with open(path, 'w') as f:
             f.write('P1 Time (sec), GPS Time (sec), Vehicle Speed (m/s), Gear\n')
-            for message in vehicle_speed_data.messages:
-                gps_time = reader.convert_to_gps_time(message.p1_time)
-                f.write(
-                    '%.6f, %.6f, %.6f, %d\n' %
-                    (float(message.p1_time),
-                     float(gps_time),
-                     message.vehicle_speed_mps,
-                     message.gear))
+            np.savetxt(path, np.stack([vehicle_speed_data.p1_time,
+                                       gps_time,
+                                       vehicle_speed_data.vehicle_speed_mps,
+                                       vehicle_speed_data.gear], axis=1), fmt='%.6f')
     else:
         logger.info("No corrected vehicle speed data.")
 
+    raw_vehicle_speed_data = result[RawVehicleSpeedOutput.MESSAGE_TYPE]
     # Generate a CSV file for raw vehicle speed data.
-    if len(raw_vehicle_speed_data.messages) != 0:
+    if len(raw_vehicle_speed_data.p1_time) != 0:
         path = os.path.join(output_dir, 'raw_vehicle_speed_data.csv')
         logger.info("Generating '%s'." % path)
+        gps_time = reader.convert_to_gps_time(raw_vehicle_speed_data.p1_time)
         with open(path, 'w') as f:
             f.write('P1 Time (sec), GPS Time (sec), Vehicle Speed (m/s), Gear\n')
-            for message in vehicle_speed_data.messages:
-                gps_time = reader.convert_to_gps_time(message.p1_time)
-                f.write(
-                    '%.6f, %.6f, %.6f, %d\n' %
-                    (float(message.p1_time),
-                     float(gps_time),
-                     message.vehicle_speed_mps,
-                     message.gear))
+            np.savetxt(path, np.stack([raw_vehicle_speed_data.p1_time,
+                                       gps_time,
+                                       raw_vehicle_speed_data.vehicle_speed_mps,
+                                       raw_vehicle_speed_data.gear], axis=1), fmt='%.6f')
     else:
         logger.info("No raw vehicle speed data.")
 


### PR DESCRIPTION
Improve the speed of the CSV write step by 1000x. The slowest step is the `reader.read()` call which can still take  ~5 minutes on a large log with high rate measurements. Writing the CSV now takes less than a minute.