### PR TITLE
[FUS-2790] Add Response::UNSUPPORTED_INTERFACE

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -286,13 +286,13 @@ jobs:
         tar czf version-docs.tar.gz docs/include_header.js docs/versions.html
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: fusion-engine-client-docs.tar.gz
         path: fusion-engine-client-docs.tar.gz
 
     - name: Upload Versioned Files
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: version-docs.tar.gz
         path: version-docs.tar.gz
@@ -319,12 +319,12 @@ jobs:
         echo "Setting tag to: ${GIT_TAG}"
 
     - name: Get Documentation Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: fusion-engine-client-docs.tar.gz
 
     - name: Get Versioned Files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: version-docs.tar.gz
 
@@ -371,7 +371,7 @@ jobs:
         twine check dist/*
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: python_dist
         path: python/dist
@@ -386,12 +386,12 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
     - name: Get Documentation Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: fusion-engine-client-docs.tar.gz
 
     - name: Get Python Distribution Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: python_dist
         path: python/dist

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -79,7 +79,7 @@ class Response(IntEnum):
     NO_DATA_STORED = 8
     ## The device is in a state where it can't process the command.
     UNAVAILABLE = 9
-    ## A interface specified in the command is invalid, or unsupported on the target device.
+    ## An interface specified in the command is invalid, or unsupported on the target device.
     UNSUPPORTED_INTERFACE = 10
 
 

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -79,6 +79,8 @@ class Response(IntEnum):
     NO_DATA_STORED = 8
     ## The device is in a state where it can't process the command.
     UNAVAILABLE = 9
+    ## A interface specified in the command is invalid, or unsupported on the target device.
+    UNSUPPORTED_INTERFACE = 10
 
 
 class MessageType(IntEnum):

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -415,7 +415,7 @@ enum class Response : uint8_t {
    */
   UNAVAILABLE = 9,
   /**
-   * A interface specified in the command is invalid, or unsupported on the
+   * An interface specified in the command is invalid, or unsupported on the
    * target device.
    */
   UNSUPPORTED_INTERFACE = 10,
@@ -451,7 +451,7 @@ P1_CONSTEXPR_FUNC const char* to_string(Response val) {
     case Response::UNAVAILABLE:
       return "Device Unavailable";
     case Response::UNSUPPORTED_INTERFACE:
-      return "Interface ID Error";
+      return "Unsupported Interface";
   }
   return "Unrecognized";
 }

--- a/src/point_one/fusion_engine/messages/defs.h
+++ b/src/point_one/fusion_engine/messages/defs.h
@@ -414,6 +414,11 @@ enum class Response : uint8_t {
    * The device is in a state where it can't process the command.
    */
   UNAVAILABLE = 9,
+  /**
+   * A interface specified in the command is invalid, or unsupported on the
+   * target device.
+   */
+  UNSUPPORTED_INTERFACE = 10,
 };
 
 /**
@@ -445,9 +450,10 @@ P1_CONSTEXPR_FUNC const char* to_string(Response val) {
       return "No Data Stored";
     case Response::UNAVAILABLE:
       return "Device Unavailable";
-    default:
-      return "Unrecognized";
+    case Response::UNSUPPORTED_INTERFACE:
+      return "Interface ID Error";
   }
+  return "Unrecognized";
 }
 
 /**


### PR DESCRIPTION
# New Features
- Added separate `UNSUPPORTED_INTERFACE` response code

# Changes
- Issue a compiler warning for missing enum values in `to_string(Response val)`

# Bug Fixes
- Update deprecated Github actions