### PR TITLE
Use input file prefix for output filenames in extract_* scripts.

### DIFF
--- a/python/examples/extract_imu_data.py
+++ b/python/examples/extract_imu_data.py
@@ -56,9 +56,11 @@ Extract IMU accelerometer and gyroscope measurements.
         logger.warning('No IMU data found in log file.')
         sys.exit(2)
 
+    output_prefix = os.path.join(output_dir, os.path.splitext(os.path.basename(input_path))[0])
+
     # Generate a CSV file for corrected IMU data.
     if len(imu_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'imu_data.csv')
+        path = f'{output_prefix}.imu.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(imu_data.p1_time)
         with open(path, 'w') as f:
@@ -72,7 +74,7 @@ Extract IMU accelerometer and gyroscope measurements.
 
     # Generate a CSV file for raw IMU data.
     if len(raw_imu_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'raw_imu_data.csv')
+        path = f'{output_prefix}.raw_imu.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(raw_imu_data.p1_time)
         with open(path, 'w') as f:

--- a/python/examples/extract_position_data.py
+++ b/python/examples/extract_position_data.py
@@ -154,8 +154,10 @@ Extract position data to both CSV and KML files.
         logger.warning('No pose data found in log file.')
         sys.exit(2)
 
+    output_prefix = os.path.join(output_dir, os.path.splitext(os.path.basename(input_path))[0])
+
     # Generate a CSV file.
-    path = os.path.join(output_dir, 'position.csv')
+    path = f'{output_prefix}.position.csv'
     logger.info("Generating '%s'." % path)
     with open(path, 'w') as f:
         f.write('P1 Time (sec), GPS Time (sec), Solution Type, Lat (deg), Lon (deg), Ellipsoid Alt (m), # Satellites, '
@@ -168,7 +170,7 @@ Extract position data to both CSV and KML files.
                      *pose.ypr_deg, *pose_aux.velocity_enu_mps))
 
     # Generate a KML file.
-    path = os.path.join(output_dir, 'position.kml')
+    path = f'{output_prefix}.kml'
     logger.info("Generating '%s'." % path)
     with open(path, 'w') as f:
         f.write(KML_TEMPLATE_START)

--- a/python/examples/extract_satellite_info.py
+++ b/python/examples/extract_satellite_info.py
@@ -55,8 +55,10 @@ Extract satellite azimuth, elevation, and L1 signal C/N0 data to a CSV file.
         logger.warning('No satellite data found in log file.')
         sys.exit(2)
 
+    output_prefix = os.path.join(output_dir, os.path.splitext(os.path.basename(input_path))[0])
+
     # Generate a CSV file.
-    path = os.path.join(output_dir, 'satellite_info.csv')
+    path = f'{output_prefix}.satellite_info.csv'
     logger.info("Generating '%s'." % path)
     with open(path, 'w') as f:
         f.write('P1 Time (sec), GPS Time (sec), System, PRN, Azimuth (deg), Elevation (deg), C/N0 (dB-Hz)\n')

--- a/python/examples/extract_vehicle_speed_data.py
+++ b/python/examples/extract_vehicle_speed_data.py
@@ -61,10 +61,12 @@ Extract wheel speed data.
         logger.warning('No speed data found in log file.')
         sys.exit(2)
 
+    output_prefix = os.path.join(output_dir, os.path.splitext(os.path.basename(input_path))[0])
+
     # Generate a CSV file for corrected wheel speed data.
     wheel_speed_data = result[WheelSpeedOutput.MESSAGE_TYPE]
     if len(wheel_speed_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'wheel_speed_data.csv')
+        path = f'{output_prefix}.wheel_speed.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(wheel_speed_data.p1_time)
         with open(path, 'w') as f:
@@ -82,7 +84,7 @@ Extract wheel speed data.
     # Generate a CSV file for raw wheel speed data.
     raw_wheel_speed_data = result[RawWheelSpeedOutput.MESSAGE_TYPE]
     if len(raw_wheel_speed_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'raw_wheel_speed_data.csv')
+        path = f'{output_prefix}.raw_wheel_speed.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(raw_wheel_speed_data.p1_time)
         with open(path, 'w') as f:
@@ -100,7 +102,7 @@ Extract wheel speed data.
     # Generate a CSV file for corrected vehicle speed data.
     vehicle_speed_data = result[VehicleSpeedOutput.MESSAGE_TYPE]
     if len(vehicle_speed_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'vehicle_speed_data.csv')
