### PR TITLE
`HeadingOutput` Python and documentation cleanup.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1808,7 +1808,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             row=3, col=1
         )
 
-        fig.update_layout(title='Heading Plots', legend_traceorder='normal')
+        fig.update_layout(title='Heading Plots', legend_traceorder='normal', modebar_add=['v1hovermode'])
 
 
         # Display the navigation engine's heading estimate, if available, for comparison with the heading sensor

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2005,7 +2005,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
                     marker={'color': 'green'},
                     hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
                                   '<br><b>Solution</b>: %{text}',
-                    text=[str(SolutionType(s)) for s in raw_heading_data.solution_type],
+                    text=[str(SolutionType(s)) for s in heading_data.solution_type],
                     name='Corrected Heading Solution Type'
                 ),
                 row=3, col=1

--- a/python/fusion_engine_client/analysis/data_loader.py
+++ b/python/fusion_engine_client/analysis/data_loader.py
@@ -199,7 +199,7 @@ class DataLoader(object):
                 self._need_system_t0 = False
         else:
             self.read(require_p1_time=True, max_messages=1, max_bytes=1 * 1024 * 1024,
-                      disable_index_generation=True, ignore_cache=True, show_progress=False)
+                      ignore_cache=True, show_progress=False)
 
         # Similarly, we also set the system t0 based on the first system-stamped (typically POSIX) message to appear in
         # the log, if any (profiling data, etc.). Unlike P1 time, since the index file does not contain system
@@ -207,7 +207,7 @@ class DataLoader(object):
         # read operation.
         if self._need_system_t0:
             self.read(require_system_time=True, max_messages=1, max_bytes=1 * 1024 * 1024,
-                      disable_index_generation=True, ignore_cache=True, show_progress=False)
+                      ignore_cache=True, show_progress=False)
 
     def close(self):
         """!
@@ -234,8 +234,6 @@ class DataLoader(object):
                be read. See @ref TimeRange for more details.
 
         @param show_progress If `True`, print the read progress every 10 MB (useful for large files).
-        @param disable_index_generation If `True`, override the `save_index` argument provided to `open()` and do
-               not generate an index file during this call (intended for internal use only).
         @param ignore_cache If `True`, ignore any cached data from a previous @ref read() call, and reload the requested
                data from disk.
 
@@ -277,7 +275,7 @@ class DataLoader(object):
               message_types: Union[Iterable[MessageType], MessageType] = None,
               time_range: TimeRange = None,
               show_progress: bool = False,
-              ignore_cache: bool = False, disable_index_generation: bool = False,
+              ignore_cache: bool = False,
               max_messages: int = None, max_bytes: int = None,
               require_p1_time: bool = False, require_system_time: bool = False,
               return_in_order: bool = False, return_bytes: bool = False, return_message_index: bool = False,

--- a/python/fusion_engine_client/messages/control.py
+++ b/python/fusion_engine_client/messages/control.py
@@ -25,6 +25,7 @@ class CommandResponseMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -84,6 +85,7 @@ class MessageRequest(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -322,6 +324,7 @@ class ResetRequest(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         self._STRUCT.pack_into(buffer, offset, self.reset_mask)
 

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -2,7 +2,7 @@ import inspect
 import re
 import struct
 import sys
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 from zlib import crc32
 
 import numpy as np
@@ -314,7 +314,8 @@ class MessageHeader:
             return self.calcsize()
 
     def unpack(self, buffer: bytes, offset: int = 0, validate_sync: bool = False, validate_crc: bool = False,
-               warn_on_unrecognized: bool = True) -> int:
+               warn_on_unrecognized: bool = True, return_sync_bytes: bool = False) -> \
+            Union[int, Tuple[int, bytes]]:
         """!
         @brief Deserialize a message header and validate its sync bytes and CRC.
 
@@ -326,6 +327,7 @@ class MessageHeader:
         @param validate_sync If `True`, validate the sync bytes contained in the data buffer.
         @param validate_crc If `True`, validate the deserialized CRC against the data in the buffer.
         @param warn_on_unrecognized If `True`, print a warning if the message type is not listed in @ref MessageType.
+        @param return_sync_bytes If `True`, return the decoded sync bytes in addition to the header size.
 
         @return The size of the serialized header (in bytes).
         """
@@ -350,7 +352,10 @@ class MessageHeader:
                             'Unrecognized message type %d.' % message_type_int)
             self.message_type = MessageType(message_type_int, raise_on_unrecognized=False)
 
-        return MessageHeader._SIZE
+        if return_sync_bytes:
+            return MessageHeader._SIZE, bytes((sync0, sync1))
+        else:
+            return MessageHeader._SIZE
 
     def get_message_size(self) -> int:
         """!

