### PR TITLE
Added support for printing `InputDataWrapper` message contents.

### DIFF
--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1574,6 +1574,9 @@ class InputDataWrapperMessage(MessagePayload):
         self.data_type = InputDataType.M_TYPE_UNKNOWN
         self.data = bytes()
 
+        self._fe_content_header = None
+        self._fe_content_payload = None
+
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
         if buffer is None:
             buffer = bytearray(self.calcsize())
@@ -1616,14 +1619,63 @@ class InputDataWrapperMessage(MessagePayload):
 
     def calcsize(self) -> int:
         return self._STRUCT.size + len(self.data)
+
+    def get_fe_content_header(self) -> Optional[MessageHeader]:
+        if self._fe_content_header is None and self.data_type == InputDataType.M_TYPE_FUSION_ENGINE_MESSAGE:
+            try:
+                wrapped_fe_header = MessageHeader()
+                wrapped_fe_header.unpack(self.data, validate_sync=True, validate_crc=False)
+                self._fe_content_header = wrapped_fe_header
+            except Exception:
+                # Set to False instead of None so we don't try to unpack the header multiple times.
+                self._fe_content_header = False
+
+        if self._fe_content_header == False:
+            return None
+        else:
+            return self._fe_content_header
+
+    def get_fe_content_payload(self) -> Optional[MessagePayload]:
+        header = self.get_fe_content_header()
+        if header is None:
+            return None
+
+        if self._fe_content_payload is None:
+            cls = MessagePayload.message_type_to_class.get(header.message_type, None)
+            if cls is not None:
+                try:
+                    payload = cls()
+                    payload.unpack(buffer=self.data, offset=MessageHeader.calcsize(),
+                                   message_version=header.message_version)
+                    self._fe_content_payload = payload
+                except Exception:
+                    pass
+
+            if self._fe_content_payload is None:
+                # Set to False instead of None so we don't try to unpack the header multiple times.
+                self._fe_content_payload = False
+
+        if self._fe_content_payload == False:
+            return None
+        else:
+            return self._fe_content_payload
+
     def __repr__(self):
         result = super().__repr__()[:-1]
         result += f', data_type={self.data_type.to_string()}, data_len={len(self.data)} B'
+        fe_header = self.get_fe_content_header()
+        if fe_header is not None:
+            result += f', fe_content_type={fe_header.message_type.to_string()}'
         result += ']'
         return result
 
     def __str__(self):
