### PR TITLE
Removed deprecated HeadingBias config in favor of GNSS aux lever arm specification.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -30,7 +30,8 @@ class ConfigType(IntEnum):
     VEHICLE_DETAILS = 20
     WHEEL_CONFIG = 21
     HARDWARE_TICK_CONFIG = 22
-    HEADING_BIAS = 23
+    DEPRECATED_HEADING_BIAS = 23
+    GNSS_AUX_LEVER_ARM = 24
     ENABLED_GNSS_SYSTEMS = 50
     ENABLED_GNSS_FREQUENCY_BANDS = 51
     LEAP_SECOND = 52
@@ -654,19 +655,6 @@ class _ConfigClassGenerator:
         "wheel_ticks_to_m" / Float32l,
     )
 
-    class HeadingBias(NamedTuple):
-        """!
-        @brief Horizontal and vertical heading bias configuration settings.
-        """
-        horizontal_bias_deg: float = math.nan
-        vertical_bias_deg: float = math.nan
-
-
-    HeadingBiasConstruct = Struct(
-        "horizontal_bias_deg" / Float32l,
-        "vertical_bias_deg" / Float32l,
-    )
-
     class IonosphereConfig(NamedTuple):
         """!
         @brief Ionospheric delay model configuration.
@@ -754,13 +742,22 @@ class DeviceLeverArmConfig(_conf_gen.Point3F):
 @_conf_gen.create_config_class(ConfigType.GNSS_LEVER_ARM, _conf_gen.Point3FConstruct)
 class GNSSLeverArmConfig(_conf_gen.Point3F):
     """!
-    @brief The location of the GNSS antenna with respect to the vehicle body frame, resolved in the vehicle body frame
-           (in meters).
+    @brief The location of the primary GNSS antenna with respect to the vehicle body frame, resolved in the vehicle body
+           frame (in meters).
     """
     pass
 
 # Alias for convenience.
 GnssLeverArmConfig = GNSSLeverArmConfig
+
+
+@_conf_gen.create_config_class(ConfigType.GNSS_AUX_LEVER_ARM, _conf_gen.Point3FConstruct)
+class GNSSAuxLeverArmConfig(_conf_gen.Point3F):
+    """!
+    @brief The location of the secondary GNSS antenna with respect to the vehicle body frame on a dual-antenna platform,
+           resolved in the vehicle body frame (in meters).
+    """
+    pass
 
 
 @_conf_gen.create_config_class(ConfigType.OUTPUT_LEVER_ARM, _conf_gen.Point3FConstruct)
@@ -926,14 +923,6 @@ class WheelConfig(_conf_gen.WheelConfig):
 class HardwareTickConfig(_conf_gen.HardwareTickConfig):
     """!
     @brief Tick configuration settings.
-    """
-    pass
-
-
-@_conf_gen.create_config_class(ConfigType.HEADING_BIAS, _conf_gen.HeadingBiasConstruct)
-class HeadingBias(_conf_gen.HeadingBias):
-    """!
-    @brief Horizontal and vertical heading bias.
     """
     pass
 

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -745,7 +745,8 @@ _conf_gen = _ConfigClassGenerator()
 @_conf_gen.create_config_class(ConfigType.DEVICE_LEVER_ARM, _conf_gen.Point3FConstruct)
 class DeviceLeverArmConfig(_conf_gen.Point3F):
     """!
-    @brief The location of the device IMU with respect to the vehicle body frame (in meters).
+    @brief The location of the device IMU with respect to the vehicle body frame, resolved in the vehicle body frame (in
+           meters).
     """
     pass
 
@@ -753,7 +754,8 @@ class DeviceLeverArmConfig(_conf_gen.Point3F):
 @_conf_gen.create_config_class(ConfigType.GNSS_LEVER_ARM, _conf_gen.Point3FConstruct)
 class GNSSLeverArmConfig(_conf_gen.Point3F):
     """!
-    @brief The location of the GNSS antenna with respect to the vehicle body frame (in meters).
+    @brief The location of the GNSS antenna with respect to the vehicle body frame, resolved in the vehicle body frame
+           (in meters).
     """
     pass
 
@@ -764,7 +766,8 @@ GnssLeverArmConfig = GNSSLeverArmConfig
 @_conf_gen.create_config_class(ConfigType.OUTPUT_LEVER_ARM, _conf_gen.Point3FConstruct)
 class OutputLeverArmConfig(_conf_gen.Point3F):
     """!
