### PR TITLE
Added enum bitmask support and default numpy, pack, and unpack support.

### DIFF
--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -25,7 +25,7 @@ def print_message(header, contents, offset_bytes, format='pretty', bytes=None):
             raise ValueError('No data provided for binary format.')
         parts = []
     elif isinstance(contents, MessagePayload):
-        if format in ('oneline', 'oneline-binary', 'oneline-detailed'):
+        if format.startswith('oneline-'):
             # The repr string should always start with the message type, then other contents:
             #   [POSE (10000), p1_time=12.029 sec, gps_time=2249:528920.500 (1360724120.500 sec), ...]
             # We want to reformat and insert the additional details as follows for consistency:
@@ -43,7 +43,7 @@ def print_message(header, contents, offset_bytes, format='pretty', bytes=None):
     else:
         parts = [f'{header.get_type_string()} (unsupported)']
 
-    if format in ('pretty', 'pretty-binary', 'oneline-detailed', 'oneline-binary'):
+    if format != 'oneline':
         details = 'sequence=%d, size=%d B, offset=%d B (0x%x)' %\
                   (header.sequence_number, header.get_message_size(), offset_bytes, offset_bytes)
 
@@ -58,10 +58,14 @@ def print_message(header, contents, offset_bytes, format='pretty', bytes=None):
     elif format == 'binary':
         byte_string = bytes_to_hex(bytes, bytes_per_row=-1, bytes_per_col=2).replace('\n', '\n  ')
         parts.insert(1, byte_string)
-    elif format == 'pretty-binary':
+    elif format == 'pretty-binary' or format == 'pretty-binary-payload':
+        if format.endswith('-payload'):
+            bytes = bytes[MessageHeader.calcsize():]
         byte_string = '    ' + bytes_to_hex(bytes, bytes_per_row=16, bytes_per_col=2).replace('\n', '\n    ')
         parts.insert(1, "  Binary:\n%s" % byte_string)
-    elif format == 'oneline-binary':
+    elif format == 'oneline-binary' or format == 'oneline-binary-payload':
+        if format.endswith('-payload'):
+            bytes = bytes[MessageHeader.calcsize():]
         byte_string = '  ' + bytes_to_hex(bytes, bytes_per_row=16, bytes_per_col=2).replace('\n', '\n  ')
         parts.insert(1, byte_string)
 
@@ -80,16 +84,18 @@ other types of data.
         help="Interpret the timestamps in --time as absolute P1 times. Otherwise, treat them as relative to the first "
              "message in the file. Ignored if --time contains a type specifier.")
     parser.add_argument(
-        '-f', '--format', choices=['binary', 'pretty', 'pretty-binary', 'oneline', 'oneline-detailed',
-                                   'oneline-binary'],
+        '-f', '--format', choices=['binary', 'pretty', 'pretty-binary', 'pretty-binary-payload',
+                                   'oneline', 'oneline-detailed', 'oneline-binary', 'oneline-binary-payload'],
         default='pretty',
         help="Specify the format used to print the message contents:\n"
              "- Print the binary representation of each message on a single line, but no other details\n"
              "- pretty - Print the message contents in a human-readable format (default)\n"
              "- pretty-binary - Use `pretty` format, but include the binary representation of each message\n"
+             "- pretty-binary-payload - Like `pretty-binary`, but exclude the message header from the binary\n"
              "- oneline - Print a summary of each message on a single line\n"
              "- oneline-detailed - Print a one-line summary, including message offset details\n"
-             "- oneline-binary - Use `oneline-detailed` format, but include the binary representation of each message")
+             "- oneline-binary - Use `oneline-detailed` format, but include the binary representation of each message\n"
+             "- oneline-binary-payload - Like `oneline-binary`, but exclude the message header from the binary")
     parser.add_argument(
         '-s', '--summary', action='store_true',
         help="Print a summary of the messages in the file.")

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -436,11 +436,11 @@ class _ConfigClassGenerator:
                 # SatelliteTypeMaskVal(SatelliteType.GPS)
                 # SatelliteTypeMaskVal('GPS')
                 if isinstance(args[0], SatelliteType) or isinstance(args[0], str):