+        fe_header = self.get_fe_content_header()
+        if fe_header is not None:
+            fe_content_str = f'\n  FusionEngine content type: {fe_header.message_type.to_string()}'
+        else:
+            fe_content_str = ""
         return f"""\
 Input Data Wrapper @ {system_time_to_str(self.system_time_ns)}
   Data type: {self.data_type.to_string(include_value=True)}
-  Data: {len(self.data)} B payload"""
+  Data: {len(self.data)} B payload{fe_content_str}"""

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1552,6 +1552,9 @@ class InputDataType(IntEnum):
     M_TYPE_EXTERNAL_UNFRAMED_GNSS = 0x42
     M_TYPE_EXTERNAL_FRAMED_GNSS = 0x44
     M_TYPE_RTCM3_POLARIS_EPHEM = 0x77
+    M_TYPE_FUSION_ENGINE_MESSAGE = 0xc6
+    M_TYPE_FUSION_ENGINE_WRAPPED_DATA = 0xc9,
+    M_TYPE_UNFRAMED_FUSION_ENGINE = 0xce,
     M_TYPE_RTCM3_UNKNOWN = 0x100
 
     def to_string(self, include_value=True, print_hex=True):

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -2,7 +2,7 @@ import math
 import struct
 from typing import Sequence
 
-from construct import Array, BytesInteger, GreedyBytes, Struct, Padding, Float32l, Int16ul, Int16sl, Int32sl
+from construct import Array, Struct, Padding, Float32l, Int16sl, Int32sl
 import numpy as np
 
 from .defs import *

--- a/python/fusion_engine_client/messages/measurements.py
+++ b/python/fusion_engine_client/messages/measurements.py
@@ -1567,45 +1567,63 @@ class InputDataWrapperMessage(MessagePayload):
 
     CENTI_NANO_SCALE_FACTOR = 10_000_000
 
-    Construct = Struct(
-        # 5 byte, unsigned, little endian integer
-        "system_time_cs" / BytesInteger(5, swapped=True),
-        Padding(1),
-        "data_type" / Int16ul,
-        # NOTE: Since this message does no capture the expected data size, the Construct relies on the size of the
-        # Python buffer passed to `unpack`` to infer the size of the data. This is the behavior of @ref GreedyBytes.
-        "data" / GreedyBytes
-    )
+    _STRUCT = struct.Struct('<IB x H')
 
     def __init__(self):
         self.system_time_ns = 0
-        self.data_type = 0
+        self.data_type = InputDataType.M_TYPE_UNKNOWN
         self.data = bytes()
 
     def pack(self, buffer: bytes = None, offset: int = 0, return_buffer: bool = True) -> (bytes, int):
-        self.system_time_cs = int(self.system_time_ns / self.CENTI_NANO_SCALE_FACTOR)
-        ret = MessagePayload.pack(self, buffer, offset, return_buffer)
-        del self.__dict__['system_time_cs']
-        return ret
+        if buffer is None:
+            buffer = bytearray(self.calcsize())
+            offset = 0
+
+        initial_offset = offset
+
+        system_time_cs = int(self.system_time_ns / self.CENTI_NANO_SCALE_FACTOR)
+        offset += self.pack_values(
+            self._STRUCT, buffer, offset,
+            system_time_cs & 0xFFFFFFFF,
+            system_time_cs >> 32,
+            int(self.data_type))
+
+        buffer += self.data
+        offset += len(self.data)
+
+        if return_buffer:
+            return buffer
+        else:
+            return offset - initial_offset
 
     def unpack(self, buffer: bytes, offset: int = 0, message_version: int = MessagePayload._UNSPECIFIED_VERSION) -> int:
-        ret = MessagePayload.unpack(self, buffer, offset, message_version)
-        self.system_time_ns = self.system_time_cs * self.CENTI_NANO_SCALE_FACTOR
-        del self.__dict__['system_time_cs']
-        return ret
+        initial_offset = offset
 
+        (system_time_cs_low,
+         system_time_cs_high,
+         data_type_int) = \
+            self._STRUCT.unpack_from(buffer=buffer, offset=offset)
+        offset += self._STRUCT.size
+
+        system_time_cs = (system_time_cs_high << 32) | system_time_cs_low
+        self.system_time_ns = system_time_cs * self.CENTI_NANO_SCALE_FACTOR
+        self.data_type = InputDataType(data_type_int, raise_on_unrecognized=False)
+
+        self.data = buffer[offset:]
+        offset += len(self.data)
+
+        return offset - initial_offset
+
+    def calcsize(self) -> int:
+        return self._STRUCT.size + len(self.data)
     def __repr__(self):
         result = super().__repr__()[:-1]
-        result += f', data_type={self.data_type}, data_len={len(self.data)}]'
+        result += f', data_type={self.data_type.to_string()}, data_len={len(self.data)} B'
+        result += ']'
         return result
 
     def __str__(self):
-        return construct_message_to_string(message=self, construct=self.Construct,
-                                           value_to_string={
-                                               'data': lambda x: f'{len(x)} B payload',
-                                               'data_type': lambda x: f'{x} (0x{x:02x})',
-                                           },
-                                           title=f'Data Wrapper')
-
-    def calcsize(self) -> int:
-        return len(self.pack())
+        return f"""\
+Input Data Wrapper @ {system_time_to_str(self.system_time_ns)}
+  Data type: {self.data_type.to_string(include_value=True)}
+  Data: {len(self.data)} B payload"""

--- a/python/fusion_engine_client/messages/signal_defs.py
+++ b/python/fusion_engine_client/messages/signal_defs.py
@@ -1,8 +1,5 @@
 import functools
-import re
 from typing import NamedTuple, Optional, TypeAlias, TypeVar, Union
-
-import numpy as np
 
 from ..utils.enum_utils import IntEnum, enum_bitmask
 
@@ -52,10 +49,6 @@ class SatelliteTypeMask:
     ALL = 0xFFFF
 
 
-class SignalType(IntEnum):
-    UNKNOWN = 0
-
-
 ## @brief GNSS frequency band definitions.
 #
 # A frequency band generally includes multiple GNSS carrier frequencies and
@@ -95,9 +88,6 @@ class FrequencyBand(IntEnum):
 class FrequencyBandMask:
     ALL = 0xFFFF
 
-
-_SHORT_FORMAT = re.compile(r'([%s])(\d+)(?:\s+(\w+))?' % ''.join(SatelliteTypeCharReverse.keys()))
-_LONG_FORMAT = re.compile(r'(\w+)(?:\s+(\w+))(?:\s+PRN\s+(\d+))?')
 
 ##
 # @brief Groupings encapsulating the form of the signal broadcast by a
@@ -299,7 +289,7 @@ def _shift_enum_value(value: _GNSSSignalPartType) -> int:
     '''!
     Get the integer value for a component of @ref GNSSSignalType shifted into the bits it will occupy in the @ref
     GNSSSignalType value.
-s
+
     @param value The value of the enum component.
 
     @return The shifted value.

--- a/python/fusion_engine_client/utils/enum_utils.py
+++ b/python/fusion_engine_client/utils/enum_utils.py
@@ -104,9 +104,12 @@ class IntEnum(IntEnumBase, metaclass=DynamicEnumMeta):
     def __repr__(self):
         return f'<{self.__class__.__name__}.{str(self)}: {int(self)}>'
 
-    def to_string(self, include_value=True):
+    def to_string(self, include_value=True, print_hex=False):
         if include_value:
-            return '%s (%d)' % (str(self), int(self))
+            if print_hex:
+                return '%s (0x%X)' % (str(self), int(self))
+            else:
+                return '%s (%d)' % (str(self), int(self))
         else:
             return str(self)
 

--- a/python/fusion_engine_client/utils/print_utils.py
+++ b/python/fusion_engine_client/utils/print_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Set, Union
 
 import argparse
 from collections import defaultdict
@@ -26,10 +26,25 @@ def add_print_format_argument(parser: argparse._ActionsContainer, *arg_names):
              "- oneline-binary - Use `oneline-detailed` format, but include the binary representation of each message\n"
              "- oneline-binary-payload - Like `oneline-binary`, but exclude the message header from the binary")
 
+def add_wrapped_data_mode_argument(parser: argparse._ActionsContainer, *arg_names):
+    parser.add_argument(
+        *arg_names,
+        choices=['auto', 'all', 'parent', 'content'],
+        default='parent',
+        help="Specify the way in which InputDataWrapper messages should be handled:\n"
+             "- auto - Use 'all' mode unless specific message types are specified, in which case use 'content' mode "
+             "and only print the wrapped contents.\n"
+             "- all - Print both the @ref InputDataWrapperMessage and its contents if it contains a FusionEngine "
+             "message\n"
+             "- parent - Print the @ref InputDataWrapperMessage message but not its contents\n"
+             "- content - Print the wrapped contents, if the wrapper contains a FusionEngine message, but do not print "
+             "the InputDataWrapper message itself")
+
 
 def print_message(header: MessageHeader, contents: Union[MessagePayload, bytes],
-                  offset_bytes: Optional[int] = None, format: str = 'pretty', bytes: Optional[int] = None,
-                  logger: Optional[logging.Logger] = None):
+                  offset_bytes: Optional[int] = None, format: str = 'pretty', bytes: Optional[bytes] = None,
+                  logger: Optional[logging.Logger] = None,
+                  message_types: Optional[Set[MessageType]] = None, wrapped_data_mode: str = 'all'):
     """!
     @brief Print the specified FusionEngine message to the console or provided `Logger` instance.
 
