### PR TITLE
Added `DataVersion` `str()` operator.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -1601,6 +1601,9 @@ class DataVersion(NamedTuple):
     major: int
     minor: int
 
+    def __str__(self):
+        return f'{self.major}.{self.minor}'
+
 
 _DataVersionConstructRaw = Struct(
     Padding(1),

--- a/python/fusion_engine_client/utils/argument_parser.py
+++ b/python/fusion_engine_client/utils/argument_parser.py
@@ -176,6 +176,8 @@ class CSVAction(argparse.Action):
         result = getattr(namespace, self.dest)
         if result is None:
             result = []
+        elif result is self.default:
+            result = []
         result.extend(flattened_values)
         setattr(namespace, self.dest, result)
 


### PR DESCRIPTION
# Changes
- Added simplified `str()` operator to `DataVersion` (e.g., "6.7")

# Fixes
- Fixed CSV-style command line arguments appending to the default value unexpectedly