### PR TITLE
Fixed speed measurement bugs and added example speed send script.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -64,6 +64,8 @@ FusionEngine message specification.
         optionally mixed with other binary data, and decode the contents using the `FusionEngineDecoder` helper class
       - [send_command.py](examples/send_command.py) - Send a command to a device over serial or TCP, and wait for a
         response
+      - [send_vehicle_speed.py](examples/send_vehicle_speed.py) - Send example vehicle/wheel speed input to a device
+        over serial or TCP
       - [serial_client.py](examples/serial_client.py) - Connect to a device over a local serial port and decode/print
         incoming FusionEngine messages
       - [tcp_client.py](examples/tcp_client.py) - Connect to a device over TCP and decode messages in real time and

--- a/python/examples/send_vehicle_speed.py
+++ b/python/examples/send_vehicle_speed.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import os
+import socket
+import sys
+import time
+from urllib.parse import urlparse
+
+try:
+    import serial
+except ImportError:
+    serial = None
+
+# Add the Python root directory (fusion-engine-client/python/) to the import search path to enable FusionEngine imports
+# if this application is being run directly out of the repository and is not installed as a pip package.
+root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, root_dir)
+
+from fusion_engine_client.messages import *
+from fusion_engine_client.parsers import FusionEngineEncoder
+from fusion_engine_client.utils import trace as logging
+from fusion_engine_client.utils.argument_parser import ArgumentParser
+from fusion_engine_client.utils.bin_utils import bytes_to_hex
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="""\
+Send a vehicle speed measurements to a Point One device at 1Hz.
+""")
+
+    parser.add_argument(
+        '-v', '--verbose', action='count', default=0,
+        help="Print verbose/trace debugging messages.")
+
+    parser.add_argument('device',
+                        help="""\
+The path to the target FusionEngine device:
+- [serial://]<device>[:<baud>] - Send over serial (baud rate defaults to 460800).
+- tcp://<hostname>[:<port>] - Send over TCP (port defaults to 30201).
+""".strip())
+    options = parser.parse_args()
+
+    # Configure output logging.
+    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s:%(lineno)d - %(message)s', stream=sys.stdout)
+    logger = logging.getLogger('point_one.fusion_engine.app')
+
+    if options.verbose == 0:
+        logger.setLevel(logging.INFO)
+    elif options.verbose == 1:
+        logger.setLevel(logging.DEBUG)
+    elif options.verbose == 2:
+        logger.setLevel(logging.DEBUG)
+        logging.getLogger('point_one.fusion_engine.parsers').setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.DEBUG)
+        logging.getLogger('point_one.fusion_engine.parsers').setLevel(
+            logging.getTraceLevel(depth=options.verbose - 1))
+
+    # message = VehicleSpeedInput()
+    # message.vehicle_speed_mps = 1
+    message = WheelSpeedInput()
+    message.front_right_speed_mps = 1
+
+    # Connect to the device.
+    url = urlparse(options.device)
+
+    if url.scheme == "":
+        url = url._replace(scheme="serial")
+
+    if url.hostname is None:
+        parts = url.path.split(":")
+        hostname = parts[0]
+        if len(parts) > 1:
+            port = int(parts[1])
+        else:
+            port = None
+    else:
+        hostname = url.hostname
+        port = url.port
+
+    response_timeout_sec = 3.0
+    serial_port = None
+    sock = None
+    if url.scheme == 'serial':
+        if serial is None:
+            logger.error("Serial port access requires pyserial. Please install (pip install pyserial) and run again.")
+            sys.exit(1)
+
+        baud_rate = 460800 if port is None else port
+        path = hostname
+        if path == "":
+            logger.error("You must specify the path to a serial device.")
+            sys.exit(2)
+
+        logger.info("Sending speeds to serial port %s @ %d baud." % (path, baud_rate))
+        serial_port = serial.Serial(port=path, baudrate=baud_rate, timeout=response_timeout_sec)
+    elif url.scheme == 'tcp':
+        port = 30201 if port is None else port
+        if hostname == "":
+            logger.error("You must specify a hostname or IP address.")
+            sys.exit(2)
+
+        ip_address = socket.gethostbyname(hostname)
+        logger.info("Sending speeds to tcp://%s:%d." % (ip_address, port))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((ip_address, port))
+        sock.settimeout(response_timeout_sec)
+    else:
+        logger.error("Unsupported device specifier.")
+        sys.exit(2)
+
+    encoder = FusionEngineEncoder()
+
+    try:
+        while True:
+            logger.info("Sending message:\n%s" % str(message))
+
+            encoded_data = encoder.encode_message(message)
+
+            logger.debug(bytes_to_hex(encoded_data, bytes_per_row=16, bytes_per_col=2))
+
+            if serial_port:
+                serial_port.write(encoded_data)
+            else:
+                sock.send(encoded_data)
+
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if serial_port:
+            serial_port.close()
+        else:
+            sock.close()

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1676,7 +1676,7 @@ Gold=Float, Green=Integer (Not Fixed), Blue=Integer (Fixed, Float Solution Type)
             common_time_source = corrected_time_source
         elif measurement_type is None:
             corrected_time_source = None
