### PR TITLE
Fix missing header return in _populate_available_source_ids.

### DIFF
--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -627,6 +627,8 @@ class MixedLogReader(object):
 
     def _populate_available_source_ids(self, num_messages_to_read: int = 10):
         self.available_source_ids = set()
+        # This function requires that the header is returned. Store the current
+        # `self.return_header` value.
         stored_return_header = self.return_header
         self.return_header = True
         # Loop over all message types and read N of each type.

--- a/python/fusion_engine_client/parsers/mixed_log_reader.py
+++ b/python/fusion_engine_client/parsers/mixed_log_reader.py
@@ -627,6 +627,8 @@ class MixedLogReader(object):
 
     def _populate_available_source_ids(self, num_messages_to_read: int = 10):
         self.available_source_ids = set()
+        stored_return_header = self.return_header
+        self.return_header = True
         # Loop over all message types and read N of each type.
         for message_type in np.unique(self.index['type']):
             message_type = MessageType(message_type, raise_on_unrecognized=False)
@@ -644,6 +646,7 @@ class MixedLogReader(object):
 
             self.clear_filters()
 
+        self.return_header = stored_return_header
         self.rewind()
 
     def __iter__(self):


### PR DESCRIPTION
Fix crash when `self.return_header` is False.

```
Traceback (most recent call last):
  File "/home/jdiamond/src/nautilus/./point_one/platform/quectel-lg69t-evb/p1_runner/bin/extract_storage.py", line 215, in <module>
    main()
  File "/home/jdiamond/src/nautilus/./point_one/platform/quectel-lg69t-evb/p1_runner/bin/extract_storage.py", line 127, in main
    reader = MixedLogReader(input_path, message_types=(VersionInfoMessage,), return_header=False, return_bytes=True)
  File "/home/jdiamond/src/nautilus/venv_host_tools/lib/python3.10/site-packages/fusion_engine_client/parsers/mixed_log_reader.py", line 125, in __init__
    self._populate_available_source_ids()
  File "/home/jdiamond/src/nautilus/venv_host_tools/lib/python3.10/site-packages/fusion_engine_client/parsers/mixed_log_reader.py", line 643, in _populate_available_source_ids
    self.available_source_ids.add(header.source_identifier)
AttributeError: 'PlatformStorageDataMessage' object has no attribute 'source_identifier'
```