-                    args = (SatelliteTypeMask.to_bit_mask(args),)
+                    args = (SatelliteTypeMask.to_bitmask(args),)
                 # SatelliteTypeMaskVal([SatelliteType.GPS, SatelliteType.GALILEO])
                 # SatelliteTypeMaskVal(['GPS', 'GALILEO'])
                 elif isinstance(args[0], Iterable):
-                    args = (SatelliteTypeMask.to_bit_mask(args[0])),
+                    args = (SatelliteTypeMask.to_bitmask(args[0])),
                 # SatelliteTypeMaskVal(bit_mask)
                 else:
                     pass
@@ -448,13 +448,13 @@ class _ConfigClassGenerator:
             #   SatelliteTypeMaskVal(SatelliteType.GPS, SatelliteType.GALILEO)
             #   SatelliteTypeMaskVal('GPS', 'GALILEO')
             elif len(args) > 1:
-                args = (SatelliteTypeMask.to_bit_mask(args),)
+                args = (SatelliteTypeMask.to_bitmask(args),)
 
             return super().__new__(cls, *args, **kwargs)
 
         def __repr__(self):
             return f'{self.__class__.__name__}(value=0x{self.value:02x} ' \
-                   f'({SatelliteTypeMask.bit_mask_to_string(self.value)}))'
+                   f'({SatelliteTypeMask.bitmask_to_string(self.value)}))'
 
     class FrequencyBandMaskVal(IntegerVal):
         """!
@@ -466,11 +466,11 @@ class _ConfigClassGenerator:
                 # FrequencyBandMaskVal(FrequencyBand.L1)
                 # FrequencyBandMaskVal('L1')
                 if isinstance(args[0], FrequencyBand) or isinstance(args[0], str):
-                    args = (FrequencyBandMask.to_bit_mask(args),)
+                    args = (FrequencyBandMask.to_bitmask(args),)
                 # FrequencyBandMaskVal([FrequencyBand.L1, FrequencyBand.L5])
                 # FrequencyBandMaskVal(['L1', 'L5'])
                 elif isinstance(args[0], Iterable):
-                    args = (FrequencyBandMask.to_bit_mask(args[0])),
+                    args = (FrequencyBandMask.to_bitmask(args[0])),
                 # FrequencyBandMaskVal(bit_mask)
                 else:
                     pass
@@ -478,13 +478,13 @@ class _ConfigClassGenerator:
             #   FrequencyBandMaskVal(FrequencyBand.L1, FrequencyBand.L5)
             #   FrequencyBandMaskVal('L1', 'L5')
             elif len(args) > 1:
-                args = (FrequencyBandMask.to_bit_mask(args),)
+                args = (FrequencyBandMask.to_bitmask(args),)
 
             return super().__new__(cls, *args, **kwargs)
 
         def __repr__(self):
             return f'{self.__class__.__name__}(value=0x{self.value:02x} ' \
-                   f'({FrequencyBandMask.bit_mask_to_string(self.value)}))'
+                   f'({FrequencyBandMask.bitmask_to_string(self.value)}))'
 
     class CoarseOrientation(NamedTuple):
         """!

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -557,13 +557,8 @@ class MessagePayload:
         else:
             raise NotImplementedError('unpack() not implemented.')
 
-    @classmethod
-    def calcsize(cls) -> int:
-        construct = getattr(cls, 'Construct', None)
-        if construct is not None:
-            return construct.sizeof()
-        else:
-            raise NotImplementedError('calcsize() not implemented.')
+    def calcsize(self) -> int:
+        raise NotImplementedError('calcsize() not implemented.')
 
     def get_p1_time(self) -> Timestamp:
         measurement_details = getattr(self, 'details', None)

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -610,12 +610,17 @@ class MessagePayload:
     def __str__(self):
         construct = getattr(self.__class__, 'Construct', None)
         if construct is not None:
