### PR TITLE
Fixed various `p1_print` issues.

### DIFF
--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -299,7 +299,12 @@ other types of data.
         _logger.info(format_string.format('Message Name', 'Type', 'Count'))
         _logger.info(format_string.format('-' * 50, '-' * 5, '-' * 8))
         for type, info in sorted(message_stats.items(), key=lambda x: int(x[0])):
-            name = message_type_to_class[type].__name__ if type in message_type_to_class else "Unknown"
+            if type in message_type_to_class:
+                name = message_type_to_class[type].__name__
+            elif type.is_unrecognized():
+                name = str(type)
+            else:
+                name = f'Unsupported ({str(type)})'
             _logger.info(format_string.format(name, int(type), info['count']))
         _logger.info(format_string.format('-' * 50, '-' * 5, '-' * 8))
         _logger.info(format_string.format('Total', '', total_messages))

--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -262,7 +262,7 @@ other types of data.
                         else:
                             # We allow a small tolerance to account for normal latency between measurements and computed
                             # data like pose solutions, as well as latency between different types of measurements.
-                            dt_sec = newest_system_time_sec - system_time_sec
+                            dt_sec = system_time_sec - newest_system_time_sec
                             if dt_sec < -0.2:
                                 _logger.warning(
                                     'Backwards/restarted system time detected after %s (%s). [new_message=%s, '

--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -213,7 +213,7 @@ other types of data.
     total_messages = 0
     bytes_decoded = 0
 
-    def create_stats_entry(): return {'count': 1}
+    def create_stats_entry(): return {'count': 0}
     message_stats = defaultdict(create_stats_entry)
     try:
         for header, message, data, offset_bytes in reader:

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -79,7 +79,7 @@ class IntEnum(IntEnumBase, metaclass=DynamicEnumMeta):
         #       BAR = 1
         #
         #   print(Foo.BAR)   # Prints "BAR", not "Foo.BAR"
-        if self.name.startswith(IntEnum.UNRECOGNIZED_PREFIX):
+        if self.is_unrecognized():
             return "(Unrecognized)"
         else:
             return self.name
@@ -92,6 +92,9 @@ class IntEnum(IntEnumBase, metaclass=DynamicEnumMeta):
             return '%s (%d)' % (str(self), int(self))
         else:
             return str(self)
+
+    def is_unrecognized(self):
+        return self.name.startswith(IntEnum.UNRECOGNIZED_PREFIX)
 
 
 def enum_bitmask(enum_type, offset=0, define_bits=True, predicate=None):

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -9,6 +9,14 @@ from aenum import extend_enum
 class DynamicEnumMeta(EnumMeta):
     UNRECOGNIZED_PREFIX = '_U'
 
+    def __new__(cls, name, bases, dict):
+        # Add is_recognized() to the definition for the class using this metaclass.
+        def is_unrecognized(self):
+            return self.name.startswith(cls.UNRECOGNIZED_PREFIX)
+        dict['is_unrecognized'] = is_unrecognized
+        enum_class = super().__new__(cls, name, bases, dict)
+        return enum_class
+
     def __call__(cls, value, *args, **kwargs):
         raise_on_unrecognized = kwargs.pop('raise_on_unrecognized', True)
 
@@ -92,9 +100,6 @@ class IntEnum(IntEnumBase, metaclass=DynamicEnumMeta):
             return '%s (%d)' % (str(self), int(self))
         else:
             return str(self)
-
-    def is_unrecognized(self):
-        return self.name.startswith(IntEnum.UNRECOGNIZED_PREFIX)
 
 
 def enum_bitmask(enum_type, offset=0, define_bits=True, predicate=None):


### PR DESCRIPTION
# New Features
- Added `is_unrecognized()` helper function to all classes derived from `IntEnum`

# Fixes
- Fixed `p1_print` check for backwards system time
- Fixed off-by-1 in `p1_print` summary table message counts
- Print the `MessageType` enum name for unsupported messages if known