### PR TITLE
Allow applications to be run as scripts if desired.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -75,8 +75,9 @@ FusionEngine message specification.
           time-aligning FusionEngine data captured in a `*.p1log` file
       - `applications` - Applications and processing tools -- see [Applications](#applications) for detailed
         descriptions of each of these tools
-        - _The applications in this directory will be installed on your system by `pip install` along with the rest of
-          the library code so that they can be called directly from the command line_
+        - _The applications in this directory will be installed on your system by `pip install`, along with the rest of
+          the library code, so that they can be called directly from the command line (e.g., `p1_display.py` can be run
+          on the command line as `p1_display`)_
       - `messages` - Python message definitions
       - `parsers` - Message encoding and decoding support
         - [decoder.py](fusion_engine_client/parsers/decoder.py) - `FusionEngineDecoder` class, used to frame and parse

--- a/python/fusion_engine_client/applications/import_utils.py
+++ b/python/fusion_engine_client/applications/import_utils.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+
+def enable_relative_imports(name, file, package=None):
+    """!
+    @brief Enable relative imports for a Python script run as `python script.py`.
+
+    When running an application directly as a script (e.g., python p1_*.py), rather than as an application installed by
+    pip (e.g., p1_*), Python will not set the application's `__package__` setting, and will not include the module
+    root directory (fusion-engine-client/python/) in the import search path. That means that by default, scripts cannot
+    perform relative imports to other files in the same module. This function sets both of those things so that an
+    application may perform either relative or absolute imports as needed.
+
+    @note
+    Note that Python will include the parent directory of the script itself in the search path, so we do not
+    need to do that in order to do the _absolute_ import `from import_utils ...` below. However, if the file is being
+    imported within another file and not executed directly (for example, called as `p1_*` from an entry point script
+    installed by `pip`), its parent directory is _not_ guaranteed to be present on the search path so the absolute
+    import will fail. It is highly recommended that you check the value of `__package__` before importing this function.
+
+    For example, imagine an application `fusion_engine_client/applications/p1_my_app.py` and run as
+    `python p1_my_app.py`:
+    ```py
+    if __package__ is None or __package__ == "":
+        from import_utils import enable_relative_imports
+        __package__ = enable_relative_imports(__name__, __file__, __package__)
+
+    # Can now do a relative import (recommended):
+    from ..messages import PoseMessage
+    # or an absolute import:
+    from fusion_engine_client.messages import PoseMessage
+    ```
+    """
+    if name == "__main__":
+        # Note that the root directory is fixed relative to the path to _this_ file, not the caller's file.
+        root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
+        sys.path.insert(0, root_dir)
+
+        if package is None or package == "":
+            package = os.path.dirname(os.path.relpath(file, root_dir)).replace('/', '.')
+    return package

--- a/python/fusion_engine_client/applications/p1_display.py
+++ b/python/fusion_engine_client/applications/p1_display.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python3
 
-import os
-import sys
-
-# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
-# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
-# import search path to enable relative imports.
-if __name__ == "__main__":
-    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
-    sys.path.insert(0, root_dir)
-    __package__ = os.path.dirname(__file__).replace('/', '.')
-
+if __package__ is None or __package__ == "":
+    from import_utils import enable_relative_imports
+    __package__ = enable_relative_imports(__name__, __file__)
 
 from ..analysis.analyzer import main as analyzer_main
 

--- a/python/fusion_engine_client/applications/p1_display.py
+++ b/python/fusion_engine_client/applications/p1_display.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
 
+import os
+import sys
+
+# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
+# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
+# import search path to enable relative imports.
+if __name__ == "__main__":
+    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
+    sys.path.insert(0, root_dir)
+    __package__ = os.path.dirname(__file__).replace('/', '.')
+
+
 from ..analysis.analyzer import main as analyzer_main
 
 

--- a/python/fusion_engine_client/applications/p1_extract.py
+++ b/python/fusion_engine_client/applications/p1_extract.py
@@ -3,6 +3,14 @@
 import os
 import sys
 
+# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
+# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
+# import search path to enable relative imports.
+if __name__ == "__main__":
+    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
+    sys.path.insert(0, root_dir)
+    __package__ = os.path.dirname(__file__).replace('/', '.')
+
 from ..utils import trace as logging
 from ..utils.argument_parser import ArgumentParser
 from ..utils.log import extract_fusion_engine_log, find_log_file, CANDIDATE_LOG_FILES, DEFAULT_LOG_BASE_DIR

--- a/python/fusion_engine_client/applications/p1_extract.py
+++ b/python/fusion_engine_client/applications/p1_extract.py
@@ -3,13 +3,9 @@
 import os
 import sys
 
-# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
-# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
-# import search path to enable relative imports.
-if __name__ == "__main__":
-    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
-    sys.path.insert(0, root_dir)
-    __package__ = os.path.dirname(__file__).replace('/', '.')
+if __package__ is None or __package__ == "":
+    from import_utils import enable_relative_imports
+    __package__ = enable_relative_imports(__name__, __file__)
 
 from ..utils import trace as logging
 from ..utils.argument_parser import ArgumentParser

--- a/python/fusion_engine_client/applications/p1_lband_extract.py
+++ b/python/fusion_engine_client/applications/p1_lband_extract.py
@@ -3,13 +3,9 @@
 import os
 import sys
 
-# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
-# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
-# import search path to enable relative imports.
-if __name__ == "__main__":
-    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
-    sys.path.insert(0, root_dir)
-    __package__ = os.path.dirname(__file__).replace('/', '.')
+if __package__ is None or __package__ == "":
+    from import_utils import enable_relative_imports
+    __package__ = enable_relative_imports(__name__, __file__)
 
 from ..utils.trace import HighlightFormatter, BrokenPipeStreamHandler
 from ..utils.time_range import TimeRange

--- a/python/fusion_engine_client/applications/p1_lband_extract.py
+++ b/python/fusion_engine_client/applications/p1_lband_extract.py
@@ -3,6 +3,14 @@
 import os
 import sys
 
+# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
+# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
+# import search path to enable relative imports.
+if __name__ == "__main__":
+    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
+    sys.path.insert(0, root_dir)
+    __package__ = os.path.dirname(__file__).replace('/', '.')
+
 from ..utils.trace import HighlightFormatter, BrokenPipeStreamHandler
 from ..utils.time_range import TimeRange
 from ..utils.log import locate_log, DEFAULT_LOG_BASE_DIR

--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
 
 from collections import defaultdict
-import os
 import sys
 
-# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
-# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
-# import search path to enable relative imports.
-if __name__ == "__main__":
-    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
-    sys.path.insert(0, root_dir)
-    __package__ = os.path.dirname(__file__).replace('/', '.')
+if __package__ is None or __package__ == "":
+    from import_utils import enable_relative_imports
+    __package__ = enable_relative_imports(__name__, __file__)
 
 from ..messages import *
 from ..parsers import MixedLogReader

--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
 
 from collections import defaultdict
+import os
 import sys
+
+# If this application is being run directly as a script (e.g., python p1_*.py), rather than as a script installed by pip
+# (e.g., p1_*), manually set the package name and add the Python root directory (fusion-engine-client/python/) to the
+# import search path to enable relative imports.
+if __name__ == "__main__":
+    root_dir = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..'))
+    sys.path.insert(0, root_dir)
+    __package__ = os.path.dirname(__file__).replace('/', '.')
 
 from ..messages import *
 from ..parsers import MixedLogReader

--- a/python/setup.py
+++ b/python/setup.py
@@ -81,7 +81,7 @@ for the latest FusionEngine message specification.
     packages=find_packages(where='.'),
     entry_points={
         'console_scripts': [
-            'p1_display = fusion_engine_client.analysis.analyzer:main',
+            'p1_display = fusion_engine_client.applications.p1_display:main',
             'p1_extract = fusion_engine_client.applications.p1_extract:main',
             'p1_lband_extract = fusion_engine_client.applications.p1_lband_extract:main',
             'p1_print = fusion_engine_client.applications.p1_print:main',


### PR DESCRIPTION
This allows users to run:
```
python fusion_engine_client/applications/p1_display.py
# or
./fusion_engine_client/applications/p1_display.py
```

in addition to the normally recommended:
```
p1_display
```