-            raw_time_source = _get_time_source(raw_measurement_type, data)
+            raw_time_source = _get_time_source(raw_measurement_type, raw_data)
             common_time_source = raw_time_source
         else:
             corrected_time_source = _get_time_source(measurement_type, data)

--- a/python/fusion_engine_client/applications/p1_capture.py
+++ b/python/fusion_engine_client/applications/p1_capture.py
@@ -38,11 +38,11 @@ _logger = logging.getLogger('point_one.fusion_engine.applications.p1_capture')
 
 
 def create_transport(descriptor: str) -> Union[socket.socket, serial.Serial]:
-    m = re.match(r'^tcp://([a-zA-Z0-9-_.]+)?:([0-9]+)$', descriptor)
+    m = re.match(r'^tcp://([a-zA-Z0-9-_.]+)?(?::([0-9]+))?$', descriptor)
     if m:
         transport = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         hostname = m.group(1)
-        port = int(m.group(2))
+        port = 30200 if m.group(2) is None else int(m.group(2))
         transport.connect((socket.gethostbyname(hostname), port))
         return transport
 
@@ -111,8 +111,8 @@ The format of the file to be generated when --output is enabled:
         'transport',
         help="""\
 The method used to communicate with the target device:
-- tcp://HOSTNAME:PORT - Connect to the specified hostname (or IP address) and
-  port over TCP (e.g., tty://192.168.0.3:30201)
+- tcp://HOSTNAME[:PORT] - Connect to the specified hostname (or IP address) and
+  port over TCP (e.g., tty://192.168.0.3:30202); defaults to port 30200
 - udp://:PORT - Listen for incoming data on the specified UDP port (e.g.,
   udp://:12345)
   Note: When using UDP, you must configure the device to send data to your

--- a/python/fusion_engine_client/applications/p1_capture.py
+++ b/python/fusion_engine_client/applications/p1_capture.py
@@ -41,26 +41,32 @@ def create_transport(descriptor: str) -> Union[socket.socket, serial.Serial]:
     m = re.match(r'^tcp://([a-zA-Z0-9-_.]+)?:([0-9]+)$', descriptor)
     if m:
         transport = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        transport.connect((socket.gethostbyname(m.group(1)), int(m.group(2))))
+        hostname = m.group(1)
+        port = int(m.group(2))
+        transport.connect((socket.gethostbyname(hostname), port))
         return transport
 
     m = re.match(r'^udp://:([0-9]+)$', descriptor)
     if m:
         transport = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         transport.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        transport.bind(('', int(m.group(1))))
+        port = int(m.group(1))
+        transport.bind(('', port))
         return transport
 
     m = re.match(r'^unix://([a-zA-Z0-9-_./]+)$', descriptor)
     if m:
         transport = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        transport.connect(m.group(1))
+        path = m.group(1)
+        transport.connect(path)
         return transport
 
     m = re.match(r'^(?:(?:serial|tty)://)?([^:]+):([0-9]+)$', descriptor)
     if m:
         if serial_supported:
-            transport = serial.Serial(port=m.group(1), baudrate=int(m.group(2)))
+            path = m.group(1)
+            baud_rate= int(m.group(2))
+            transport = serial.Serial(port=path, baudrate=baud_rate)
             return transport
         else:
             raise RuntimeError(

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -188,9 +188,6 @@ class RawIMUOutput(MessagePayload):
         self.__dict__.update(parsed)
         del self.__dict__['_io']
 
-        # Disregard any user-specified P1 timestamps in input data.
-        self.details.p1_time = Timestamp()
-
         return parsed._io.tell()
 
     @classmethod
@@ -454,9 +451,6 @@ class RawWheelSpeedOutput(MessagePayload):
         self.__dict__.update(parsed)
         del self.__dict__['_io']
 
-        # Disregard any user-specified P1 timestamps in input data.
-        self.details.p1_time = Timestamp()
-
         return parsed._io.tell()
 
     @classmethod
@@ -528,7 +522,7 @@ class VehicleSpeedInput(MessagePayload):
         self.details = MeasurementDetails()
         self.gear = GearType.UNKNOWN
         self.flags = 0x0
-        self.vehicle_speed = np.nan
+        self.vehicle_speed_mps = np.nan
 
     def is_signed(self) -> bool:
         return (self.flags & self.FLAG_SIGNED) != 0
@@ -689,7 +683,7 @@ class RawVehicleSpeedOutput(MessagePayload):
         self.details = MeasurementDetails()
         self.gear = GearType.UNKNOWN
         self.flags = 0x0
-        self.vehicle_speed = np.nan
+        self.vehicle_speed_mps = np.nan
 
     def is_signed(self) -> bool:
         return (self.flags & self.FLAG_SIGNED) != 0

--- a/python/fusion_engine_client/utils/transport_utils.py
+++ b/python/fusion_engine_client/utils/transport_utils.py
@@ -70,11 +70,14 @@ def create_transport(descriptor: str, timeout_sec: float = None) -> Union[socket
             transport.settimeout(timeout_sec)
         return transport
 
-    m = re.match(r'^(?:(?:serial|tty)://)?([^:]+):([0-9]+)$', descriptor)
+    m = re.match(r'^(?:(?:serial|tty)://)?([^:]+)(:([0-9]+))?$', descriptor)
     if m:
         if serial_supported:
             path = m.group(1)
-            baud_rate= int(m.group(2))
+            if m.group(2) is None:
+                raise ValueError('Serial baud rate not specified.')
+            else:
+                baud_rate = int(m.group(2))
             transport = serial.Serial(port=path, baudrate=baud_rate, timeout=timeout_sec)
             return transport
         else:

--- a/python/fusion_engine_client/utils/transport_utils.py
+++ b/python/fusion_engine_client/utils/transport_utils.py
@@ -6,6 +6,19 @@ try:
     # pySerial is optional.
     import serial
     serial_supported = True
+
+    # The Serial class has read() and write() functions. For convenience, we add recv() and send() aliases, consistent
+    # with the Python socket class.
+    def __recv(self, size, flags=None):
+        data = self.read(size)
+        if len(data) == 0 and size > 0:
+            raise socket.timeout('Serial read timed out.')
+        else:
+            return data
+    def __send(self, data, flags=None):
+        self.write(data)
+    serial.Serial.recv = __recv
+    serial.Serial.send = __send
 except ImportError:
     serial_supported = False
     # Dummy stand-in if pySerial is not installed.

--- a/python/fusion_engine_client/utils/transport_utils.py
+++ b/python/fusion_engine_client/utils/transport_utils.py
@@ -35,8 +35,8 @@ The method used to communicate with the target device:
   Note: When using UDP, you must configure the device to send data to your
   machine.
 - unix://FILENAME - Connect to the specified UNIX domain socket file
-- [tty://]DEVICE:BAUD - Connect to a serial device with the specified baud rate
-  (e.g., tty:///dev/ttyUSB0:460800 or /dev/ttyUSB0:460800) 
+- [(serial|tty)://]DEVICE:BAUD - Connect to a serial device with the specified
+  baud rate (e.g., tty:///dev/ttyUSB0:460800 or /dev/ttyUSB0:460800)
 """
 
 