+            return self._construct_str_impl()
+        else:
+            return repr(self)
+
+    def _construct_str_impl(self, **kwargs):
+        if 'title' not in kwargs:
             title = self.__class__.__name__
             if hasattr(self, 'p1_time'):
                 title += f' @ {self.p1_time}'
-            return construct_message_to_string(message=self, title=title)
-        else:
-            return repr(self)
+            kwargs['title'] = title
+        return construct_message_to_string(message=self, **kwargs)
 
     @classmethod
     def pack_values(cls, format: Union[str, struct.Struct], buffer: bytes, offset: int = 0, *args):

--- a/python/fusion_engine_client/messages/signal_defs.py
+++ b/python/fusion_engine_client/messages/signal_defs.py
@@ -3,7 +3,7 @@ from typing import List, Union
 
 import numpy as np
 
-from ..utils.enum_utils import IntEnum
+from ..utils.enum_utils import IntEnum, enum_bitmask
 
 
 class SatelliteType(IntEnum):
@@ -35,41 +35,9 @@ SatelliteTypeChar = {
 SatelliteTypeCharReverse = {v: k for k, v in SatelliteTypeChar.items()}
 
 
-class SatelliteTypeMask(IntEnum):
-    GPS = (1 << SatelliteType.GPS)
-    GLONASS = (1 << SatelliteType.GLONASS)
-    LEO = (1 << SatelliteType.LEO)
-    GALILEO = (1 << SatelliteType.GALILEO)
-    BEIDOU = (1 << SatelliteType.BEIDOU)
-    QZSS = (1 << SatelliteType.QZSS)
-    MIXED = (1 << SatelliteType.MIXED)
-    SBAS = (1 << SatelliteType.SBAS)
-    IRNSS = (1 << SatelliteType.IRNSS)
-
+@enum_bitmask(SatelliteType)
+class SatelliteTypeMask:
     ALL = 0xFFFFFFFF
-
-    @classmethod
-    def to_bitmask(cls, systems: List[Union[SatelliteType, str]]):
-        mask = 0
-        for system in systems:
-            if isinstance(system, str):
-                mask |= getattr(cls, system.upper())
-            else:
-                mask |= (1 << int(system))
-        return mask
-
-    @classmethod
-    def bitmask_to_values(cls, mask: int):
-        systems = []
-        for system in SatelliteType:
-            if (mask & (1 << int(system))) != 0:
-                systems.append(system)
-        return systems
-
-    @classmethod
-    def bitmask_to_string(cls, mask: int):
-        values = cls.bitmask_to_values(mask)
-        return ', '.join(str(s) for s in values)
 
 
 class SignalType(IntEnum):
@@ -84,36 +52,9 @@ class FrequencyBand(IntEnum):
     L6 = 6
 
 
-class FrequencyBandMask(IntEnum):
-    L1 = (1 << FrequencyBand.L1)
-    L2 = (1 << FrequencyBand.L2)
-    L5 = (1 << FrequencyBand.L5)
-    L6 = (1 << FrequencyBand.L6)
-
+@enum_bitmask(FrequencyBand)
+class FrequencyBandMask:
     ALL = 0xFFFFFFFF
-
-    @classmethod
-    def to_bitmask(cls, frequencies: List[Union[FrequencyBand, str]]):
-        mask = 0
-        for freq in frequencies:
-            if isinstance(freq, str):
-                mask |= getattr(cls, freq.upper())
-            else:
-                mask |= (1 << int(freq))
-        return mask
-
-    @classmethod
-    def bitmask_to_values(cls, mask: int):
-        frequencies = []
-        for freq in FrequencyBand:
-            if (mask & (1 << int(freq))) != 0:
-                frequencies.append(freq)
-        return frequencies
-
-    @classmethod
-    def bitmask_to_string(cls, mask: int):
-        values = cls.bitmask_to_values(mask)
-        return ', '.join(str(s) for s in values)
 
 
 _SHORT_FORMAT = re.compile(r'([%s])(\d+)(?:\s+(\w+))?' % ''.join(SatelliteTypeCharReverse.keys()))

--- a/python/fusion_engine_client/messages/signal_defs.py
+++ b/python/fusion_engine_client/messages/signal_defs.py
@@ -49,7 +49,7 @@ class SatelliteTypeMask(IntEnum):
     ALL = 0xFFFFFFFF
 
     @classmethod
-    def to_bit_mask(cls, systems: List[Union[SatelliteType, str]]):
+    def to_bitmask(cls, systems: List[Union[SatelliteType, str]]):
         mask = 0
         for system in systems:
             if isinstance(system, str):
@@ -59,7 +59,7 @@ class SatelliteTypeMask(IntEnum):
         return mask
 
     @classmethod
-    def bit_mask_to_systems(cls, mask: int):
+    def bitmask_to_values(cls, mask: int):
         systems = []
         for system in SatelliteType:
             if (mask & (1 << int(system))) != 0:
@@ -67,9 +67,9 @@ class SatelliteTypeMask(IntEnum):
         return systems
 
     @classmethod
-    def bit_mask_to_string(cls, mask: int):
-        systems = cls.bit_mask_to_systems(mask)
-        return ', '.join(str(s) for s in systems)
+    def bitmask_to_string(cls, mask: int):
+        values = cls.bitmask_to_values(mask)
+        return ', '.join(str(s) for s in values)
 
 
 class SignalType(IntEnum):
@@ -93,7 +93,7 @@ class FrequencyBandMask(IntEnum):
     ALL = 0xFFFFFFFF
 
     @classmethod
-    def to_bit_mask(cls, frequencies: List[Union[FrequencyBand, str]]):
+    def to_bitmask(cls, frequencies: List[Union[FrequencyBand, str]]):
         mask = 0
         for freq in frequencies:
             if isinstance(freq, str):
@@ -103,7 +103,7 @@ class FrequencyBandMask(IntEnum):
         return mask
 
     @classmethod
-    def bit_mask_to_systems(cls, mask: int):
+    def bitmask_to_values(cls, mask: int):
         frequencies = []
         for freq in FrequencyBand:
             if (mask & (1 << int(freq))) != 0:
@@ -111,9 +111,9 @@ class FrequencyBandMask(IntEnum):
         return frequencies
 
     @classmethod
-    def bit_mask_to_string(cls, mask: int):
-        systems = cls.bit_mask_to_systems(mask)
-        return ', '.join(str(s) for s in systems)
+    def bitmask_to_string(cls, mask: int):
+        values = cls.bitmask_to_values(mask)
+        return ', '.join(str(s) for s in values)
 
 
 _SHORT_FORMAT = re.compile(r'([%s])(\d+)(?:\s+(\w+))?' % ''.join(SatelliteTypeCharReverse.keys()))

--- a/python/fusion_engine_client/messages/timestamp.py
+++ b/python/fusion_engine_client/messages/timestamp.py
@@ -76,7 +76,7 @@ class Timestamp:
             tow_sec = self.seconds - week * SECONDS_PER_WEEK
             return week, tow_sec
         else:
-            return np.nan, np.nan
+            return -1, np.nan
 
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = False) -> (bytes, int):
         if math.isnan(self.seconds):
