### PR TITLE
Added file name/path config option for file and UNIX domain socket interfaces.

### DIFF
--- a/python/fusion_engine_client/messages/configuration.py
+++ b/python/fusion_engine_client/messages/configuration.py
@@ -60,6 +60,7 @@ class InterfaceConfigType(IntEnum):
   ENABLED = 5
   DIRECTION = 6
   SOCKET_TYPE = 7
+  FILE_PATH = 8
 
 
 class Direction(IntEnum):
@@ -988,6 +989,14 @@ class InterfaceDirectionConfig(_conf_gen.TransportDirectionVal):
 class InterfaceSocketTypeConfig(_conf_gen.SocketTypeVal):
     """!
     @brief UNIX domain socket type configuration (stream, datagram, sequence).
+    """
+    pass
+
+
+@_conf_gen.create_interface_config_class(InterfaceConfigType.FILE_PATH, _conf_gen.StringConstruct(64))
+class InterfaceFilePathConfig(_conf_gen.StringVal):
+    """!
+    @brief The path to a local file to be written or UNIX domain socket to be used.
     """
     pass
 

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1558,8 +1558,8 @@ enum class InterfaceConfigType : uint8_t {
   /**
    * Configure the network address for a client to connect to.
    *
-   * For UNIX domain sockets, this string represents the path to the local
-   * socket file.
+   * For UNIX domain sockets, this is an alias for @ref FILE_PATH and represents
+   * the path to the local UNIX domain socket file.
    *
    * Valid for:
    * - @ref TransportType::TCP
@@ -1612,6 +1612,17 @@ enum class InterfaceConfigType : uint8_t {
    * Payload format: @ref SocketType
    */
   SOCKET_TYPE = 7,
+
+  /**
+   * Configure the path to a local file or UNIX domain socket.
+   *
+   * Valid for:
+   * - @ref TransportType::FILE
+   * - @ref TransportType::UNIX
+   *
+   * Payload format: `char[64]` containing a NULL terminated string.
+   */
+  FILE_PATH = 8,
 };
 
 /**
@@ -1647,6 +1658,9 @@ P1_CONSTEXPR_FUNC const char* to_string(InterfaceConfigType type) {
 
     case InterfaceConfigType::SOCKET_TYPE:
       return "Socket Type";
+
+    case InterfaceConfigType::FILE_PATH:
+      return "File Path";
   }
 
   return "Unrecognized Configuration";

--- a/src/point_one/fusion_engine/messages/configuration.h
+++ b/src/point_one/fusion_engine/messages/configuration.h
@@ -1556,15 +1556,12 @@ enum class InterfaceConfigType : uint8_t {
   BAUD_RATE = 2,
 
   /**
-   * Configure the network address for a client to connect to.
-   *
-   * For UNIX domain sockets, this is an alias for @ref FILE_PATH and represents
-   * the path to the local UNIX domain socket file.
+   * Configure the remote network IP address or hostname for a client to connect
+   * to.
    *
    * Valid for:
    * - @ref TransportType::TCP
    * - @ref TransportType::UDP
-   * - @ref TransportType::UNIX
    *
    * Payload format: `char[64]` containing a NULL terminated string.
    */


### PR DESCRIPTION
# New Features
- Added `InterfaceConfigType.FILE_PATH` option

# Changes
- Removed use of `InterfaceConfigType.REMOTE_ADDRESS` as alias for UNIX domain socket file paths