-    @brief The location of the desired output location with respect to the vehicle body frame (in meters).
+    @brief The location of the desired output location with respect to the vehicle body frame, resolved in the vehicle
+           body frame (in meters).
     """
     pass
 

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -796,9 +796,19 @@ def PackedDataToBuffer(packed_data: bytes, buffer: Optional[bytes] = None, offse
         return len(packed_data)
 
 
-def yaw_to_heading(yaw_deg: Union[float, np.ndarray]):
-    return 90.0 - yaw_deg
+def yaw_to_heading(yaw: Union[float, np.ndarray], deg: bool = True):
+    if deg:
+        heading_deg = 90.0 - yaw
+        return np.fmod(heading_deg + 180.0, 360.0)
+    else:
+        heading_rad = math.pi / 2.0 - yaw
+        return np.fmod(heading_rad + math.pi, 2.0 * math.pi)
 
 
-def heading_to_yaw(heading_deg: Union[float, np.ndarray]):
-    return 90.0 - heading_deg
+def heading_to_yaw(heading: Union[float, np.ndarray], deg: bool = True):
+    if deg:
+        yaw_deg = 90.0 - heading
+        return np.fmod(yaw_deg + 180.0, 360.0) - 180.0
+    else:
+        yaw_rad = math.pi / 2.0 - heading
+        return np.fmod(yaw_rad + math.pi, 2.0 * math.pi) - math.pi

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -53,8 +53,8 @@ enum class ConfigType : uint16_t {
   DEVICE_COARSE_ORIENTATION = 17,
 
   /**
-   * The location of the GNSS antenna with respect to the vehicle body frame,
-   * resolved in the vehicle body frame (in meters).
+   * The location of the primary GNSS antenna with respect to the vehicle body
+   * frame, resolved in the vehicle body frame (in meters).
    *
    * Payload format: @ref Point3f
    */
@@ -101,11 +101,24 @@ enum class ConfigType : uint16_t {
 
   /**
    * Used to set horizontal (yaw) & vertical (pitch) biases (in degrees) on
-   * a dual-antenna heading platform configuration.
+   * a dual-antenna heading platform configuration (deprecated).
    *
-   * Payload format: @ref HeadingBias
+   * @deprecated
+   * Use @ref ConfigType::GNSS_AUX_LEVER_ARM instead.
    */
-  HEADING_BIAS = 23,
+  DEPRECATED_HEADING_BIAS = 23,
+
+  /**
+   * The location of the secondary GNSS antenna with respect to the vehicle body
+   * frame on a dual-antenna platform, resolved in the vehicle body frame (in
+   * meters).
+   *
+   * For dual-antenna systems, the secondary or auxiliary antenna is used to
+   * measure vehicle yaw and pitch.
+   *
+   * Payload format: @ref Point3f
+   */
+  GNSS_AUX_LEVER_ARM = 24,
 
   /**
    * A bitmask indicating which GNSS constellations are enabled.
@@ -287,8 +300,11 @@ P1_CONSTEXPR_FUNC const char* to_string(ConfigType type) {
     case ConfigType::HARDWARE_TICK_CONFIG:
       return "Hardware Tick Config";
 
-    case ConfigType::HEADING_BIAS:
+    case ConfigType::DEPRECATED_HEADING_BIAS:
       return "Heading Bias";
+
+    case ConfigType::GNSS_AUX_LEVER_ARM:
+      return "GNSS Aux Lever Arm";
 
     case ConfigType::ENABLED_GNSS_SYSTEMS:
       return "Enabled GNSS Systems";
@@ -1211,48 +1227,6 @@ struct P1_ALIGNAS(4) HardwareTickConfig {
    * meters/tick). Used for @ref WheelSensorType::TICKS.
    */
   float wheel_ticks_to_m = NAN;
-};
-
-/**
- * @brief Heading bias horizontal/vertical configuration settings.
- * @ingroup config_types
- *
- * @note
- * Both HeadingBias values must be set for the system to use them.
- * If one value is NOT set, the system will not output the corrected
- * heading message.
- *
- * @ref GNSSAttitudeOutput
- */
-struct P1_ALIGNAS(4) HeadingBias {
-  /**
-   * The offset between the heading measured by a secondary GNSS device and the
-   * vehicle's direction of motion in the horizontal plane (defined by the
-   * vehicle's forward and left axes).
-   *
-   * Bias is defined as the angle between the vector pointing from the primary
-   * GNSS antenna to the secondary heading antenna, and the vector pointing from
-   * the primary antenna pointing in the forward direction of the vehicle. A
-   * positive angle means the secondary antenna is offset in a counter-clockwise
-   * direction from the forward vector (positive yaw rotation).
-   *
-   * For example, if the primary antenna is in the back of the vehicle and the
-   * secondary antenna is in the front, a positive angle would indicate that the
-   * secondary antenna is offset to the left side of the vehicle.
-   */
-  float horizontal_bias_deg = NAN;
-
-  /**
-   * The offset between the heading measured by a secondary GNSS device and the
-   * vehicle's direction of motion in the vertical plane (defined by the
-   * vehicle's forward and up axes).
-   *
-   * A positive angle means the secondary antenna is offset in the downward
-   * direction. For example, if the primary antenna is in the back of the
-   * vehicle and the secondary antenna is in the front, a positive angle would
-   * indicate that the secondary antenna is mounted below the primary antenna.
-   */
-  float vertical_bias_deg = NAN;
 };
 
 /**

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -38,8 +38,8 @@ enum class ConfigType : uint16_t {
   INVALID = 0,
 
   /**
-   * The location of the device IMU with respect to the vehicle body frame (in
-   * meters).
+   * The location of the device IMU with respect to the vehicle body frame,
+   * resolved in the vehicle body frame (in meters).
    *
    * Payload format: @ref Point3f
    */
@@ -53,8 +53,8 @@ enum class ConfigType : uint16_t {
   DEVICE_COARSE_ORIENTATION = 17,
 
   /**
-   * The location of the GNSS antenna with respect to the vehicle body frame (in
-   * meters).
+   * The location of the GNSS antenna with respect to the vehicle body frame,
+   * resolved in the vehicle body frame (in meters).
    *
    * Payload format: @ref Point3f
    */
@@ -62,7 +62,7 @@ enum class ConfigType : uint16_t {
 
   /**
    * The offset of the desired output location with respect to the vehicle
-   * body frame (in meters).
+   * body frame, resolved in the vehicle body frame (in meters).
    *
    * Payload format: @ref Point3f
    */


### PR DESCRIPTION
# New Features
- Added new `GNSS_AUX_LEVER_ARM` (secondary antenna) configuration setting

# Changes
- Removed deprecated `HEADING_BIAS` configuration setting

# Fixes
- Corrected Python `RawGNSSAttitudeOutput` yaw/pitch printout