### PR TITLE
Switch to P1 fork of gpstime published on PyPI (p1-gpstime).

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,8 +2,7 @@ aenum>=3.1.1
 # Note: Using the Point One fork of gpstime until the patch to download the leap
 # seconds file from alternate servers is merged:
 # https://gitlab.com/jrollins/gpstime/-/merge_requests/2
-git+https://github.com/PointOneNav/gpstime@1b39ea27698df36e08b9f9e8da7a57838d289191#egg=gpstime
-#gpstime>=0.6.2
+p1-gpstime>=0.6.3.dev1
 numpy>=1.16.0
 construct>=2.10.0
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,8 +20,7 @@ message_requirements = set([
     # Note: Using the Point One fork of gpstime until the patch to download the leap
     # seconds file from alternate servers is merged:
     # https://gitlab.com/jrollins/gpstime/-/merge_requests/2
-    'gpstime @ git+https://github.com/PointOneNav/gpstime@1b39ea27698df36e08b9f9e8da7a57838d289191#egg=gpstime',
-    #'gpstime>=0.6.2',
+    'p1-gpstime>=0.6.3.dev1',
     'numpy>=1.16.0',
     'construct>=2.10.0',
 ])


### PR DESCRIPTION
This is temporary until https://gitlab.com/jrollins/gpstime/-/merge_requests/2 is merged upstream. It's not possible to push updates of this repo to PyPI when referencing a dependency via github.