### PR TITLE
Add bitmask in `PoseMessage` to signal stationary status of device

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -744,8 +744,8 @@ class Analyzer(object):
 
         figure['layout']['xaxis'].update(title=self.p1_time_label)
         figure['layout']['yaxis1'].update(title="Stationary Status",
-                                          ticktext=['Nonstationary', 'Stationary'],
-                                          tickvals=[0, 1])
+                                          ticktext=['Moving', 'Stationary'],
+                                          tickvals=[0, PoseMessage.FLAG_STATIONARY])
 
         time = pose_data.p1_time - float(self.t0)
 

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -26,6 +26,8 @@ class PoseMessage(MessagePayload):
 
         self.solution_type = SolutionType.Invalid
 
+        self.dynamic_status = np.nan
+
         # Added in version 1.1.
         self.undulation_m = np.nan
 
@@ -60,6 +62,7 @@ class PoseMessage(MessagePayload):
         self._STRUCT.pack_into(
             buffer, offset,
             int(self.solution_type),
+            self.dynamic_status,
             undulation_cm,
             self.lla_deg[0], self.lla_deg[1], self.lla_deg[2],
             self.position_std_enu_m[0], self.position_std_enu_m[1], self.position_std_enu_m[2],
@@ -84,6 +87,7 @@ class PoseMessage(MessagePayload):
         offset += self.gps_time.unpack(buffer, offset)
 
         (solution_type_int,
+         dynamic_status,
          undulation_cm,
          self.lla_deg[0], self.lla_deg[1], self.lla_deg[2],
          self.position_std_enu_m[0], self.position_std_enu_m[1], self.position_std_enu_m[2],
@@ -103,6 +107,8 @@ class PoseMessage(MessagePayload):
             self.undulation_m = undulation_cm * 1e-2
 
         self.solution_type = SolutionType(solution_type_int)
+
+        self.dynamic_status = dynamic_status
 
         return offset - initial_offset
 
@@ -152,6 +158,7 @@ class PoseMessage(MessagePayload):
             'p1_time': np.array([float(m.p1_time) for m in messages]),
             'gps_time': np.array([float(m.gps_time) for m in messages]),
             'solution_type': np.array([int(m.solution_type) for m in messages], dtype=int),
+            'dynamic_status': np.array([m.dynamic_status for m in messages]),
             'undulation': np.array([m.undulation_m for m in messages]),
             'lla_deg': np.array([m.lla_deg for m in messages]).T,
             'ypr_deg': np.array([m.ypr_deg for m in messages]).T,

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -18,6 +18,8 @@ class PoseMessage(MessagePayload):
 
     INVALID_UNDULATION = -32768
 
+    FLAG_STATIONARY = 0x1
+
     _STRUCT = struct.Struct('<Bx h ddd fff ddd fff ddd fff fff')
 
     def __init__(self):
@@ -26,7 +28,7 @@ class PoseMessage(MessagePayload):
 
         self.solution_type = SolutionType.Invalid
 
-        self.dynamic_status = np.nan
+        self.flags = 0x0
 
         # Added in version 1.1.
         self.undulation_m = np.nan
@@ -62,7 +64,7 @@ class PoseMessage(MessagePayload):
         self._STRUCT.pack_into(
             buffer, offset,
             int(self.solution_type),
-            self.dynamic_status,
+            self.flags,
             undulation_cm,
             self.lla_deg[0], self.lla_deg[1], self.lla_deg[2],
             self.position_std_enu_m[0], self.position_std_enu_m[1], self.position_std_enu_m[2],
@@ -87,7 +89,7 @@ class PoseMessage(MessagePayload):
         offset += self.gps_time.unpack(buffer, offset)
 
         (solution_type_int,
-         dynamic_status,
+         flags,
          undulation_cm,
          self.lla_deg[0], self.lla_deg[1], self.lla_deg[2],
          self.position_std_enu_m[0], self.position_std_enu_m[1], self.position_std_enu_m[2],
@@ -108,7 +110,7 @@ class PoseMessage(MessagePayload):
 
         self.solution_type = SolutionType(solution_type_int)
 
-        self.dynamic_status = dynamic_status
+        self.flags = flags
 
         return offset - initial_offset
 
@@ -158,7 +160,7 @@ class PoseMessage(MessagePayload):
             'p1_time': np.array([float(m.p1_time) for m in messages]),
             'gps_time': np.array([float(m.gps_time) for m in messages]),
             'solution_type': np.array([int(m.solution_type) for m in messages], dtype=int),
-            'dynamic_status': np.array([m.dynamic_status for m in messages]),
+            'flags': np.array([m.flags for m in messages]),
             'undulation': np.array([m.undulation_m for m in messages]),
             'lla_deg': np.array([m.lla_deg for m in messages]).T,
             'ypr_deg': np.array([m.ypr_deg for m in messages]).T,

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -160,7 +160,7 @@ class PoseMessage(MessagePayload):
             'p1_time': np.array([float(m.p1_time) for m in messages]),
             'gps_time': np.array([float(m.gps_time) for m in messages]),
             'solution_type': np.array([int(m.solution_type) for m in messages], dtype=int),
-            'flags': np.array([m.flags for m in messages]),
+            'flags': np.array([m.flags for m in messages], dtype=int),
             'undulation': np.array([m.undulation_m for m in messages]),
             'lla_deg': np.array([m.lla_deg for m in messages]).T,
             'ypr_deg': np.array([m.ypr_deg for m in messages]).T,

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -20,7 +20,7 @@ class PoseMessage(MessagePayload):
 
     FLAG_STATIONARY = 0x1
 
-    _STRUCT = struct.Struct('<Bx h ddd fff ddd fff ddd fff fff')
+    _STRUCT = struct.Struct('<BB h ddd fff ddd fff ddd fff fff')
 
     def __init__(self):
         self.p1_time = Timestamp()

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -42,6 +42,9 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   static constexpr uint8_t MESSAGE_VERSION = 1;
   static constexpr int16_t INVALID_UNDULATION = INT16_MIN;
 
+  static constexpr uint8_t NONSTATIONARY = 0x00000000;
+  static constexpr uint8_t STATIONARY = 0x00000001;
+
   /** The time of the message, in P1 time (beginning at power-on). */
   Timestamp p1_time;
 
@@ -51,7 +54,8 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   /** The type of this position solution. */
   SolutionType solution_type;
 
-  uint8_t reserved = 0;
+  /** Signals device dynamic status (stationary or nonstationary). */
+  uint8_t dynamic_status = NONSTATIONARY;
 
   /**
    * The geoid undulation at at the current location (i.e., the difference

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -42,8 +42,8 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   static constexpr uint8_t MESSAGE_VERSION = 1;
   static constexpr int16_t INVALID_UNDULATION = INT16_MIN;
 
-  static constexpr uint8_t NONSTATIONARY = 0x00000000;
-  static constexpr uint8_t STATIONARY = 0x00000001;
+  /** Set this flag if the device is stationary. */
+  static constexpr uint8_t FLAG_STATIONARY = 0x01;
 
   /** The time of the message, in P1 time (beginning at power-on). */
   Timestamp p1_time;
@@ -54,8 +54,8 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   /** The type of this position solution. */
   SolutionType solution_type;
 
-  /** Signals device dynamic status (stationary or nonstationary). */
-  uint8_t dynamic_status = NONSTATIONARY;
+  /** A bitmask of flags associated with the pose data. */
+  uint8_t flags = 0x0;
 
   /**
    * The geoid undulation at at the current location (i.e., the difference

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -42,7 +42,7 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   static constexpr uint8_t MESSAGE_VERSION = 1;
   static constexpr int16_t INVALID_UNDULATION = INT16_MIN;
 
-  /** Set this flag if the device is stationary. */
+  /** Set if the device is stationary. */
   static constexpr uint8_t FLAG_STATIONARY = 0x01;
 
   /** The time of the message, in P1 time (beginning at power-on). */


### PR DESCRIPTION
# New Features
- `PoseMessage` now has `flags member, which currently signals whether the device is stationary or not
- Add `Stationary Status` plotting tool