@@ -149,9 +149,12 @@ class Timestamp:
 
     def __str__(self):
         if self.is_gps():
-            return 'GPS: %d:%.3f (%.3f sec)' % (*self.get_week_tow(), self.seconds)
+            return 'GPS: %s' % self.to_gps_str()
         else:
             return 'P1: %.3f sec' % self.seconds
+
+    def to_gps_str(self):
+        return '%d:%.3f (%.3f sec)' % (*self.get_week_tow(), self.seconds)
 
 
 def system_time_to_str(system_time, is_seconds=False):

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -1,4 +1,7 @@
 from enum import EnumMeta, IntEnum as IntEnumBase
+import functools
+import inspect
+from typing import List, Union
 
 from aenum import extend_enum
 
@@ -89,3 +92,112 @@ class IntEnum(IntEnumBase, metaclass=DynamicEnumMeta):
             return '%s (%d)' % (str(self), int(self))
         else:
             return str(self)
+
+
+def enum_bitmask(enum_type, define_bits=True):
+    """!
+    @brief Create a bitmask class definition corresponding with an existing class derived from `IntEnum`.
+
+    ```py
+    class MyEnum(IntEnum):
+        A = 1
+        B = 2
+
+    @enum_bitmask(MyEnum)
+    class MyMask: pass
+    ```
+
+    The `MyMask` definition above is the equivalent of:
+
+    ```py
+    class MyMask(IntEnum):
+        A = (1 << 1)
+        B = (1 << 2)
+
+        @classmethod
+        def to_bitmask(cls, values): ...
+
+        @classmethod
+        def to_values(cls, mask): ...
+
+        @classmethod
+        def to_string(cls, mask): ...
+    ```
+
+    @param enum_type The enum to which the mask class corresponds.
+    @param define_bits If `True`, define mask bit member variables for each value defined in the enum (e.g., `A` and `B`
+           above). Otherwise, do not define any member variables for the class, only attach the helper methods.
+    """
+    def _wrapper(base_cls):
+        # Define a wrapper class that inherits from both the base class and IntEnum, and adds the additional bitmask
+        # helper functions.
+        @functools.wraps(base_cls, updated=())
+        class WrappedCls(base_cls, IntEnum):
+            @classmethod
+            def to_bitmask(cls, values: List[Union[enum_type, str]]) -> int:
+                """!
+                @brief Convert a list of enum values or string names to a bitmask.
+
+                @param values A list of one or more enum values or string names.
+
+                @return The corresponding integer bitmask.
+                """
+                mask = 0
+                for value in values:
+                    if isinstance(value, str):
+                        mask |= getattr(cls, value.upper())
+                    else:
+                        mask |= (1 << int(value))
+                return mask
+
+            @classmethod
+            def to_values(cls, mask: int) -> List[enum_type]:
+                """!
+                @brief Decode a bitmask into a list of enum values.
+
+                @param mask The bitmask to be decoded.
+
+                @return A list of enum values for each bit set in the mask.
+                """
+                values = []
+                for value in enum_type:
+                    if (mask & (1 << int(value))) != 0:
+                        values.append(value)
+                return values
+
+            @classmethod
+            def to_string(cls, mask: int) -> str:
+                """!
+                @brief Decode a bitmask into a human-readable string.
+
+                @param mask The bitmask to be decoded.
+
+                @return A comma-separated string listing the names of the enum value for each bit set in the mask.
+                """
+                values = cls.to_values(mask)
+                return ', '.join(str(s) for s in values)
+
+        # List elements returned by getmembers() for _all_ objects so we can skip them in the loops below when looking
+        # for enum values to be added.
+        internals = set(dir(type('dummy', (object,), {})))
+        internals.add('__members__')
+
+        # If the user defined any additional enum values in the template base class, remove them from the base and add
+        # them back using extend_enum() so they are usable enum values. For example:
+        #   @enum_bitmask(MyEnum)
+        #   class MyMask:
+        #       ALL = 0xFF
+        for entry in inspect.getmembers(base_cls):
+            if entry[0] not in internals:
+                delattr(base_cls, entry[0])
+                extend_enum(WrappedCls, entry[0], int(entry[1]))
+
+        # Now define additional enum values for each bit:
+        #   A = (1 << MyEnum.A)
+        if define_bits:
+            for entry in inspect.getmembers(enum_type):
+                if entry[0] not in internals:
+                    extend_enum(WrappedCls, entry[0], (1 << int(entry[1])))
+
+        return WrappedCls
+    return _wrapper

