### PR TITLE
Added common helper function for defining log search CLI arguments.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -28,7 +28,7 @@ from .attitude import get_enu_rotation_matrix
 from .data_loader import DataLoader, TimeRange
 from ..utils import trace as logging
 from ..utils.argument_parser import ArgumentParser, ExtendedBooleanAction, TriStateBooleanAction, CSVAction
-from ..utils.log import locate_log, DEFAULT_LOG_BASE_DIR
+from ..utils.log import define_cli_arguments as define_log_search_arguments, locate_log
 from ..utils.numpy_utils import find_first
 from ..utils.trace import HighlightFormatter
 
@@ -2929,21 +2929,7 @@ Load and display information stored in a FusionEngine binary file.
              "unless an 'abs' type is specified or --absolute-time is set.")
 
     log_group = parser.add_argument_group('Input File/Log Control')
-    log_group.add_argument(
-        '--ignore-index', action=ExtendedBooleanAction,
-        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a "
-             ".p1i file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
-             "improve data read speed in the future.")
-    log_group.add_argument(
-        '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
-        help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
-    log_group.add_argument(
-        'log',
-        help="The log to be read. May be one of:\n"
-             "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
-             "- The path to a FusionEngine log directory\n"
-             "- A pattern matching a FusionEngine log directory under the specified base directory "
-             "(see find_fusion_engine_log() and --log-base-dir)")
+    define_log_search_arguments(log_group)
 
     output_group = parser.add_argument_group('Output Control')
     output_group.add_argument(

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2968,8 +2968,8 @@ Load and display information stored in a FusionEngine binary file.
         time_range = None
 
     # Locate the input file and set the output directory.
-    input_path, output_dir, log_id = locate_log(input_path=options.log, log_base_dir=options.log_base_dir,
-                                                return_output_dir=True, return_log_id=True)
+    input_path, log_dir, log_id = locate_log(input_path=options.log, log_base_dir=options.log_base_dir,
+                                             return_output_dir=True, return_log_id=True)
     if input_path is None:
         # locate_log() will log an error.
         sys.exit(1)
@@ -2980,8 +2980,7 @@ Load and display information stored in a FusionEngine binary file.
         _logger.info('Loading %s (log ID: %s).' % (input_path, log_id))
 
     if options.output is None:
-        if log_id is not None:
-            output_dir = os.path.join(output_dir, 'plot_fusion_engine')
+        output_dir = os.path.join(log_dir, 'plot_fusion_engine')
     else:
         output_dir = options.output
 

--- a/python/fusion_engine_client/applications/p1_print.py
+++ b/python/fusion_engine_client/applications/p1_print.py
@@ -10,7 +10,7 @@ from ..messages import *
 from ..parsers import MixedLogReader
 from ..utils import trace as logging
 from ..utils.argument_parser import ArgumentParser, ExtendedBooleanAction, CSVAction
-from ..utils.log import locate_log, DEFAULT_LOG_BASE_DIR
+from ..utils.log import define_cli_arguments as define_log_search_arguments, locate_log
 from ..utils.print_utils import DeviceSummary, add_print_format_argument, print_message, print_summary_table
 from ..utils.time_range import TimeRange
 from ..utils.trace import HighlightFormatter, BrokenPipeStreamHandler
@@ -65,25 +65,11 @@ other types of data.
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help="Print verbose/trace debugging messages.")
 
-    log_parser = parser.add_argument_group('Log Control')
-    log_parser.add_argument(
-        '--ignore-index', action='store_true',
-        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a .p1i "
-             "file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
-             "improve data read speed in the future.")
-    log_parser.add_argument(
-        '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
-        help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
+    log_parser = parser.add_argument_group('Input File/Log Control')
+    define_log_search_arguments(log_parser)
     log_parser.add_argument(
         '--progress', action='store_true',
         help="Print file read progress to the console periodically.")
-    log_parser.add_argument(
-        'log',
-        help="The log to be read. May be one of:\n"
-             "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
-             "- The path to a FusionEngine log directory\n"
-             "- A pattern matching a FusionEngine log directory under the specified base directory "
-             "(see find_fusion_engine_log() and --log-base-dir)")
 
     options = parser.parse_args()
 

--- a/python/fusion_engine_client/utils/log.py
+++ b/python/fusion_engine_client/utils/log.py
@@ -7,6 +7,7 @@ from . import trace as logging
 from ..messages import MessageType
 from ..parsers.file_index import FileIndexBuilder, FileIndex
 from ..parsers.mixed_log_reader import MixedLogReader
+from ..utils.argument_parser import ExtendedBooleanAction
 
 _logger = logging.getLogger('point_one.utils.log')
 
@@ -42,6 +43,24 @@ if DEFAULT_LOG_BASE_DIR is None:
             DEFAULT_LOG_BASE_DIR = '/logs'
         else:
             DEFAULT_LOG_BASE_DIR = os.path.expanduser("~/point_one/logs")
+
+
+def define_cli_arguments(parser_group):
+    parser_group.add_argument(
+        '--ignore-index', action=ExtendedBooleanAction,
+        help="If set, do not load the .p1i index file corresponding with the .p1log data file. If specified and a "
+             ".p1i file does not exist, do not generate one. Otherwise, a .p1i file will be created automatically to "
+             "improve data read speed in the future.")
+    parser_group.add_argument(
+        '--log-base-dir', metavar='DIR', default=DEFAULT_LOG_BASE_DIR,
+        help="The base directory containing FusionEngine logs to be searched if a log pattern is specified.")
+    parser_group.add_argument(
+        'log',
+        help="The log to be read. May be one of:\n"
+             "- The path to a .p1log file or a file containing FusionEngine messages and other content\n"
+             "- The path to a FusionEngine log directory\n"
+             "- A pattern matching a FusionEngine log directory under the specified base directory "
+             "(see find_fusion_engine_log() and --log-base-dir)")
 
 
 def find_log_by_pattern(pattern, log_base_dir=DEFAULT_LOG_BASE_DIR, allow_multiple=False, skip_empty_files=True,


### PR DESCRIPTION
# Changes
- Added common helper function for defining log search CLI arguments

# Fixes
- Fixed `p1_display` default output directory when reading from a `.p1log` file that's not within a P1 log directory