@@ -47,11 +62,35 @@ def print_message(header: MessageHeader, contents: Union[MessagePayload, bytes],
            - `oneline-binary-payload` - Like `oneline-binary`, but exclude the message header from the binary
     @param bytes The binary representation of the message.
     @param logger A `logging.Logger` instance with which the output will be printed.
+    @param message_types An optional set of FusionEngine @ref MessageType%s to be displayed. All other message types
+           will be ignored.
+    @param wrapped_data_mode The way in which @ref InputDataWrapperMessage%s should be handled:
+           - all - Print both the @ref InputDataWrapperMessage and its contents if it contains a FusionEngine message
+           - parent - Print the @ref InputDataWrapperMessage message but not its contents
+           - content - Print the wrapped contents, if the wrapper contains a FusionEngine message, but do not print the
+                       @ref InputDataWrapperMessage itself
     """
     if logger is None:
         logger = _logger
 
-    if format == 'binary':
+    is_requested = message_types is None or header.message_type in message_types
+    if header.message_type == MessageType.INPUT_DATA_WRAPPER:
+        wrapped_fe_header = contents.get_fe_content_header()
+        if is_requested:
+            hide_message = False
+        elif wrapped_data_mode == 'content':
+            hide_message = True
+        # Note: is_requested==False above implies message_types is not None, no need to check again.
+        elif wrapped_fe_header is None:
+            hide_message = True
+        else:
+            hide_message = wrapped_fe_header.message_type not in message_types
+    else:
+        hide_message = not is_requested
+
+    if hide_message:
+        pass
+    elif format == 'binary':
         if bytes is None:
             raise ValueError('No data provided for binary format.')
         parts = []
@@ -74,7 +113,9 @@ def print_message(header: MessageHeader, contents: Union[MessagePayload, bytes],
     else:
         parts = [f'{header.get_type_string()} (unsupported)']
 
-    if format != 'oneline':
+    if hide_message:
+        pass
+    elif format != 'oneline':
         details = 'source_id=%d, sequence=%d, size=%d B' % (header.source_identifier,
                                                             header.sequence_number,
                                                             header.get_message_size())
@@ -87,7 +128,9 @@ def print_message(header: MessageHeader, contents: Union[MessagePayload, bytes],
         else:
             parts[0] = f'{parts[0][:(idx + 1)]}{details}, {parts[0][(idx + 1):]}'
 
-    if bytes is None:
+    if hide_message:
+        pass
+    elif bytes is None:
         pass
     elif format == 'binary':
         byte_string = bytes_to_hex(bytes, bytes_per_row=-1, bytes_per_col=2).replace('\n', '\n  ')
@@ -103,7 +146,18 @@ def print_message(header: MessageHeader, contents: Union[MessagePayload, bytes],
         byte_string = '  ' + bytes_to_hex(bytes, bytes_per_row=16, bytes_per_col=2).replace('\n', '\n  ')
         parts.insert(1, byte_string)
 
-    logger.info('\n'.join(parts))
+    if not hide_message:
+        if wrapped_data_mode == 'recursive':
+            parts[0] += ' [wrapped]'
+
+        logger.info('\n'.join(parts))
+
+    # If this is an InputDataWrapper message, recursively display its contents.
+    if header.message_type == MessageType.INPUT_DATA_WRAPPER and wrapped_data_mode != 'parent':
+        wrapped_fe_payload = contents.get_fe_content_payload()
+        if wrapped_fe_payload is not None:
+            print_message(wrapped_fe_header, wrapped_fe_payload, 0, format=format, bytes=contents.data,
+                          message_types=message_types, wrapped_data_mode='recursive')
 
 
 class MessageStatsEntry:
@@ -121,14 +175,44 @@ class DeviceSummary:
         self.device_id = None
         self.version_info = None
         self.stats = defaultdict(MessageStatsEntry)
+        self.wrapped_non_fe_input_data_stats = defaultdict(MessageStatsEntry)
+        self.wrapped_fe_input_data_stats = defaultdict(MessageStatsEntry)
 
-    def update(self, header: MessageHeader, message: MessagePayload):
-        self.stats[header.message_type].update(header, message)
+    def update(self, header: MessageHeader, message: MessagePayload, message_types: Optional[Set[MessageType]] = None):
+        # If the user specified specific message types, ignore non-FusionEngine messages or FusionEngine messages
+        # that are not in the list.
+        wrapped_fe_header = None
+        include_wrapped_content = False
+        if header.message_type == MessageType.INPUT_DATA_WRAPPER:
+            wrapped_fe_header = message.get_fe_content_header()
+            if message_types is None:
+                include_wrapped_content = True
+            elif wrapped_fe_header is None:
+                include_wrapped_content = False
+            else:
+                include_wrapped_content = wrapped_fe_header.message_type in message_types
 
+        # Record stats for this message type. Skip InputDataWrappers messages whose content is not listed in
+        # message_types.
+        if header.message_type != MessageType.INPUT_DATA_WRAPPER or include_wrapped_content:
+            self.stats[header.message_type].update(header, message)
+
+        # Extract additional data from the message.
         if header.message_type == MessageType.DEVICE_ID:
             self.device_id = message
         elif header.message_type == MessageType.VERSION_INFO:
             self.version_info = message
+        elif header.message_type == MessageType.INPUT_DATA_WRAPPER:
+            wrapped_fe_header = message.get_fe_content_header()
+            if include_wrapped_content:
+                # Count all wrapped content, not including FusionEngine messages.
+                if wrapped_fe_header is None:
+                    self.wrapped_non_fe_input_data_stats[message.data_type].count += 1
+                    self.wrapped_non_fe_input_data_stats[message.data_type].total_bytes += len(message.data)
+                # Count FusionEngine messages separately.
+                else:
+                    self.wrapped_fe_input_data_stats[wrapped_fe_header.message_type].count += 1
+                    self.wrapped_fe_input_data_stats[wrapped_fe_header.message_type].total_bytes += len(message.data)
 
 
 def print_summary_table(device_summary: DeviceSummary, logger: Optional[logging.Logger] = None):
@@ -184,3 +268,32 @@ def print_summary_table(device_summary: DeviceSummary, logger: Optional[logging.
         total_bytes += entry.total_bytes
     logger.info(format_string.format(*dividers))
     logger.info(format_string.format('Total', '', total_messages, total_bytes))
+
+    # Print a second table displaying types/stats for messages extracted from InputDataWrapper messages.
+    wrapped_input_data_types = (set(device_summary.wrapped_non_fe_input_data_stats.keys()) |
+                                set(device_summary.wrapped_fe_input_data_stats.keys()))
+    if len(wrapped_input_data_types) > 0:
+        cols = [
+            {'name': 'Input Data Type', 'align': '<', 'min_width': 50},
+            {'name': 'Count', 'min_width': 8},
+            {'name': 'Total Size (B)'}
+        ]
+        format_string, dividers = _print_table_header(cols)
+        total_messages = 0
+        total_bytes = 0
+        have_wrapped_fe = False
+        for data_type in sorted(wrapped_input_data_types):
+            if data_type in device_summary.wrapped_non_fe_input_data_stats:
+                entry = device_summary.wrapped_non_fe_input_data_stats[data_type]
+                logger.info(format_string.format(data_type.to_string(), entry.count, entry.total_bytes))
+                total_messages += entry.count
+                total_bytes += entry.total_bytes
+
+            if data_type in device_summary.wrapped_fe_input_data_stats:
+                entry = device_summary.wrapped_fe_input_data_stats[data_type]
+                logger.info(format_string.format(f'{data_type.to_string()} **', entry.count, entry.total_bytes))
+                have_wrapped_fe = True
+        logger.info(format_string.format(*dividers))
+        logger.info(format_string.format('Total', total_messages, total_bytes))
+        if have_wrapped_fe:
+            logger.info('** FusionEngine content extracted from InputDataWrapperMessages.')

--- a/python/tests/test_encoder.py
+++ b/python/tests/test_encoder.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pytest
 
-from fusion_engine_client.messages import PoseMessage, PoseAuxMessage
+from fusion_engine_client.messages import (GNSSSignalType, GNSSSatelliteInfo, GNSSSignalInfo,
+                                           GNSSSignalsMessage, PoseAuxMessage,
+                                           PoseMessage, SatelliteType, Timestamp)
 from fusion_engine_client.parsers import FusionEngineEncoder
 from fusion_engine_client.utils import trace as logging
 
@@ -26,3 +29,80 @@ def test_pose_encode():
     assert data == P1_POSE_MESSAGE2
     data = encoder.encode_message(pose_aux)
     assert data == P1_POSE_AUX_MESSAGE3
+
+
+def test_gnss_signals_message_encode():
+    message = GNSSSignalsMessage()
+    message.gps_time = Timestamp(1432573739.134)
+    message.gps_week = 2368
+    message.gps_tow_ms = 407339134
+
+    data = message.pack()
+    assert len(data) == 32
+
+    sats = [
+        GNSSSatelliteInfo(),
+        GNSSSatelliteInfo(system=SatelliteType.GPS, prn=3, elevation_deg=45.0, azimuth_deg=27.0,
+                          status_flags=GNSSSatelliteInfo.STATUS_FLAG_IS_USED),
+    ]
+
+    message.sat_info = {e.get_satellite_id(): e for e in sats}
+    data = message.pack()
+    assert len(data) == 32 + 8 * 2
+
+    signals = [
+        GNSSSignalInfo(),
+        GNSSSignalInfo(signal_type=GNSSSignalType.GPS_L1CA, prn=3, cn0_dbhz=46.75,
+                       status_flags=GNSSSignalInfo.STATUS_FLAG_VALID_PR | GNSSSignalInfo.STATUS_FLAG_USED_PR),
+        GNSSSignalInfo(signal_type=GNSSSignalType.GALILEO_E1BC, prn=4, cn0_dbhz=13.25,
+                       status_flags=GNSSSignalInfo.STATUS_FLAG_VALID_PR),
+    ]
+
+    message.signal_info = {e.get_signal_id(): e for e in signals}
+    data = message.pack()
+    assert len(data) == 32 + 8 * len(sats) + 8 * len(signals)
+
+    decoded_message = GNSSSignalsMessage()
+    decoded_message.unpack(data)
+    assert float(decoded_message.gps_time) == pytest.approx(1432573739.134, 1e-3)
+    assert decoded_message.gps_week == 2368
+    assert decoded_message.gps_tow_ms == 407339134
+
+    # Test invalid time decoding.
+    message = GNSSSignalsMessage()
+    data = message.pack()
+
+    decoded_message = GNSSSignalsMessage()
+    decoded_message.unpack(data)
+    assert not decoded_message.gps_time
+    assert decoded_message.gps_tow_ms is None
+    assert decoded_message.gps_week is None
+
+    # It would be nice to do the following:
+    #   assert list(decoded_message.sat_info.values()) == sats
+    # but that is not possible because the invalid satellite/signal entries contain NANs, and NAN == NAN is always
+    # false.
+    #
+    # IMPORTANT: However, that check actually PASSES in Python <=3.12 and FAILS in Python 3.13.
+    #
+    # Before Python 3.13, the @dataclass __eq__ operator was implemented as follows:
+    #   (a.var1, a.var2, ...) == (b.var1, b.var2, ...)
+    #
+    # Tuple == comparison first checks if the elements are the same physical object in memory. If so, it assumes they
+    # are equal. But in Python, math.nan (and numpy.nan) is an object, _not_ a primitive, so if any variable was set to
+    # NAN, checking tuple == would return true incorrectly. In Python 3.13, they @dataclass operator was changed to the
+    # following:
+    #   a.var1 == b.var1 and a.var2 == b.var2 and ...
+    def _is_equal(a, b):
+        for k, v_a in a.__dict__.items():
+            v_b = b.__dict__[k]
+            if np.isnan(v_a):
+                if not np.isnan(v_b):
+                    return False
+            elif np.isnan(v_b):
+                return False
+            elif v_a != v_b:
+                return False
+        return True
+    assert all([_is_equal(a, b) for a, b in zip(decoded_message.sat_info.values(), sats)])
+    assert all([_is_equal(a, b) for a, b in zip(decoded_message.signal_info.values(), signals)])

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -52,7 +52,7 @@ struct P1_ALIGNAS(4) PoseMessage : public MessagePayload {
   Timestamp gps_time;
 
   /** The type of this position solution. */
-  SolutionType solution_type;
+  SolutionType solution_type = SolutionType::Invalid;
 
   /**
    * A bitmask of flags associated with the pose data.
@@ -246,7 +246,7 @@ struct P1_ALIGNAS(4) GNSSInfoMessage : public MessagePayload {
   /** The number of satellites used in the current position solution. */
   uint8_t num_svs = 0;
 
-  uint8_t reserved[2];
+  uint8_t reserved[2] = {0};
 
   /**
    * The age of the most recently received GNSS corrections data (in 0.1

--- a/src/point_one/fusion_engine/messages/solution.h
+++ b/src/point_one/fusion_engine/messages/solution.h
@@ -335,7 +335,7 @@ struct P1_ALIGNAS(4) SatelliteInfo {
   static constexpr uint8_t SATELLITE_USED = 0x01;
   /** @} */
 
-  static constexpr int16_t INVALID_CN0 = 0;
+  static constexpr uint8_t INVALID_CN0 = 0;
 
   /** The GNSS system to which this satellite belongs. */
   SatelliteType system = SatelliteType::UNKNOWN;


### PR DESCRIPTION
# New Features
- Added support for printing `InputDataWrapper` message contents

# Changes
- Use Python `struct` to improve `InputDataWrapper` parsing efficiency
- Added helper functions to extract wrapped FusionEngine content

# Fixes
- Fixed legacy `GNSSSatellite` message constant and missing default values in `solution.h`