--- a/python/tests/test_construct_utils.py
+++ b/python/tests/test_construct_utils.py
@@ -1,8 +1,9 @@
 import math
 
-from construct import Struct, Int16sl
+from construct import Struct, Float32l, Int16sl, Int16ul, Int16ub, Int8ul
+import numpy as np
 
-from fusion_engine_client.utils.construct_utils import FixedPointAdapter
+from fusion_engine_client.utils.construct_utils import FixedPointAdapter, NumpyAdapter
 
 
 def test_fixed_point_int():
@@ -128,3 +129,87 @@ def test_fixed_point_invalid():
     expected_bytes = b'\x00\x80'
     parsed = construct.parse(expected_bytes)
     assert math.isnan(parsed.value)
+
+
+def test_numpy_float():
+    construct = Struct(
+        "float64" / NumpyAdapter(shape=(3,)),
+        "float32" / NumpyAdapter(shape=(3,), construct_type=Float32l),
+        "float64_2x3" / NumpyAdapter(shape=(2, 3)),
+    )
+
+    data = {
+        'float64': [1.0, 1.1, 1.2],
+        'float32': np.array([1.0, 1.1, 1.2]),
+        'float64_2x3': np.array(([1.0, 1.1, 1.2], [2.0, 2.1, 2.2])),
+    }
+
+    bytes64_1_0 = b'\x00\x00\x00\x00\x00\x00\xF0\x3F'
+    bytes64_1_1 = b'\x9A\x99\x99\x99\x99\x99\xF1\x3F'
+    bytes64_1_2 = b'\x33\x33\x33\x33\x33\x33\xF3\x3F'
+    bytes64_2_0 = b'\x00\x00\x00\x00\x00\x00\x00\x40'
+    bytes64_2_1 = b'\xCD\xCC\xCC\xCC\xCC\xCC\x00\x40'
+    bytes64_2_2 = b'\x9A\x99\x99\x99\x99\x99\x01\x40'
+    bytes32_1_0 = b'\x00\x00\x80\x3F'
+    bytes32_1_1 = b'\xCD\xCC\x8C\x3F'
+    bytes32_1_2 = b'\x9A\x99\x99\x3F'
+    expected_bytes = \
+        (bytes64_1_0 + bytes64_1_1 + bytes64_1_2) + \
+        (bytes32_1_0 + bytes32_1_1 + bytes32_1_2) + \
+        (bytes64_1_0 + bytes64_1_1 + bytes64_1_2 +
+         bytes64_2_0 + bytes64_2_1 + bytes64_2_2)
+
+    bytes = construct.build(data)
+    assert bytes == expected_bytes
+
+    parsed = construct.parse(expected_bytes)
+    for key, expected_value in data.items():
+        assert np.allclose(expected_value, parsed[key], equal_nan=True), \
+            f"'{key}' values did not match:\n\nExpected:\n{repr(expected_value)}\n\nGot:\n{repr(parsed[key])}"
+
+
+def test_numpy_int():
+    construct = Struct(
+        "int16" / NumpyAdapter(shape=(3,), construct_type=Int16sl),
+        "uint16" / NumpyAdapter(shape=(3,), construct_type=Int16ul),
+        "uint16be" / NumpyAdapter(shape=(3,), construct_type=Int16ub),
+        "uint8" / NumpyAdapter(shape=(3,), construct_type=Int8ul),
+        "uint16_2x3" / NumpyAdapter(shape=(2, 3), construct_type=Int16ul),
+    )
+
+    data = {
+        'int16': [-1, 2, 3],
+        'uint16': np.array([1, 2, 3], dtype=int),
+        'uint16be': np.array([1, 2, 3], dtype=int),
+        'uint8': [1, 2, 3],
+        'uint16_2x3': np.array(([1, 2, 3], [4, 5, 6]), dtype=int),
+    }
+
+    bytes16_1 = b'\x01\x00'
+    bytes16_2 = b'\x02\x00'
+    bytes16_3 = b'\x03\x00'
+    bytes16_4 = b'\x04\x00'
+    bytes16_5 = b'\x05\x00'
+    bytes16_6 = b'\x06\x00'
+    bytes16_n1 = b'\xFF\xFF'
+    bytes16be_1 = b'\x00\x01'
+    bytes16be_2 = b'\x00\x02'
+    bytes16be_3 = b'\x00\x03'
+    bytes8_1 = b'\x01'
+    bytes8_2 = b'\x02'
+    bytes8_3 = b'\x03'
+    expected_bytes = \
+        (bytes16_n1 + bytes16_2 + bytes16_3) + \
+        (bytes16_1 + bytes16_2 + bytes16_3) + \
+        (bytes16be_1 + bytes16be_2 + bytes16be_3) + \
+        (bytes8_1 + bytes8_2 + bytes8_3) + \
+        (bytes16_1 + bytes16_2 + bytes16_3 +
+         bytes16_4 + bytes16_5 + bytes16_6)
+
+    bytes = construct.build(data)
+    assert bytes == expected_bytes
+
+    parsed = construct.parse(expected_bytes)
+    for key, expected_value in data.items():
+        assert np.allclose(expected_value, parsed[key], equal_nan=True), \
+            f"'{key}' values did not match:\n\nExpected:\n{repr(expected_value)}\n\nGot:\n{repr(parsed[key])}"

