### PR TITLE
Add check to ensure file index is used correctly

### DIFF
--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -416,7 +416,9 @@ class MixedLogReader(object):
         if file_size is None:
             file_size = min(self.file_size_bytes, self.max_bytes)
 
-        if self.total_bytes_read - self.last_print_bytes > 10e6 or self.total_bytes_read == file_size:
+        if self.total_bytes_read < self.last_print_bytes or \
+           self.total_bytes_read - self.last_print_bytes > 10e6 or \
+           self.total_bytes_read == file_size:
             elapsed_sec = (datetime.now() - self.start_time).total_seconds()
             self.logger.log(logging.INFO if show_progress else logging.DEBUG,
                             'Processed %d/%d bytes (%.1f%%). [elapsed=%.1f sec, rate=%.1f MB/s]' %

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -591,6 +591,8 @@ class MixedLogReader(object):
         if self.index is not None:
             if len(self.index) == 0:
                 self.next_index_elem = 0
+            elif prev_offset_bytes < 0:
+                self.next_index_elem = 0
             else:
                 idx = np.argmax(self.index.offset > prev_offset_bytes)
                 if idx == 0 and self.index.offset[0] <= prev_offset_bytes:


### PR DESCRIPTION
# Fixes
- Add check for when `MixedLogReader` is rewound in order to prevent a numerical overflow error
- Set default next index element when file is being read from beginning