### PR TITLE
Add SBAS option to iono model config

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -223,6 +223,7 @@ class IonoDelayModel(IntEnum):
     AUTO = 0
     OFF = 1
     KLOBUCHAR = 2
+    SBAS = 3
 
 
 class TropoDelayModel(IntEnum):

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1350,6 +1350,8 @@ enum class IonoDelayModel : uint8_t {
   OFF = 1,
   /** Use the Klobuchar ionospheric model. */
   KLOBUCHAR = 2,
+  /** Use the SBAS ionospheric model. */
+  SBAS = 3,
 };
 
 P1_CONSTEXPR_FUNC const char* to_string(IonoDelayModel iono_delay_model) {
@@ -1360,6 +1362,8 @@ P1_CONSTEXPR_FUNC const char* to_string(IonoDelayModel iono_delay_model) {
       return "OFF";
     case IonoDelayModel::KLOBUCHAR:
       return "KLOBUCHAR";
+    case IonoDelayModel::SBAS:
+      return "SBAS";
     default:
       return "UNRECOGNIZED";
   }


### PR DESCRIPTION
# Changes
- Add SBAS to configuration choices of ionospheric delay models. 