### PR TITLE
Add config type for enabling profiling.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -45,7 +45,7 @@ class ConfigType(IntEnum):
     UART2_OUTPUT_DIAGNOSTICS_MESSAGES = 259
     ENABLE_WATCHDOG_TIMER = 300
     USER_DEVICE_ID = 301
-    PROFILING_ENABLED = 310
+    PROFILING_MASK = 310
     LBAND_PARAMETERS = 1024
 
 
@@ -887,8 +887,8 @@ class UserDeviceID(_conf_gen.StringVal):
     pass
 
 
-@_conf_gen.create_config_class(ConfigType.PROFILING_ENABLED, _conf_gen.UInt8Construct)
-class ProfilingEnabled(_conf_gen.IntegerVal):
+@_conf_gen.create_config_class(ConfigType.PROFILING_MASK, _conf_gen.UInt8Construct)
+class ProfilingMask(_conf_gen.IntegerVal):
     """!
     @brief A bitmask indicating which profiling features are enabled.
     """

--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -45,6 +45,7 @@ class ConfigType(IntEnum):
     UART2_OUTPUT_DIAGNOSTICS_MESSAGES = 259
     ENABLE_WATCHDOG_TIMER = 300
     USER_DEVICE_ID = 301
+    PROFILING_ENABLED = 310
     LBAND_PARAMETERS = 1024
 
 
@@ -882,6 +883,14 @@ class WatchdogTimerEnabled(_conf_gen.BoolVal):
 class UserDeviceID(_conf_gen.StringVal):
     """!
     @brief A string for identifying a device.
+    """
+    pass
+
+
+@_conf_gen.create_config_class(ConfigType.PROFILING_ENABLED, _conf_gen.UInt8Construct)
+class ProfilingEnabled(_conf_gen.IntegerVal):
+    """!
+    @brief A bitmask indicating which profiling features are enabled.
     """
     pass
 

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -258,9 +258,10 @@ enum class ConfigType : uint16_t {
   /**
    * A bitmask indicating which profiling features are enabled.
    *
-   * Payload format: `uint8_t` (see @ref sat_type_masks)
+   * Payload format: `uint8_t` (`0` for disabled and `0xFF` for all features
+   * enabled. Individual bits are device specific.)
    */
-  PROFILING_ENABLED = 310,
+  PROFILING_MASK = 310,
 
   /**
    * Configuration of L-band Demodulator Parameters.
@@ -349,8 +350,8 @@ P1_CONSTEXPR_FUNC const char* to_string(ConfigType type) {
     case ConfigType::USER_DEVICE_ID:
       return "User Device ID";
 
-    case ConfigType::PROFILING_ENABLED:
-      return "Profiling Enabled";
+    case ConfigType::PROFILING_MASK:
+      return "Profiling Features Enabled";
 
     case ConfigType::INTERFACE_CONFIG:
       return "Interface Submessage";

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -256,6 +256,13 @@ enum class ConfigType : uint16_t {
   USER_DEVICE_ID = 301,
 
   /**
+   * A bitmask indicating which profiling features are enabled.
+   *
+   * Payload format: `uint8_t` (see @ref sat_type_masks)
+   */
+  PROFILING_ENABLED = 310,
+
+  /**
    * Configuration of L-band Demodulator Parameters.
    *
    * @note
@@ -341,6 +348,9 @@ P1_CONSTEXPR_FUNC const char* to_string(ConfigType type) {
 
     case ConfigType::USER_DEVICE_ID:
       return "User Device ID";
+
+    case ConfigType::PROFILING_ENABLED:
+      return "Profiling Enabled";
 
     case ConfigType::INTERFACE_CONFIG:
       return "Interface Submessage";


### PR DESCRIPTION
Reopening https://github.com/PointOneNav/fusion-engine-client/pull/354 after botched rebase.