--- a/python/fusion_engine_client/utils/transport_utils.py
+++ b/python/fusion_engine_client/utils/transport_utils.py
@@ -1,0 +1,65 @@
+import re
+import socket
+from typing import Union
+
+try:
+    # pySerial is optional.
+    import serial
+    serial_supported = True
+except ImportError:
+    serial_supported = False
+    # Dummy stand-in if pySerial is not installed.
+    class serial:
+        class Serial: pass
+        class SerialException: pass
+
+TRANSPORT_HELP_STRING = """\
+The method used to communicate with the target device:
+- tcp://HOSTNAME[:PORT] - Connect to the specified hostname (or IP address) and
+  port over TCP (e.g., tty://192.168.0.3:30202); defaults to port 30200
+- udp://:PORT - Listen for incoming data on the specified UDP port (e.g.,
+  udp://:12345)
+  Note: When using UDP, you must configure the device to send data to your
+  machine.
+- unix://FILENAME - Connect to the specified UNIX domain socket file
+- [tty://]DEVICE:BAUD - Connect to a serial device with the specified baud rate
+  (e.g., tty:///dev/ttyUSB0:460800 or /dev/ttyUSB0:460800) 
+"""
+
+
+def create_transport(descriptor: str) -> Union[socket.socket, serial.Serial]:
+    m = re.match(r'^tcp://([a-zA-Z0-9-_.]+)?(?::([0-9]+))?$', descriptor)
+    if m:
+        transport = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        hostname = m.group(1)
+        port = 30200 if m.group(2) is None else int(m.group(2))
+        transport.connect((socket.gethostbyname(hostname), port))
+        return transport
+
+    m = re.match(r'^udp://:([0-9]+)$', descriptor)
+    if m:
+        transport = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        transport.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        port = int(m.group(1))
+        transport.bind(('', port))
+        return transport
+
+    m = re.match(r'^unix://([a-zA-Z0-9-_./]+)$', descriptor)
+    if m:
+        transport = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        path = m.group(1)
+        transport.connect(path)
+        return transport
+
+    m = re.match(r'^(?:(?:serial|tty)://)?([^:]+):([0-9]+)$', descriptor)
+    if m:
+        if serial_supported:
+            path = m.group(1)
+            baud_rate= int(m.group(2))
+            transport = serial.Serial(port=path, baudrate=baud_rate)
+            return transport
+        else:
+            raise RuntimeError(
+                "This application requires pyserial. Please install (pip install pyserial) and run again.")
+
+    raise ValueError('Unsupported transport descriptor.')


### PR DESCRIPTION
# New Features
- Add example for sending input speed measurements
 
# Changes
- Moved `create_transport()` helper into reusable utility and added to `send_command.py` example app

# Fixes
- Fix misnamed field in `RawVehicleSpeedOutput` and `RawVehicleSpeedInput`
- Fix dropping P1 time in `Raw*Output` messages
- Fix detecting time source in raw measurements