--- a/python/tests/test_enum_utils.py
+++ b/python/tests/test_enum_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fusion_engine_client.utils.enum_utils import IntEnum
+from fusion_engine_client.utils.enum_utils import IntEnum, enum_bitmask
 
 
 @pytest.fixture
@@ -73,3 +73,28 @@ def test_unrecognized(Enum):
 
     value = Enum('W', raise_on_unrecognized=False)
     assert int(value) == -2
+
+
+def test_bitmask_decorator(Enum):
+    @enum_bitmask(Enum)
+    class EnumMask: pass
+    expected_values = [Enum.A, Enum.B]
+    expected_mask = (1 << int(Enum.A)) | (1 << int(Enum.B))
+    assert EnumMask.to_bitmask(expected_values) == expected_mask
+    assert EnumMask.to_values(expected_mask) == expected_values
+    assert EnumMask.to_string(expected_mask) == 'A, B'
+
+
+def test_bitmask_decorator_extended(Enum):
+    @enum_bitmask(Enum)
+    class EnumMask:
+        ALL = 0xFF
+
+    expected_values = [Enum.A, Enum.B]
+    expected_mask = (1 << int(Enum.A)) | (1 << int(Enum.B))
+    assert EnumMask.to_bitmask(expected_values) == expected_mask
+    assert EnumMask.to_values(expected_mask) == expected_values
+    assert EnumMask.to_string(expected_mask) == 'A, B'
+
+    assert EnumMask.to_values(0xFF) == expected_values
+    assert EnumMask[0xFF] == EnumMask.ALL

