### PR TITLE
Allow programmatic access to `p1_display` internals.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -88,6 +88,10 @@ FusionEngine message specification.
     
 ### Usage Instructions
 
+> Note for Windows users: You must install Python using an installer from
+> https://www.python.org/downloads/windows/ and select "Add python.exe to PATH". (Do not install Python using Microsoft
+> Store.)
+
 #### Install From PyPI
 
 1. Install Python (3.6 or later) and pip.

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2812,7 +2812,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         return {e: colors[i % len(colors)] for i, e in enumerate(elements)}
 
 
-def main():
+def main(args=None):
     parser = ArgumentParser(description="""\
 Load and display information stored in a FusionEngine binary file.
 """)
@@ -2908,7 +2908,7 @@ Load and display information stored in a FusionEngine binary file.
         '-v', '--verbose', action='count', default=0,
         help="Print verbose/trace debugging messages.")
 
-    options = parser.parse_args()
+    options = parser.parse_args(args=args)
 
     # Configure logging.
     if options.verbose >= 1:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -858,18 +858,18 @@ class Analyzer(object):
         @param truth_lla_deg The truth LLA location (in degrees/meters).
         """
         truth_ecef_m = np.array(geodetic2ecef(*truth_lla_deg, deg=True))
-        self._plot_pose_displacement(title='Position Error', center_ecef_m=truth_ecef_m)
+        return self._plot_pose_displacement(title='Position Error', center_ecef_m=truth_ecef_m)
 
     def plot_pose_displacement(self):
         """!
         @brief Generate a topocentric (top-down) plot of position displacement, as well as plot of displacement over
                time.
         """
-        self._plot_pose_displacement()
+        return self._plot_pose_displacement()
 
     def _plot_pose_displacement(self, title='Pose Displacement', center_ecef_m=None):
         if self.output_dir is None:
-            return
+            return None
 
         # Read the pose data.
         result = self.reader.read(message_types=[PoseMessage], source_ids=self.default_source_id, **self.params)
@@ -877,13 +877,13 @@ class Analyzer(object):
 
         if len(pose_data.p1_time) == 0:
             self.logger.info('No pose data available. Skipping displacement plots.')
-            return
+            return None
 
         # Remove invalid solutions.
         valid_idx = np.logical_and(~np.isnan(pose_data.p1_time), pose_data.solution_type != SolutionType.Invalid)
         if not np.any(valid_idx):
             self.logger.info('No valid position solutions detected. Skipping displacement plots.')
-            return
+            return None
 
         time = pose_data.p1_time[valid_idx] - float(self.t0)
         solution_type = pose_data.solution_type[valid_idx]
@@ -905,6 +905,8 @@ class Analyzer(object):
 
         self._plot_displacement(source=title, title=axis_title, time=time, solution_type=solution_type,
                                 displacement_enu_m=displacement_enu_m, std_enu_m=std_enu_m)
+
+        return displacement_enu_m
 
     def plot_relative_position(self):
         """!

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -3042,7 +3042,7 @@ Load and display information stored in a FusionEngine binary file.
     analyzer.generate_index(auto_open=not options.no_index)
 
     _logger.info("Output stored in '%s'." % os.path.abspath(output_dir))
-
+    return analyzer
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Changes
- Added a note to `README.md` explaining Windows Python requirements
- Return `Analyzer` from `main()` so it may be accessed further when embedded within another application
- Constrain the 3D displacement Y axis to min 0