--- a/python/fusion_engine_client/messages/measurement_details.py
+++ b/python/fusion_engine_client/messages/measurement_details.py
@@ -66,6 +66,7 @@ class MeasurementDetails(object):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1243,8 +1243,7 @@ class HeadingOutput(MessagePayload):
 
     def __repr__(self):
         result = super().__repr__()[:-1]
-        ypr_str = ['%.1f' % v for v in self.ypr_deg]
-        result += f', solution_type={self.solution_type}, ypr=[{ypr_str}] deg]'
+        result += f', solution_type={self.solution_type}, heading={self.heading_true_north_deg:.1f} deg]'
         return result
 
     def __str__(self):

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1170,7 +1170,7 @@ Vehicle Speed Measurement @ {str(self.details.p1_time)}
 
 class HeadingOutput(MessagePayload):
     """!
-     @brief Corrected heading sensor measurement output.
+    @brief Heading sensor measurement output with heading bias corrections applied.
     """
     MESSAGE_TYPE = MessageType.HEADING_OUTPUT
     MESSAGE_VERSION = 0
@@ -1185,12 +1185,15 @@ class HeadingOutput(MessagePayload):
         self.solution_type = SolutionType.Invalid
         ## A bitmask of flags associated with the solution
         self.flags = 0
-        ## The measured YPR vector (in degrees), resolved in the ENU frame.
+
+        ##
+        # The measured YPR vector (in degrees), resolved in the ENU frame, after applying horizontal (yaw) and vertical
+        # (pitch) bias corrections.
         self.ypr_deg = np.full((3,), np.nan)
 
         ##
-        # The corrected heading between the primary device antenna and the secondary (in degrees) with
-        # respect to true north.
+        # The heading angle (in degrees) with respect to true north, pointing from the primary antenna to the secondary
+        # antenna, after applying bias corrections.
         #
         # @note
         # Reported in the range [0, 360).
@@ -1270,7 +1273,7 @@ Heading Output @ {str(self.details.p1_time)}
 
 class RawHeadingOutput(MessagePayload):
     """!
-     @brief Raw (uncorrected) heading sensor measurement output.
+    @brief Raw (uncorrected) heading sensor measurement output.
     """
     MESSAGE_TYPE = MessageType.RAW_HEADING_OUTPUT
     MESSAGE_VERSION = 0

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1251,8 +1251,7 @@ class HeadingOutput(MessagePayload):
 Heading Output @ {str(self.details.p1_time)}
   Solution Type: {self.solution_type}
   YPR (ENU) (deg): {self.ypr_deg[0]:.2f}, {self.ypr_deg[1]:.2f}, {self.ypr_deg[2]:.2f}
-  Heading (deg): {self.heading_true_north_deg:.2f}
-  """
+  Heading (deg): {self.heading_true_north_deg:.2f}"""
 
     @classmethod
     def calcsize(cls) -> int:

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1203,8 +1203,7 @@ class HeadingOutput(MessagePayload):
 
         initial_offset = offset
 
-        buffer = self.details.pack(buffer)
-        offset += self.details.calcsize()
+        offset += self.details.pack(buffer, offset, return_buffer=False)
 
         self._STRUCT.pack_into(
             buffer, offset,
@@ -1231,7 +1230,8 @@ class HeadingOutput(MessagePayload):
          self.ypr_deg[0],
          self.ypr_deg[1],
          self.ypr_deg[2],
-         self.heading_true_north_deg) = self._STRUCT.unpack_from(buffer, offset)
+         self.heading_true_north_deg) = \
+            self._STRUCT.unpack_from(buffer, offset)
         offset += self._STRUCT.size
 
         self.solution_type = SolutionType(solution_type_int)

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -73,6 +73,7 @@ class IMUInput(MessagePayload):
         return construct_message_to_string(message=self, construct=self.Construct, title='IMU Input',
                                            fields=['details', 'accel_mps2', 'gyro_rps', 'temperature_degc'])
 
