### PR TITLE
Update Github action from no longer supported Clang11.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -51,7 +51,7 @@ jobs:
             version: 10
           - os: ubuntu-latest
             compiler: clang
-            version: 11
+            version: 14
     steps:
     - uses: actions/checkout@v2
 
@@ -123,7 +123,7 @@ jobs:
             version: 10
           - os: ubuntu-latest
             compiler: clang
-            version: 11
+            version: 14
           - os: windows-latest
             compiler: msvc
     defaults:


### PR DESCRIPTION
Move clang builds to clang-14.