+        path = f'{output_prefix}.vehicle_speed.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(vehicle_speed_data.p1_time)
         with open(path, 'w') as f:
@@ -115,7 +117,7 @@ Extract wheel speed data.
     # Generate a CSV file for raw vehicle speed data.
     raw_vehicle_speed_data = result[RawVehicleSpeedOutput.MESSAGE_TYPE]
     if len(raw_vehicle_speed_data.p1_time) != 0:
-        path = os.path.join(output_dir, 'raw_vehicle_speed_data.csv')
+        path = f'{output_prefix}.raw_vehicle_speed.csv'
         logger.info("Generating '%s'." % path)
         gps_time = reader.convert_to_gps_time(raw_vehicle_speed_data.p1_time)
         with open(path, 'w') as f:

--- a/python/examples/serial_client.py
+++ b/python/examples/serial_client.py
@@ -15,11 +15,10 @@ except ImportError:
 root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, root_dir)
 
+from fusion_engine_client.applications.p1_print import add_print_format_argument, print_message
 from fusion_engine_client.parsers import FusionEngineDecoder
 from fusion_engine_client.utils import trace as logging
 from fusion_engine_client.utils.argument_parser import ArgumentParser
-
-from examples.message_decode import print_message
 
 
 if __name__ == "__main__":
@@ -30,6 +29,7 @@ contents and/or log the messages to disk.
 
     parser.add_argument('-b', '--baud', type=int, default=460800,
                         help="The serial baud rate to be used.")
+    add_print_format_argument(parser, '--display-format')
     parser.add_argument('-f', '--format', default='p1log', choices=('p1log', 'raw'),
                         help="The format of the file to be generated when --output is enabled."
                              "If 'p1log' (default), create a *.p1log file containing only FusionEngine messages."
@@ -113,7 +113,7 @@ contents and/or log the messages to disk.
                     output_file.write(raw_data)
 
                 if options.display:
-                    print_message(header, message)
+                    print_message(header, message, format=options.display_format)
 
     # Close the serial port.
     port.close()

--- a/python/examples/tcp_client.py
+++ b/python/examples/tcp_client.py
@@ -10,10 +10,9 @@ import sys
 root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, root_dir)
 
+from fusion_engine_client.applications.p1_print import add_print_format_argument, print_message
 from fusion_engine_client.parsers import FusionEngineDecoder
 from fusion_engine_client.utils.argument_parser import ArgumentParser
-
-from examples.message_decode import print_message
 
 
 if __name__ == "__main__":
@@ -22,6 +21,7 @@ Connect to an Point One device over TCP and print out the incoming message
 contents and/or log the messages to disk.
 """)
 
+    add_print_format_argument(parser, '--display-format')
     parser.add_argument('-f', '--format', default='p1log', choices=('p1log', 'raw'),
                         help="The format of the file to be generated when --output is enabled."
                              "If 'p1log' (default), create a *.p1log file containing only FusionEngine messages."
@@ -101,7 +101,7 @@ contents and/or log the messages to disk.
                     output_file.write(raw_data)
 
                 if options.display:
-                    print_message(header, message)
+                    print_message(header, message, format=options.display_format)
 
     # Close the socket.
     sock.close()

--- a/python/examples/udp_client.py
+++ b/python/examples/udp_client.py
@@ -12,10 +12,10 @@ import time
 root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, root_dir)
 
+from fusion_engine_client.applications.p1_print import add_print_format_argument, print_message
 from fusion_engine_client.parsers import FusionEngineDecoder
 from fusion_engine_client.utils.argument_parser import ArgumentParser
 
-from examples.message_decode import print_message
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="""\
@@ -25,6 +25,7 @@ contents and/or log the messages to disk.
 When using UDP, you must configure the device to send data to your machine.
 """)
 
+    add_print_format_argument(parser, '--display-format')
     parser.add_argument('-f', '--format', default='p1log', choices=('p1log', 'raw', 'csv'),
                         help="""\
 The format of the file to be generated when --output is enabled:
@@ -108,7 +109,7 @@ The format of the file to be generated when --output is enabled:
                     output_file.write(raw_data)
 
                 if options.display:
-                    print_message(header, message)
+                    print_message(header, message, format=options.display_format)
 
                 if generating_csv:
                     p1_time = message.get_p1_time()


### PR DESCRIPTION
# Changes
- Use input file prefix for output filenames in extract_* scripts
- Added `--display-format` option to example client apps matching `p1_print`