### PR TITLE
Fixed CI build errors for example external project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (C) Point One Navigation - All Rights Reserved
-cmake_minimum_required(VERSION 3.3.2)
+cmake_minimum_required(VERSION 3.12)
 
 # Set toolchain parameters before calling project().
 set(CMAKE_CXX_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ include(FetchContent)
 FetchContent_Declare(
     fusion_engine_client
     # Recommended:
-    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.16.0.zip
-    URL_HASH MD5=3d35c1c56e111d2e9a164cdbf7878228
-    # Alternative:
+    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.22.3.zip
+    URL_HASH MD5=cfe1de319725822a1b825cd3421fb6b1
+    # Alternatively:
     # GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
-    # GIT_TAG v1.16.0
+    # GIT_TAG v1.22.3
 )
 set(P1_FE_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(fusion_engine_client)
@@ -114,7 +114,7 @@ target_link_libraries(example_app PUBLIC fusion_engine_client)
 ```
 
 Note that we strongly recommend using a specific version of the library in your code by specifying a release zip file or
-a git tag (e.g., `GIT_TAG v1.15.2`), and updating that as new versions are released. That way, you can be sure that your
+a git tag (e.g., `GIT_TAG vA.B.C`), and updating that as new versions are released. That way, you can be sure that your
 code is always built with a known version of fusion-engine-client. If you prefer, however, you can tell CMake to track
 the latest changes by using `GIT_TAG master` instead.
 
@@ -168,12 +168,12 @@ To use this library in an existing Bazel project, add the following to your proj
 git_repository(
     name = "fusion_engine_client",
     remote = "git@github.com:PointOneNav/fusion_engine_client.git",
-    tag = "v1.15.2",
+    tag = "v1.22.3",
 )
 ```
 
 Note that we strongly recommend using a specific version of the library in your code by specifying a git tag (e.g.,
-`tag = "v1.15.2"`), and updating that as new versions are released. That way, you can be sure that your code is always
+`tag = "v1.22.3"`), and updating that as new versions are released. That way, you can be sure that your code is always
 built with a known version of fusion-engine-client. If you prefer, however, you can tell Bazel to track the latest
 changes by using `branch = "master"` instead.
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,12 @@ below, rather than compiling and installing the library manually as in the secti
 include(FetchContent)
 FetchContent_Declare(
     fusion_engine_client
-    GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
-    GIT_TAG v1.15.2
+    # Recommended:
+    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.16.0.zip
+    URL_HASH MD5=3d35c1c56e111d2e9a164cdbf7878228
+    # Alternative:
+    # GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
+    # GIT_TAG v1.16.0
 )
 set(P1_FE_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(fusion_engine_client)
@@ -109,10 +113,10 @@ add_executable(example_app main.cc)
 target_link_libraries(example_app PUBLIC fusion_engine_client)
 ```
 
-Note that we strongly recommend using a specific version of the library in your code by specifying a git tag (e.g.,
-`GIT_TAG v1.15.2`), and updating that as new versions are released. That way, you can be sure that your code is always
-built with a known version of fusion-engine-client. If you prefer, however, you can tell CMake to track the latest
-changes by using `GIT_TAG master` instead.
+Note that we strongly recommend using a specific version of the library in your code by specifying a release zip file or
+a git tag (e.g., `GIT_TAG v1.15.2`), and updating that as new versions are released. That way, you can be sure that your
+code is always built with a known version of fusion-engine-client. If you prefer, however, you can tell CMake to track
+the latest changes by using `GIT_TAG master` instead.
 
 See [examples/external_cmake_project/CMakeLists.txt](examples/external_cmake_project/CMakeLists.txt) for more details.
 

--- a/examples/external_cmake_project/CMakeLists.txt
+++ b/examples/external_cmake_project/CMakeLists.txt
@@ -19,11 +19,11 @@ project(fusion_engine_usage_example C CXX)
 # Use FetchContent to import the fusion-engine-client C++ library using Git.
 #
 # Note that we always recommend using a specific version of the library in your
-# code by specifying a git tag (e.g., `GIT_TAG v1.15.2`), and updating that as
-# new versions are released. That way, you can be sure that your code is always
-# built with a known version of fusion-engine-client. If you prefer, however,
-# you can set the GIT_TAG to track the latest changes by setting
-# `GIT_TAG master` below.
+# code by specifying a release zip file or a git tag (e.g., `GIT_TAG v1.15.2`),
+# and updating that as new versions are released. That way, you can be sure that
+# your code is always built with a known version of fusion-engine-client. If you
+# prefer, however, you can set the GIT_TAG to track the latest changes by
+# setting `GIT_TAG master` below.
 #
 # We explicitly disable example applications from the fusion-engine-client
 # library by setting P1_FE_BUILD_EXAMPLES to OFF below. We only want to build
@@ -38,8 +38,12 @@ project(fusion_engine_usage_example C CXX)
 include(FetchContent)
 FetchContent_Declare(
     fusion_engine_client
-    GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
-    GIT_TAG v1.16.0
+    # Recommended:
+    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.16.0.zip
+    URL_HASH MD5=3d35c1c56e111d2e9a164cdbf7878228
+    # Or alternatively:
+    # GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
+    # GIT_TAG v1.16.0
 )
 set(P1_FE_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(fusion_engine_client)

--- a/examples/external_cmake_project/CMakeLists.txt
+++ b/examples/external_cmake_project/CMakeLists.txt
@@ -19,7 +19,7 @@ project(fusion_engine_usage_example C CXX)
 # Use FetchContent to import the fusion-engine-client C++ library using Git.
 #
 # Note that we always recommend using a specific version of the library in your
-# code by specifying a release zip file or a git tag (e.g., `GIT_TAG v1.15.2`),
+# code by specifying a release zip file or a git tag (e.g., `GIT_TAG vA.B.C`),
 # and updating that as new versions are released. That way, you can be sure that
 # your code is always built with a known version of fusion-engine-client. If you
 # prefer, however, you can set the GIT_TAG to track the latest changes by
@@ -39,11 +39,11 @@ include(FetchContent)
 FetchContent_Declare(
     fusion_engine_client
     # Recommended:
-    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.16.0.zip
-    URL_HASH MD5=3d35c1c56e111d2e9a164cdbf7878228
+    URL https://github.com/PointOneNav/fusion-engine-client/archive/refs/tags/v1.22.3.zip
+    URL_HASH MD5=cfe1de319725822a1b825cd3421fb6b1
     # Or alternatively:
     # GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
-    # GIT_TAG v1.16.0
+    # GIT_TAG v1.22.3
 )
 set(P1_FE_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(fusion_engine_client)


### PR DESCRIPTION
# Changes
- Recommend using CMake `FetchContent` with HTTPS by default for machines (Docker containers) without git

# Fixes
- Updated `external_cmake_project` example dependency version to resolve missing typedef errors when using clang (fix included in release 1.18.0)