--- a/python/tests/test_enum_utils.py
+++ b/python/tests/test_enum_utils.py
@@ -98,3 +98,22 @@ def test_bitmask_decorator_extended(Enum):
 
     assert EnumMask.to_values(0xFF) == expected_values
     assert EnumMask[0xFF] == EnumMask.ALL
+
+
+def test_bitmask_decorator_offset(Enum):
+    @enum_bitmask(Enum, offset=1)
+    class EnumMask: pass
+    assert EnumMask.B == (1 << (Enum.B - 1))
+
+    expected_values = [Enum.A, Enum.B]
+    expected_mask = (1 << (int(Enum.A) - 1)) | (1 << (int(Enum.B) - 1))
+    assert EnumMask.to_bitmask(expected_values) == expected_mask
+    assert EnumMask.to_values(expected_mask) == expected_values
+    assert EnumMask.to_string(expected_mask) == 'A, B'
+
+
+def test_bitmask_decorator_predicate(Enum):
+    @enum_bitmask(Enum, predicate=lambda x: str(x) == 'A')
+    class EnumMask: pass
+    assert hasattr(EnumMask, 'A')
+    assert not hasattr(EnumMask, 'B')


### PR DESCRIPTION
# New Features
- Added default `to_numpy()` support for all messages (where applicable)
- Added default `pack()`/`unpack()`/`str()` implementations for messages using Construct
- Added Construct `NumpyAdapter` to implicitly convert to/from a numpy array
- Added `@enum_bitmask` decorator to simplify enum<->bitmask class creation (e.g., `SatelliteType` vs `SatelliteTypeMask`)
- Added `p1_print` options `--skip` and `--max`