### PR TITLE
Copy include_header.js automatically in Doxygen build.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -282,7 +282,6 @@ jobs:
         pip install packaging
         python3 docs/update_versions.py ${GIT_TAG}
         doxygen Doxyfile.version
-        cp docs/include_header.js docs/html/
         tar czf fusion-engine-client-docs.tar.gz docs/html --transform 's|^docs/html|fusion-engine-client/docs/html|'
         tar czf version-docs.tar.gz docs/include_header.js docs/versions.html
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1249,7 +1249,7 @@ HTML_EXTRA_STYLESHEET  =
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = docs/favicon.ico docs/point_one_logo.png
+HTML_EXTRA_FILES       = docs/favicon.ico docs/point_one_logo.png docs/include_header.js
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to


### PR DESCRIPTION
This way you can run doxygen manually on the command line without having to copy this file in separately.