+
 class IMUOutput(MessagePayload):
     """!
     @brief IMU sensor measurement data.
@@ -94,6 +95,7 @@ class IMUOutput(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -785,6 +787,7 @@ class WheelTickInput(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -888,6 +891,7 @@ class VehicleTickInput(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -999,6 +1003,7 @@ class DeprecatedWheelSpeedMeasurement(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -1103,6 +1108,7 @@ class DeprecatedVehicleSpeedMeasurement(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -1193,6 +1199,7 @@ class HeadingOutput(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -1303,6 +1310,7 @@ class RawHeadingOutput(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 

--- a/python/fusion_engine_client/messages/ros.py
+++ b/python/fusion_engine_client/messages/ros.py
@@ -38,6 +38,7 @@ class ROSPoseMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -160,6 +161,7 @@ class ROSGPSFixMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -288,6 +290,7 @@ class ROSIMUMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -45,6 +45,7 @@ class PoseMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -188,6 +189,7 @@ class PoseAuxMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -277,6 +279,7 @@ class GNSSInfoMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -418,6 +421,7 @@ class SatelliteInfo:
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         if np.isnan(self.cn0_dbhz):
             cn0_int = SatelliteInfo.INVALID_CN0
@@ -476,6 +480,7 @@ class GNSSSatelliteMessage(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 
@@ -680,6 +685,7 @@ class CalibrationStatus(MessagePayload):
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
+            offset = 0
 
         initial_offset = offset
 

--- a/src/point_one/fusion_engine/messages/measurements.h
+++ b/src/point_one/fusion_engine/messages/measurements.h
@@ -1134,8 +1134,8 @@ struct P1_ALIGNAS(4) DeprecatedVehicleSpeedMeasurement : public MessagePayload {
  *        MessageType::RAW_HEADING_OUTPUT, version 1.0).
  * @ingroup measurement_messages
  *
- * This message contains raw heading sensor measurements that have not been
- * corrected for mounting angle biases.
+ * This message is an output from the device contaning raw heading sensor
+ * measurements that have not been corrected for mounting angle biases.
  *
  * See also @ref HeadingOutput.
  */
@@ -1194,15 +1194,16 @@ struct P1_ALIGNAS(4) RawHeadingOutput : public MessagePayload {
 };
 
 /**
- * @brief Heading sensor measurement output (@ref MessageType::HEADING_OUTPUT,
- *        version 1.0).
+ * @brief Heading sensor measurement output with heading bias corrections
+ *        applied (@ref MessageType::HEADING_OUTPUT, version 1.0).
  * @ingroup measurement_messages
  *
- * The HeadingOutput message behaves similarly to the RawHeadingOutput,
- * however, if no biases have been set AND the message is enabled,
- * then the message will not be published.
+ * This message is an output from the device contaning heading sensor
+ * measurements after applying user-specified horizontal and vertical bias
+ * corrections to account for the orientation of the primary and secondary GNSS
+ * antennas.
  *
- * See also @ref RawHeadingOutput and @ref SolutionType::Invalid.
+ * See also @ref RawHeadingOutput.
  */
 struct P1_ALIGNAS(4) HeadingOutput : public MessagePayload {
   static constexpr MessageType MESSAGE_TYPE = MessageType::HEADING_OUTPUT;
@@ -1242,8 +1243,9 @@ struct P1_ALIGNAS(4) HeadingOutput : public MessagePayload {
   float ypr_deg[3] = {NAN, NAN, NAN};
 
   /**
-   * The corrected heading angle (in degrees) with respect to true north,
-   * pointing from the primary antenna to the secondary antenna.
+   * The heading angle (in degrees) with respect to true north, pointing from
+   * the primary antenna to the secondary  antenna, after applying bias
+   * corrections.
    *
    * @note
    * Reported in the range [0, 360).

--- a/src/point_one/fusion_engine/messages/measurements.h
+++ b/src/point_one/fusion_engine/messages/measurements.h
@@ -1130,6 +1130,66 @@ struct P1_ALIGNAS(4) DeprecatedVehicleSpeedMeasurement : public MessagePayload {
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
+ * @brief Heading sensor measurement output with heading bias corrections
+ *        applied (@ref MessageType::HEADING_OUTPUT, version 1.0).
+ * @ingroup measurement_messages
+ *
+ * This message is an output from the device contaning heading sensor
+ * measurements after applying user-specified horizontal and vertical bias
+ * corrections to account for the orientation of the primary and secondary GNSS
+ * antennas.
+ *
+ * See also @ref RawHeadingOutput.
+ */
+struct P1_ALIGNAS(4) HeadingOutput : public MessagePayload {
+  static constexpr MessageType MESSAGE_TYPE = MessageType::HEADING_OUTPUT;
+  static constexpr uint8_t MESSAGE_VERSION = 0;
+
+  /**
+   * Measurement timestamp and additional information, if available. See @ref
+   * MeasurementDetails for details.
+   */
+  MeasurementDetails details;
+
+  /**
+   * Set to @ref SolutionType::RTKFixed when heading is available, or @ref
+   * SolutionType::Invalid otherwise.
+   */
+  SolutionType solution_type = SolutionType::Invalid;
+
+  uint8_t reserved[3] = {0};
+
+  /** A bitmask of flags associated with the solution. */
+  uint32_t flags = 0;
+
+  /**
+   * The measured YPR vector (in degrees), resolved in the ENU frame.
+   *
+   * YPR is defined as an intrinsic Euler-321 rotation, i.e., yaw, pitch, then
+   * roll.
+   *
+   * @note
+   * This field contains the measured attitude information (@ref
+   * RawHeadingOutput) from a secondary heading device after applying @ref
+   * ConfigType::HEADING_BIAS configuration settings for yaw (horizontal) and
+   * pitch (vertical) offsets between the primary and secondary GNSS antennas.
+   * If either bias value is not specified, the corresponding measurement values
+   * will be set to `NAN`.
+   */
+  float ypr_deg[3] = {NAN, NAN, NAN};
+
+  /**
+   * The heading angle (in degrees) with respect to true north, pointing from
+   * the primary antenna to the secondary  antenna, after applying bias
+   * corrections.
+   *
+   * @note
+   * Reported in the range [0, 360).
+   */
+  float heading_true_north_deg = NAN;
+};
+
+/**
  * @brief Raw (uncorrected) heading sensor measurement output (@ref
  *        MessageType::RAW_HEADING_OUTPUT, version 1.0).
  * @ingroup measurement_messages
@@ -1191,66 +1251,6 @@ struct P1_ALIGNAS(4) RawHeadingOutput : public MessagePayload {
    * The estimated distance between primary and secondary antennas (in meters).
    */
   float baseline_distance_m = NAN;
-};
-
-/**
- * @brief Heading sensor measurement output with heading bias corrections
- *        applied (@ref MessageType::HEADING_OUTPUT, version 1.0).
- * @ingroup measurement_messages
- *
- * This message is an output from the device contaning heading sensor
- * measurements after applying user-specified horizontal and vertical bias
- * corrections to account for the orientation of the primary and secondary GNSS
- * antennas.
- *
- * See also @ref RawHeadingOutput.
- */
-struct P1_ALIGNAS(4) HeadingOutput : public MessagePayload {
-  static constexpr MessageType MESSAGE_TYPE = MessageType::HEADING_OUTPUT;
-  static constexpr uint8_t MESSAGE_VERSION = 0;
-
-  /**
-   * Measurement timestamp and additional information, if available. See @ref
-   * MeasurementDetails for details.
-   */
-  MeasurementDetails details;
-
-  /**
-   * Set to @ref SolutionType::RTKFixed when heading is available, or @ref
-   * SolutionType::Invalid otherwise.
-   */
-  SolutionType solution_type = SolutionType::Invalid;
-
-  uint8_t reserved[3] = {0};
-
-  /** A bitmask of flags associated with the solution. */
-  uint32_t flags = 0;
-
-  /**
-   * The measured YPR vector (in degrees), resolved in the ENU frame.
-   *
-   * YPR is defined as an intrinsic Euler-321 rotation, i.e., yaw, pitch, then
-   * roll.
-   *
-   * @note
-   * This field contains the measured attitude information (@ref
-   * RawHeadingOutput) from a secondary heading device after applying @ref
-   * ConfigType::HEADING_BIAS configuration settings for yaw (horizontal) and
-   * pitch (vertical) offsets between the primary and secondary GNSS antennas.
-   * If either bias value is not specified, the corresponding measurement values
-   * will be set to `NAN`.
-   */
-  float ypr_deg[3] = {NAN, NAN, NAN};
-
-  /**
-   * The heading angle (in degrees) with respect to true north, pointing from
-   * the primary antenna to the secondary  antenna, after applying bias
-   * corrections.
-   *
-   * @note
-   * Reported in the range [0, 360).
-   */
-  float heading_true_north_deg = NAN;
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
# New Features
- Added option to return sync bytes from `MessageHeader.unpack()` if requested

# Changes
- Removed deprecated `disable_index_generation` argument

# Fixes
- Force `offset` to 0 in all `pack()` functions if allocating a byte buffer internally
- Cleaned up `HeadingOutput` pack/unpack functions and documentation
- Added heading value to `repr(HeadingOutput)` string
- Corrected corrected heading solution type in hover text
- Enable Plotly mouse hover mode selection on heading plot