### PR TITLE
Display UTC/GPS time on `p1_display` X axis and hover text.

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -921,7 +921,7 @@ figure.on('plotly_unhover', function(data) {
         figure.add_trace(go.Scattergl(x=time, y=stationary_status, customdata=customdata, mode='markers'), 1, 1)
 
         self._add_figure(name="stationary_status", figure=figure, title="Stationary Status", custom_hover=True,
-                         inject_js=self._custom_tooltip_js())
+                         inject_js=self._custom_tooltip_js(value_label='Status', show_name=False))
 
     def _plot_displacement(self, source, p1_time, solution_type, displacement_enu_m, std_enu_m, gps_time=None,
                            title='Displacement'):

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2993,6 +2993,7 @@ figure.on('plotly_unhover', function(data) {
         for i in range(2):
             figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Temp (deg C)")
+        figure['layout']['yaxis2'].update(title="Temp (deg C)")
 
         # Plot the data.
         figure.add_trace(go.Scattergl(x=time, y=data.gnss_temperature_degc, customdata=customdata,

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -107,10 +107,19 @@ class Analyzer(object):
     LONG_LOG_DURATION_SEC = 2 * 3600.0
     HIGH_MEASUREMENT_RATE_HZ = 40.0
 
+    # Registers _ReformatGpsAxisTicks() to run after every redraw  (see plotly_data_support.js). Needed by any plot
+    # whose X axis can be in 'gps' mode, whether or not it uses _TIME_HOVER_JS below for hover text.
+    _GPS_TICK_REFORMAT_JS = """\
+figure.on('plotly_afterplot', _ReformatGpsAxisTicks);
+// The initial render's 'plotly_afterplot' can fire before tick label text is finalized, so also run once more on
+// the next tick, after the very first render has fully settled.
+setTimeout(_ReformatGpsAxisTicks, 0);
+"""
+
     # Generic hover JS for traces whose customdata is whichever timestamp (P1 or GPS) is not already reflected by the
     # X axis (see BuildTimeHoverText() in plotly_data_support.js, and _time_hover_customdata() below). Plots needing
-    # additional custom hover logic (e.g., decoding a status bitmask) should not use this and should build their own
-    # 'plotly_hover' handler instead.
+    # additional custom hover logic (e.g., decoding a status bitmask) should not use this directly -- build a custom
+    # 'plotly_hover' handler instead, but still append _GPS_TICK_REFORMAT_JS to it.
     _TIME_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
   for (let i = 0; i < data.points.length; ++i) {
@@ -120,11 +129,7 @@ figure.on('plotly_hover', function(data) {
     }
   }
 });
-figure.on('plotly_afterplot', _ReformatGpsAxisTicks);
-// The initial render's 'plotly_afterplot' can fire before tick label text is finalized, so also run once more on
-// the next tick, after the very first render has fully settled.
-setTimeout(_ReformatGpsAxisTicks, 0);
-"""
+""" + _GPS_TICK_REFORMAT_JS
 
     def __init__(self,
                  file: Union[DataLoader, str], ignore_index: bool = False,
@@ -1414,7 +1419,7 @@ setTimeout(_ReformatGpsAxisTicks, 0);
             subplot_titles=[title])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=self.p1_time_label, showticklabels=True)
+        figure['layout']['xaxis1'].update(showticklabels=True, **self._x_axis_layout())
         figure['layout']['yaxis1'].update(title="C/N0 (dB-Hz)")
 
         # Assign colors by PRN.
@@ -1430,11 +1435,12 @@ setTimeout(_ReformatGpsAxisTicks, 0);
 
             idx = data.signal_data['signal_hash'] == signal_hash
             p1_time = data.signal_data['p1_time'][idx]
+            gps_time = data.signal_data['gps_time'][idx]
             cn0_dbhz = data.signal_data['cn0_dbhz'][idx]
 
-            text = ['P1: %.1f sec' % t for t in p1_time]
-            time = p1_time - float(self.t0)
-            figure.add_trace(go.Scattergl(x=time, y=cn0_dbhz, text=text, name=name,
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
+            figure.add_trace(go.Scattergl(x=time, y=cn0_dbhz, customdata=customdata, name=name,
                                           mode='markers', marker={'color': color_by_prn[signal.get_prn()]}),
                              1, 1)
             indices_by_signal_type[signal.signal_type].append(len(figure.data) - 1)
@@ -1460,7 +1466,7 @@ setTimeout(_ReformatGpsAxisTicks, 0);
         }]
 
         name = self._gnss_plot_filename('gnss_cn0', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS C/N0 vs Time')
+        self._add_figure(name=name, figure=figure, title=f'{label} GNSS C/N0 vs Time', inject_js=self._TIME_HOVER_JS)
 
     def plot_gnss_azimuth_elevation(self):
         """!
@@ -1485,8 +1491,9 @@ setTimeout(_ReformatGpsAxisTicks, 0);
             subplot_titles=["Azimuth Angle",
                             "Elevation Angle"])
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=self.p1_time_label, showticklabels=True)
-        figure['layout']['xaxis2'].update(title=self.p1_time_label, showticklabels=True)
+        axis_layout = self._x_axis_layout()
+        figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
+        figure['layout']['xaxis2'].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Degrees")
         figure['layout']['yaxis2'].update(title="Degrees")
 
@@ -1506,15 +1513,16 @@ setTimeout(_ReformatGpsAxisTicks, 0);
 
             idx = data.sv_data['sv_hash'] == sv_hash
             p1_time = data.sv_data['p1_time'][idx]
+            gps_time = data.sv_data['gps_time'][idx]
             az_deg = data.sv_data['azimuth_deg'][idx]
             el_deg = data.sv_data['elevation_deg'][idx]
 
-            time = p1_time - float(self.t0)
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
 
             # Plot the data.
             color = color_by_prn[sv_id.get_prn()]
-            text = ["P1: %.3f sec" % (t + float(self.t0)) for t in time]
-            figure.add_trace(go.Scattergl(x=time, y=az_deg, text=text,
+            figure.add_trace(go.Scattergl(x=time, y=az_deg, customdata=customdata,
                                           name=name,
                                           mode='markers',
                                           marker={'color': color, 'symbol': 'circle', 'size': 8},
@@ -1522,7 +1530,7 @@ setTimeout(_ReformatGpsAxisTicks, 0);
                                           legendgroup=name),
                                 1, 1)
             indices_by_system[system].append(len(figure.data) - 1)
-            figure.add_trace(go.Scattergl(x=time, y=el_deg, text=text,
+            figure.add_trace(go.Scattergl(x=time, y=el_deg, customdata=customdata,
                                           name=name,
                                           mode='markers',
                                           marker={'color': color, 'symbol': 'circle', 'size': 8},
@@ -1552,7 +1560,8 @@ setTimeout(_ReformatGpsAxisTicks, 0);
         }]
 
         name = self._gnss_plot_filename('gnss_azimuth_elevation', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS Azimuth & Elevation vs Time')
+        self._add_figure(name=name, figure=figure, title=f'{label} GNSS Azimuth & Elevation vs Time',
+                         inject_js=self._TIME_HOVER_JS)
 
     def plot_gnss_signal_status(self):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -1632,29 +1641,31 @@ Black=Unused, Red=Used'''
                    [None],
                    [{}]])
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=self.p1_time_label)
+        axis_layout = self._x_axis_layout()
+        figure['layout']['xaxis1'].update(**axis_layout)
+        figure['layout']['xaxis2'].update(**axis_layout)
         figure['layout']['yaxis1'].update(title='Signal' if have_gnss_signals_message else 'Satellite')
         figure['layout']['yaxis2'].update(title=f"# SVs/Signals", rangemode='tozero')
 
         # Plot the signal counts.
-        time = data.p1_time - float(self.t0)
-        text = ["P1: %.3f sec" % (t + float(self.t0)) for t in time]
-        figure.add_trace(go.Scattergl(x=time, y=num_svs, text=text, name=f'# SVs',
+        time, _ = self._resolve_x_axis(p1_time=data.p1_time, gps_time=data.gps_time)
+        customdata = self._time_hover_customdata(p1_time=data.p1_time, gps_time=data.gps_time)
+        figure.add_trace(go.Scattergl(x=time, y=num_svs, customdata=customdata, name=f'# SVs',
                                       mode='lines', line={'color': 'black', 'dash': 'dash'}),
                          5, 1)
         if have_gnss_signals_message:
-            figure.add_trace(go.Scattergl(x=time, y=num_signals, text=text, name=f'# Signals',
+            figure.add_trace(go.Scattergl(x=time, y=num_signals, customdata=customdata, name=f'# Signals',
                                           mode='lines', line={'color': 'gray', 'dash': 'dash'}),
                              5, 1)
 
-        figure.add_trace(go.Scattergl(x=time, y=num_used_svs, text=text, name=f'# Used SVs',
+        figure.add_trace(go.Scattergl(x=time, y=num_used_svs, customdata=customdata, name=f'# Used SVs',
                                       mode='lines', line={'color': 'green'}),
                          5, 1)
         if have_gnss_signals_message:
-            figure.add_trace(go.Scattergl(x=time, y=num_used_signals, text=text, name=f'# Used Signals',
+            figure.add_trace(go.Scattergl(x=time, y=num_used_signals, customdata=customdata, name=f'# Used Signals',
                                           mode='lines', line={'color': 'red'}),
                              5, 1)
-            figure.add_trace(go.Scattergl(x=time, y=num_fixed_signals, text=text, name=f'# Fixed Signals',
+            figure.add_trace(go.Scattergl(x=time, y=num_fixed_signals, customdata=customdata, name=f'# Fixed Signals',
                                           mode='lines', line={'color': 'orange'}),
                              5, 1)
 
@@ -1750,10 +1761,13 @@ Black=Unused, Red=Used'''
             # Extract data for this signal.
             idx = data.signal_data['signal_hash'] == signal_hash
             p1_time = data.signal_data['p1_time'][idx]
+            gps_time = data.signal_data['gps_time'][idx]
             cn0_dbhz = data.signal_data['cn0_dbhz'][idx]
             status_flags = data.signal_data['status_flags'][idx]
             signal_has_corrections = None if have_corrections is None else have_corrections[idx]
-            time = p1_time - float(self.t0)
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            # The time value NOT already reflected by the X axis, one row, to include in this signal's customdata.
+            other_time = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)[0]
 
             # Find the satellite elevation for the times this signal was present.
             sv_idx = data.sv_data['sv_hash'] == int(signal.get_satellite_id())
@@ -1766,7 +1780,8 @@ Black=Unused, Red=Used'''
                 idx = cond['cond'](status_flags, signal_has_corrections)
                 if np.any(idx):
                     figure.add_trace(go.Scattergl(x=time[idx], y=[y_offset] * np.sum(idx),
-                                                  customdata=np.vstack((status_flags[idx],
+                                                  customdata=np.vstack((other_time[idx],
+                                                                        status_flags[idx],
                                                                         cn0_dbhz[idx],
                                                                         elev_deg[idx])),
                                                   name=name,
@@ -1806,9 +1821,10 @@ Black=Unused, Red=Used'''
 
         hover_js = f"""\
 function SetSignalStatusHover(point) {{
-  let status_flags = GetCustomData(point, 0);
-  let cn0_dbhz = GetCustomData(point, 1);
-  let elev_deg = GetCustomData(point, 2);
+  let other_time = GetCustomData(point, 0);
+  let status_flags = GetCustomData(point, 1);
+  let cn0_dbhz = GetCustomData(point, 2);
+  let elev_deg = GetCustomData(point, 3);
 
   let tracking = [];
   if (status_flags & {GNSSSignalInfo.STATUS_FLAG_VALID_PR}) {{
@@ -1848,7 +1864,7 @@ function SetSignalStatusHover(point) {{
     features.push("RTK");
   }}
 
-  let new_text = GetTimeText(point.x);
+  let new_text = BuildTimeHoverText(point.x, other_time);
   new_text += "<br>C/N0: " + cn0_dbhz.toFixed(2) + " dB-Hz";
   new_text += "<br>Elevation: " + elev_deg.toFixed(1) + " deg";
   new_text += "<br>Status mask: 0x" + status_flags.toString(16);
@@ -1865,11 +1881,11 @@ figure.on('plotly_hover', function(data) {{
       SetSignalStatusHover(point);
     }}
     else {{
-      ChangeHoverText(point, GetTimeText(point.x));
+      ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
     }}
   }}
 }});
-"""
+""" + self._GPS_TICK_REFORMAT_JS
 
         self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=hover_js)
 
@@ -2038,8 +2054,9 @@ figure.on('plotly_hover', function(data) {{
                    [None],
                    [{}]])
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
+        axis_layout = self._x_axis_layout()
         for i in range(2):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True, matches='x')
+            figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, matches='x', **axis_layout)
         figure['layout']['yaxis1'].update(title="Baseline Distance (km)")
         figure['layout']['yaxis2'].update(title="Age (sec)")
 
@@ -2057,20 +2074,23 @@ figure.on('plotly_hover', function(data) {{
         # Now plot data for each base station.
         for station_id in station_ids:
             idx = data.reference_station_id == station_id
-            time = data.p1_time[idx] - float(self.t0)
+            p1_time = data.p1_time[idx]
+            gps_time = data.gps_time[idx]
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
             name = f'Station {station_id}'
             color = colors[station_id]
-            text = ["P1 Time: %.3f sec" % (t + float(self.t0)) for t in time]
-            figure.add_trace(go.Scattergl(x=time, y=data.baseline_distance_m[idx] * 1e-3, text=text,
+            figure.add_trace(go.Scattergl(x=time, y=data.baseline_distance_m[idx] * 1e-3, customdata=customdata,
                                           name=name, legendgroup=int(station_id), showlegend=True,
                                           mode='markers', marker={'color': color}),
                              1, 1)
-            figure.add_trace(go.Scattergl(x=time, y=data.corrections_age_sec[idx], text=text,
+            figure.add_trace(go.Scattergl(x=time, y=data.corrections_age_sec[idx], customdata=customdata,
                                           name=name, legendgroup=int(station_id), showlegend=False,
                                           mode='markers', marker={'color': color}),
                              4, 1)
 
-        self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS Corrections Status")
+        self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS Corrections Status",
+                         inject_js=self._TIME_HOVER_JS)
 
     def plot_wheel_data(self):
         """!

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -558,11 +558,11 @@ figure.on('plotly_hover', function(data) {
         figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=['Reset Recovery Time'])
 
-        figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=self.system_time_label, showticklabels=True)
-        figure['layout']['yaxis1'].update(title="Elapsed Time (sec)", rangemode="tozero")
+        time, axis_layout = self._resolve_x_axis(system_time=reset_system_time_sec, time_source='system')
 
-        time = reset_system_time_sec - self.system_t0
+        figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
+        figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
+        figure['layout']['yaxis1'].update(title="Elapsed Time (sec)", rangemode="tozero")
 
         text = ["System Time: %.3f sec" % (t + self.system_t0) for t in time]
         figure.add_trace(go.Scattergl(x=time, y=dt_reset_to_valid, text=text,

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -229,13 +229,6 @@ figure.on('plotly_hover', function(data) {
 
         self.time_type = time_type
 
-        if self.time_type == 'relative':
-            self.system_t0 = self.reader.get_system_t0()
-            if self.system_t0 is None:
-                self.system_t0 = np.nan
-        else:
-            self.system_t0 = 0.0
-
         # The time domain -- `p1` (covers both relative and absolute P1 time) or `gps` (covers both GPS and UTC) --
         # implied by @c self.time_type, used by @ref _resolve_x_axis() and the default of _time_hover_customdata()'s
         # `x_domain` argument. Some plots may use a different X axis regardles of self.time_type, and may override this.
@@ -3576,12 +3569,13 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
 
         # Create global variables with the log's t0 timestamp, the (leap-second accurate) GPS/POSIX offset, the
         # system time t0 (see BuildSystemTimeHoverText()), and the time domain plotted on this figure's X axis (see
-        # BuildTimeHoverText()). Note: self.reader.t0 and self.system_t0 may each independently be unavailable (e.g.
-        # a system-time-only profiling log has no P1 time at all), so both need a 'null' fallback -- plots that
+        # BuildTimeHoverText()). Note: self.reader.t0 and system_t0 may each independently be unavailable (e.g. a
+        # system-time-only profiling log has no P1 time at all), so both need a 'null' fallback -- plots that
         # don't use one of these domains at all still go through this same code path whenever inject_js is set.
         gps_posix_offset_sec = self.time_provider.get_gps_posix_offset_sec()
         p1_t0_sec = None if self.reader.t0 is None else float(self.reader.t0)
-        system_t0_sec = None if np.isnan(self.system_t0) else float(self.system_t0)
+        system_t0 = self.reader.get_system_t0() if self.time_type == 'relative' else 0.0
+        system_t0_sec = None if system_t0 is None else float(system_t0)
         post_script += f"""\
 var p1_t0_sec = {p1_t0_sec if p1_t0_sec is not None else 'null'};
 var p1_time_axis_rel = {'true' if self.time_type == 'relative' else 'false'};
@@ -3702,9 +3696,10 @@ var time_axis_type = '{time_axis_type}';
         axis_layout = self._x_axis_layout(time_source=time_source, ignore_gps=ignore_gps)
 
         if time_source == 'system':
-            # self.system_t0 is set to 0 when self.time_type == 'absolute', so this works for both absolute and relative
-            # time axes. See _x_axis_layout().
-            return system_time - float(self.system_t0), axis_layout
+            if self.time_type == 'relative':
+                return system_time - float(self.reader.get_system_t0()), axis_layout
+            else:
+                return system_time, axis_layout
 
         if self.time_type == 'relative':
             return p1_time - float(self.reader.t0), axis_layout

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -106,6 +106,25 @@ class Analyzer(object):
     LONG_LOG_DURATION_SEC = 2 * 3600.0
     HIGH_MEASUREMENT_RATE_HZ = 40.0
 
+    # Generic hover JS for traces whose customdata is whichever timestamp (P1 or GPS) is not already reflected by the
+    # X axis (see BuildTimeHoverText() in plotly_data_support.js, and _time_hover_customdata() below). Plots needing
+    # additional custom hover logic (e.g., decoding a status bitmask) should not use this and should build their own
+    # 'plotly_hover' handler instead.
+    _TIME_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    if (point.data.customdata) {
+      ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
+    }
+  }
+});
+figure.on('plotly_afterplot', _ReformatGpsAxisTicks);
+// The initial render's 'plotly_afterplot' can fire before tick label text is finalized, so also run once more on
+// the next tick, after the very first render has fully settled.
+setTimeout(_ReformatGpsAxisTicks, 0);
+"""
+
     def __init__(self,
                  file: Union[DataLoader, str], ignore_index: bool = False,
                  output_dir: str = None, prefix: str = '',
@@ -198,13 +217,18 @@ class Analyzer(object):
             self.p1_time_label = 'Relative Time (sec)'
             self.system_time_label = 'Relative Time (sec)'
         else:
-            # Per-plot support for 'gps'/'utc' x-axis values is added incrementally (see _resolve_x_axis()); until a
+            # Per-plot support for 'gps'/'utc' X-axis values is added incrementally (see _resolve_x_axis()); until a
             # given plot has been updated, it falls back to absolute P1/system time here.
             self.time_axis = 'absolute'
             self.t0 = Timestamp(0.0)
             self.system_t0 = 0.0
             self.p1_time_label = 'P1 Time (sec)'
             self.system_time_label = 'System Time (sec)'
+
+        # The time domain -- `p1` (covers both relative and absolute P1 time) or `gps` (covers both GPS and UTC) --
+        # implied by @c self.time_type, used by @ref _resolve_x_axis() and the default of _time_hover_customdata()'s
+        # `x_domain` argument. Some plots may use a different X axis regardles of self.time_type, and may override this.
+        self._default_x_domain = 'p1' if self.time_type in ('relative', 'p1') else 'gps'
 
         self.plots = {}
         self.summary = ''
@@ -685,8 +709,8 @@ class Analyzer(object):
             self.logger.info('No calibration data available. Skipping calibration plot.')
             return
 
-        time = cal_data.p1_time - float(self.t0)
-        text = ["Time: %.3f sec (%.3f sec)" % (t, t + float(self.t0)) for t in time]
+        time, axis_label, axis_layout = self._resolve_x_axis(p1_time=cal_data.p1_time)
+        time_customdata = self._time_hover_customdata(p1_time=cal_data.p1_time)
 
         # Map calibration stage enum values onto a [0, N) range for plotting.
         stage_map = {e.value: i for i, e in enumerate(CalibrationStage)}
@@ -700,7 +724,7 @@ class Analyzer(object):
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(4):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True)
+            figure['layout']['xaxis%d' % (i + 1)].update(title=axis_label, showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Percent Complete", range=[0, 100])
         figure['layout']['yaxis2'].update(ticktext=['%s' % e.name for e in CalibrationStage],
                                           tickvals=list(range(len(stage_map))))
@@ -709,44 +733,45 @@ class Analyzer(object):
         figure['layout']['yaxis5'].update(title="Meters")
 
         # Plot calibration stage and completion percentages.
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.gyro_bias_percent_complete, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.gyro_bias_percent_complete, customdata=time_customdata,
                                       name='Gyro Bias Completion',
                                       mode='lines', line={'color': 'red'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.accel_bias_percent_complete, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.accel_bias_percent_complete, customdata=time_customdata,
                                       name='Accel Bias Completion',
                                       mode='lines', line={'color': 'green'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.mounting_angle_percent_complete, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.mounting_angle_percent_complete, customdata=time_customdata,
                                       name='Mounting Angle Completion',
                                       mode='lines', line={'color': 'blue'}),
                          1, 1)
 
-        figure.add_trace(go.Scattergl(x=time, y=calibration_stage, name='Stage', text=text,
+        figure.add_trace(go.Scattergl(x=time, y=calibration_stage, name='Stage', customdata=time_customdata,
                                       mode='lines', line={'color': 'black', 'dash': 'dash'}),
                          1, 1, secondary_y=True)
 
         # Plot mounting angles.
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[0, :], name='Yaw', legendgroup='y', text=text,
-                                      mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[0, :], name='Yaw', legendgroup='y',
+                                      customdata=time_customdata, mode='lines', line={'color': 'red'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[1, :], name='Pitch', legendgroup='p', text=text,
-                                      mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[1, :], name='Pitch', legendgroup='p',
+                                      customdata=time_customdata, mode='lines', line={'color': 'green'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[2, :], name='Roll', legendgroup='r', text=text,
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_deg[2, :], name='Roll', legendgroup='r',
+                                      customdata=time_customdata, mode='lines', line={'color': 'blue'}),
                          2, 1)
 
         figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_std_dev_deg[0, :], name='Yaw Std Dev', legendgroup='y',
-                                      text=text, mode='lines', line={'color': 'red'}),
+                                      customdata=time_customdata, mode='lines', line={'color': 'red'}),
                          3, 1)
         figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_std_dev_deg[1, :], name='Pitch Std Dev', legendgroup='p',
-                                      text=text, mode='lines', line={'color': 'green'}),
+                                      customdata=time_customdata, mode='lines', line={'color': 'green'}),
                          3, 1)
         figure.add_trace(go.Scattergl(x=time, y=cal_data.ypr_std_dev_deg[2, :], name='Roll Std Dev', legendgroup='r',
-                                      text=text, mode='lines', line={'color': 'blue'}),
+                                      customdata=time_customdata, mode='lines', line={'color': 'blue'}),
                          3, 1)
 
+        # Threshold reference lines only have 2 points (first/last time), so they don't get per-point hover data.
         thresh_time = time[np.array((0, -1))]
         figure.add_trace(go.Scattergl(x=thresh_time, y=[cal_data.mounting_angle_max_std_dev_deg[0]] * 2,
                                       name='Max Yaw Std Dev', legendgroup='y',
@@ -754,23 +779,23 @@ class Analyzer(object):
                          3, 1)
         figure.add_trace(go.Scattergl(x=thresh_time, y=[cal_data.mounting_angle_max_std_dev_deg[1]] * 2,
                                       name='Max Pitch Std Dev', legendgroup='p',
-                                      text=text, mode='lines', line={'color': 'green', 'dash': 'dash'}),
+                                      mode='lines', line={'color': 'green', 'dash': 'dash'}),
                          3, 1)
         figure.add_trace(go.Scattergl(x=thresh_time, y=[cal_data.mounting_angle_max_std_dev_deg[2]] * 2,
                                       name='Max Roll Std Dev', legendgroup='r',
-                                      text=text, mode='lines', line={'color': 'blue', 'dash': 'dash'}),
+                                      mode='lines', line={'color': 'blue', 'dash': 'dash'}),
                          3, 1)
 
         # Plot travel distance.
-        figure.add_trace(go.Scattergl(x=time, y=cal_data.travel_distance_m, name='Travel Distance', text=text,
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=cal_data.travel_distance_m, name='Travel Distance',
+                                      customdata=time_customdata, mode='lines', line={'color': 'blue'}),
                          4, 1)
         figure.add_trace(go.Scattergl(x=thresh_time, y=[cal_data.min_travel_distance_m] * 2,
-                                      name='Min Travel Distance', text=text,
+                                      name='Min Travel Distance',
                                       mode='lines', line={'color': 'black', 'dash': 'dash'}),
                          4, 1)
 
-        self._add_figure(name="calibration", figure=figure, title="Calibration Status")
+        self._add_figure(name="calibration", figure=figure, title="Calibration Status", inject_js=self._TIME_HOVER_JS)
 
     def plot_solution_type(self):
         """!
@@ -3253,7 +3278,8 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
 
         self.plots[name] = {'title': title, 'path': path}
 
-    def _add_figure(self, name, figure=None, title=None, config=None, inject_js: str = None):
+    def _add_figure(self, name, figure=None, title=None, config=None, inject_js: str = None,
+                    time_axis_type: Optional[str] = None):
         """!
         @brief Generate an HTML file for the specified figure.
 
@@ -3262,9 +3288,17 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         @param title An optional human-friendly display title to be added to the generated @c index.html file.
         @param config An optional dictionary containing Plotly.js figure config options to be included in the generated
                JavaScript.
+        @param inject_js Custom Javascript to be injected into the generated HTML file (see @ref
+               __write_html_and_inject_js()).
+        @param time_axis_type The time domain actually plotted on this figure's X axis (`relative`, `p1`, `gps`, or
+               `utc`; see @ref BuildTimeHoverText() in `plotly_data_support.js`). Defaults to `self.time_type`; only
+               needs to be overridden by plots (e.g., @ref plot_time_scale()) whose X axis does not follow it.
         """
         if title is None:
             title = name
+
+        if time_axis_type is None:
+            time_axis_type = self.time_type
 
         if name in self.plots:
             raise ValueError('Plot "%s" already exists.' % name)
@@ -3280,7 +3314,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
             if inject_js is not None:
-                plotly.io.write_html = functools.partial(self.__write_html_and_inject_js, inject_js)
+                plotly.io.write_html = functools.partial(self.__write_html_and_inject_js, inject_js, time_axis_type)
 
             plotly.offline.plot(
                 figure,
@@ -3297,15 +3331,19 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         self.plots[name] = {'title': title, 'path': path if figure is not None else None}
 
     # Support for injecting custom javascript into the generated plotly HTML file.
-    def __write_html_and_inject_js(self, inject_js, *args, **kwargs):
+    def __write_html_and_inject_js(self, inject_js, time_axis_type, *args, **kwargs):
         post_script = kwargs.get("post_script", None)
         if post_script is None:
             post_script = ""
 
-        # Create a global variable with the log's t0 timestamp.
+        # Create global variables with the log's t0 timestamp, the (leap-second accurate) GPS/POSIX offset, and the
+        # time domain plotted on this figure's X axis (see BuildTimeHoverText()).
+        gps_posix_offset_sec = self.time_provider.get_gps_posix_offset_sec()
         post_script += f"""\
 var p1_t0_sec = {float(self.reader.t0)};
 var p1_time_axis_rel = {'true' if self.time_axis == 'relative' else 'false'};
+var gps_posix_offset_sec = {gps_posix_offset_sec if gps_posix_offset_sec is not None else 'null'};
+var time_axis_type = '{time_axis_type}';
 """
 
         # Inject common plotly data support functions (GetTimeText(), etc.).
@@ -3353,6 +3391,68 @@ var p1_time_axis_rel = {'true' if self.time_axis == 'relative' else 'false'};
             return 0.0
         elif time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
             return float(self.system_t0)
+
+    def _resolve_x_axis(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None) -> \
+            Tuple[np.ndarray, str, dict]:
+        """!
+        @brief Resolve the X axis values, label, and layout to use for a time series, per @c self.time_type.
+
+        @param p1_time The P1 time for each point.
+        @param gps_time The GPS time for each point, if already known (e.g., from a @ref PoseMessage). If `None`, it
+               will be computed from `p1_time` via @c self.time_provider when needed.
+
+        @return A tuple `(x, axis_label, axis_layout)`:
+                - `x`: The X axis values to plot.
+                - `axis_label`: The axis title to use.
+                - `axis_layout`: Extra `go.layout.XAxis` kwargs needed to display `x` (e.g., `type='date'`).
+        """
+        if self.time_type == 'relative':
+            return p1_time - float(self.t0), self.p1_time_label, {}
+        elif self.time_type == 'p1':
+            return p1_time, self.p1_time_label, {}
+
+        if gps_time is None:
+            gps_time = self.time_provider.p1_to_gps(p1_time)
+
+        if self.time_type == 'gps':
+            # GPS seconds are large enough that Plotly may otherwise render ticks in scientific/SI-prefix notation,
+            # which _ReformatGpsAxisTicks() (see plotly_data_support.js) can't parse back into week:tow. We let
+            # Plotly auto-generate normal (zoom-aware) numeric ticks here, and rewrite the rendered tick text into
+            # week:tow client-side, rather than computing fixed tick positions/labels ourselves -- those wouldn't
+            # regenerate on zoom/pan and could leave a zoomed-in view with no visible ticks at all.
+            return gps_time, 'GPS Time (week:tow)', {'exponentformat': 'none'}
+        else:
+            # Plotly serializes a datetime64 array as literal date strings, so (unlike plain milliseconds-since-
+            # epoch numbers) they display as given, without being reinterpreted in the browser's local timezone.
+            utc = self.time_provider.gps_sec_to_datetime64_array(gps_time)
+            return utc, 'UTC Time', {'type': 'date'}
+
+    def _time_hover_customdata(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None,
+                               x_domain: Optional[str] = None) -> np.ndarray:
+        """!
+        @brief Build the customdata array needed by `BuildTimeHoverText()` for a trace (see `plotly_data_support.js`).
+
+        Only whichever of P1/GPS time is NOT already reflected by the X axis needs to be included here -- the other
+        is recoverable in Javascript from the X value via a constant offset (P1 <-> relative, or GPS <-> UTC).
+
+        @param p1_time The P1 time for each point.
+        @param gps_time The GPS time for each point, or `None` if not already known. Computed from `p1_time` via
+               @c self.time_provider if `x_domain` is `'p1'` and this is `None`.
+        @param x_domain The time domain actually plotted on the X axis: `p1` (covers both relative and absolute P1
+               time) or `gps` (covers both GPS and UTC). Defaults to @ref _default_x_domain; only needs to be passed
+               explicitly by plots (e.g., @ref plot_time_scale()) whose X axis doesn't follow @c self.time_type.
+
+        @return A customdata array suitable for `go.Scattergl(..., customdata=...)`.
+        """
+        if x_domain is None:
+            x_domain = self._default_x_domain
+
+        if x_domain == 'p1':
+            if gps_time is None:
+                gps_time = self.time_provider.p1_to_gps(p1_time)
+            return np.vstack((gps_time,))
+        else:
+            return np.vstack((p1_time,))
 
     def _auto_detect_message_type(self, types: List[MessageType]):
         types = [t.MESSAGE_TYPE if inspect.isclass(t) else t for t in types]

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -32,6 +32,7 @@ from ..utils import trace as logging
 from ..utils.argument_parser import ArgumentParser, ExtendedBooleanAction, TriStateBooleanAction, CSVAction
 from ..utils.log import define_cli_arguments as define_log_search_arguments, locate_log
 from ..utils.numpy_utils import find_first
+from ..utils.time_provider import TimeProvider
 from ..utils.trace import HighlightFormatter
 
 
@@ -109,7 +110,7 @@ class Analyzer(object):
                  file: Union[DataLoader, str], ignore_index: bool = False,
                  output_dir: str = None, prefix: str = '',
                  time_range: TimeRange = None, max_messages: int = None,
-                 time_axis: str = 'relative',
+                 time_type: str = 'utc',
                  truncate_long_logs: bool = True, source_id: Optional[List[int]] = None):
         """!
         @brief Create an analyzer for the specified log.
@@ -123,9 +124,11 @@ class Analyzer(object):
                be read. See @ref TimeRange for more details.
         @param max_messages If set, read up to the specified maximum number of messages. Applies across all message
                types.
-        @param time_axis Specify the way in which time will be plotted:
-               - `absolute`, `abs` - Absolute P1 or system timestamps
-               - `relative`, `rel` - Elapsed time since the start of the log
+        @param time_type Specify the way in which time will be plotted:
+               - `utc` - UTC date/time, if available (falls back to P1 time otherwise)
+               - `gps` - GPS time (week and time of week), if available (falls back to P1 time otherwise)
+               - `p1` - Absolute P1 (or system) time
+               - `relative` - Elapsed time since the start of the log
         @param truncate_long_logs If `True`, reduce or skip certain plots if the log extremely long (as defined by
                @ref LONG_LOG_DURATION_SEC).
         """
@@ -170,7 +173,19 @@ class Analyzer(object):
         else:
             self.default_source_id = 0
 
-        if time_axis in ('relative', 'rel'):
+        # Load the P1/GPS time correspondence for this log, used to support time_type 'gps' and 'utc'.
+        self.time_provider = TimeProvider()
+        self.time_provider.set_reference_data(self.reader, source_id=self.default_source_id)
+
+        if time_type not in ('utc', 'gps', 'p1', 'relative'):
+            raise ValueError(f"Unsupported time type specifier '{time_type}'.")
+        elif time_type in ('gps', 'utc') and not self.time_provider.has_gps_reference():
+            _logger.warning("No GPS time reference available in this log. Falling back to P1 time.")
+            time_type = 'p1'
+
+        self.time_type = time_type
+
+        if self.time_type == 'relative':
             self.time_axis = 'relative'
             self.t0 = self.reader.t0
             if self.t0 is None:
@@ -182,14 +197,14 @@ class Analyzer(object):
 
             self.p1_time_label = 'Relative Time (sec)'
             self.system_time_label = 'Relative Time (sec)'
-        elif time_axis in ('absolute', 'abs'):
+        else:
+            # Per-plot support for 'gps'/'utc' x-axis values is added incrementally (see _resolve_x_axis()); until a
+            # given plot has been updated, it falls back to absolute P1/system time here.
             self.time_axis = 'absolute'
             self.t0 = Timestamp(0.0)
             self.system_t0 = 0.0
             self.p1_time_label = 'P1 Time (sec)'
             self.system_time_label = 'System Time (sec)'
-        else:
-            raise ValueError(f"Unsupported time axis specifier '{time_axis}'.")
 
         self.plots = {}
         self.summary = ''
@@ -3427,10 +3442,17 @@ Load and display information stored in a FusionEngine binary file.
         '-m', '--measurements', action=ExtendedBooleanAction,
         help="Plot incoming measurement data (slow). Ignored if --plot is specified.")
     plot_group.add_argument(
-        '--time-axis', choices=('absolute', 'abs', 'relative', 'rel'), default='absolute',
+        '--time-type', choices=('utc', 'gps', 'p1', 'relative'), default='utc',
         help="Specify the way in which time will be plotted:"
-             "\n- absolute, abs - Absolute P1 or system timestamps"
-             "\n- relative, rel - Elapsed time since the start of the log")
+             "\n- utc - UTC date/time, if available (falls back to P1 time otherwise)"
+             "\n- gps - GPS time (week and time of week), if available (falls back to P1 time otherwise)"
+             "\n- p1 - Absolute P1 (or system) time"
+             "\n- relative - Elapsed time since the start of the log")
+    plot_group.add_argument(
+        '--time-axis', choices=('absolute', 'abs', 'relative', 'rel'), default=None,
+        help="Deprecated. Use --time-type instead. If specified, overrides --time-type:"
+             "\n- absolute, abs - Equivalent to --time-type=utc"
+             "\n- relative, rel - Equivalent to --time-type=relative")
     plot_group.add_argument(
         '--truncate', '--trunc', action=ExtendedBooleanAction, default=True,
         help="When processing a very long log (>%.1f hours), reduce or skip some plots that may be very slow to "
@@ -3553,10 +3575,18 @@ Load and display information stored in a FusionEngine binary file.
             _logger.error('Source identifiers must be integers. Exiting.')
             sys.exit(1)
 
+    # --time-axis is deprecated in favor of --time-type, but still accepted for backwards compatibility.
+    time_type = options.time_type
+    if options.time_axis is not None:
+        if options.time_axis in ('relative', 'rel'):
+            time_type = 'relative'
+        elif options.time_axis in ('absolute', 'abs'):
+            time_type = 'utc'
+
     # Read pose data from the file.
     analyzer = Analyzer(file=input_path, output_dir=output_dir, ignore_index=options.ignore_index,
                         prefix=options.prefix + '.' if options.prefix is not None else '',
-                        time_range=time_range, time_axis=options.time_axis,
+                        time_range=time_range, time_type=time_type,
                         truncate_long_logs=options.truncate and options.plot is None, source_id=source_id)
 
     # Resolve reference data, if specified. This must happen after the analyzer (and its DataLoader) for the primary

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -3324,7 +3324,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         # in case, we'll approximate the GPS time _at_ t0 if needed.
         idx = find_first(~np.isnan(pose_data.gps_time))
         if idx >= 0:
-            first_p1_time = self.t0 if self.time_type == 'relative' else pose_data.p1_time[0]
+            first_p1_time = self.reader.t0
             dt_p1_sec = pose_data.p1_time[idx] - float(first_p1_time)
             t0_gps = Timestamp(pose_data.gps_time[idx]) - dt_p1_sec
             # If the first pose is pretty close to t0, we'll assume the approximation is reasonably accurate and not
@@ -3576,13 +3576,19 @@ var time_axis_type = '{time_axis_type}';
 
     def _get_t0_for_time_source(self, time_source: SystemTimeSource) -> float:
         if time_source == SystemTimeSource.P1_TIME:
-            return float(self.t0)
+            if self.time_type == 'relative':
+                return float(self.reader.t0)
+            else:
+                return 0.0
         elif time_source == SystemTimeSource.GPS_TIME:
             return 0.0
         elif time_source == SystemTimeSource.SENDER_SYSTEM_TIME:
             return 0.0
         elif time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
-            return float(self.system_t0)
+            if self.time_type == 'relative':
+                return float(self.reader.get_system_t0())
+            else:
+                return 0.0
 
     def _x_axis_layout(self, time_source: str = 'p1', ignore_gps: bool = False) -> dict:
         """!
@@ -3649,7 +3655,7 @@ var time_axis_type = '{time_axis_type}';
             return system_time - float(self.system_t0), axis_layout
 
         if self.time_type == 'relative':
-            return p1_time - float(self.t0), axis_layout
+            return p1_time - float(self.reader.t0), axis_layout
         elif self.time_type == 'p1' or ignore_gps:
             return p1_time, axis_layout
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -272,22 +272,15 @@ figure.on('plotly_hover', function(data) {
         if self.output_dir is None:
             return
 
-        # Setup the figure. This plot's X axis is always P1 time (relative or absolute), regardless of
-        # self.time_type -- see _resolve_x_axis(..., ignore_gps=True) below.
-        axis_layout = self._x_axis_layout(ignore_gps=True)
-        time_axis_str = 'Relative Time' if self.time_type == 'relative' else 'P1/System Time'
+        # Setup the figure.
+        axis_layout = self._x_axis_layout()
         p1_time_axis_str = axis_layout['title'].replace(' (sec)', '')
-        figure = make_subplots(rows=2, cols=1, print_grid=False, shared_xaxes=True,
-                               subplot_titles=[f'Device Time vs. {time_axis_str}',
-                                               f'Pose Message Interval vs. {p1_time_axis_str}'])
+        figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=True,
+                               subplot_titles=[f'Pose Message Interval vs. {p1_time_axis_str}'])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=f"{time_axis_str} (sec)", showticklabels=True)
-        figure['layout']['xaxis2'].update(showticklabels=True, **axis_layout)
-        figure['layout']['yaxis1'].update(title="Absolute Time",
-                                          ticktext=['P1/GPS Time', 'System Time'],
-                                          tickvals=[1, 2])
-        figure['layout']['yaxis2'].update(title="Interval (sec)", rangemode="tozero")
+        figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
+        figure['layout']['yaxis1'].update(title="Interval (sec)", rangemode="tozero")
 
         # Read the pose data to get P1 and GPS timestamps.
         result = self.reader.read(message_types=[PoseMessage], source_ids=self.default_source_id, **self.params)
@@ -353,77 +346,32 @@ figure.on('plotly_hover', function(data) {
                 p1_time = pose_data.p1_time
                 gps_time = pose_data.gps_time
 
-            # This plot's X axis is always P1 time (relative or absolute), regardless of self.time_type, since its
-            # purpose is comparing P1/GPS/System clocks against a common elapsed timeline. So customdata only needs
-            # GPS time -- BuildTimeHoverText() (see plotly_data_support.js) recovers P1 time from the X value itself.
-            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time, x_domain='p1')
-            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 1), name='P1/GPS Time', customdata=customdata,
-                                          mode='markers', marker={'color': 'blue'}),
-                             1, 1)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
 
             figure.add_trace(go.Scattergl(x=time, y=dp1_time, name='P1 Time Interval', customdata=customdata,
                                           mode='markers', marker={'color': 'red'}),
-                             2, 1)
+                             1, 1)
             if dp1_stats is not None:
                 figure.add_trace(go.Scattergl(x=time, y=dp1_stats['max'], name='P1 Time Interval (Max)',
                                               mode='markers', marker={'symbol': 'triangle-up-open'}),
-                                 2, 1)
+                                 1, 1)
                 figure.add_trace(go.Scattergl(x=time, y=dp1_stats['min'], name='P1 Time Interval (Min)',
                                               mode='markers', marker={'symbol': 'triangle-down-open'}),
-                                 2, 1)
+                                 1, 1)
 
             figure.add_trace(go.Scattergl(x=time, y=dgps_time, name='GPS Time Interval', customdata=customdata,
                                           mode='markers', marker={'color': 'green'}),
-                             2, 1)
+                             1, 1)
             if dgps_stats is not None:
                 figure.add_trace(go.Scattergl(x=time, y=dgps_stats['max'], name='GPS Time Interval (Max)',
                                               mode='markers', marker={'symbol': 'triangle-up-open'}),
-                                 2, 1)
+                                 1, 1)
                 figure.add_trace(go.Scattergl(x=time, y=dgps_stats['min'], name='GPS Time Interval (Min)',
                                               mode='markers', marker={'symbol': 'triangle-down-open'}),
-                                 2, 1)
-
-        # Read system timestamps from event notifications and profiling data, if present.
-        result = self.reader.read(message_types=[EventNotificationMessage], **self.params)
-        event_data = result[EventNotificationMessage.MESSAGE_TYPE]
-        system_time_sec = None
-        if len(event_data.system_time) > 0:
-            system_time_sec = event_data.system_time
-
-        # Plot the result.
-        if system_time_sec is not None:
-            time, _ = self._resolve_x_axis(system_time=system_time_sec, time_source='system')
-
-            # plotly starts to struggle with > 2 hours of data and won't display mouseover text, so decimate if
-            # necessary.
-            dt_sec = time[-1] - time[0]
-            if dt_sec > 7200.0:
-                step = math.ceil(dt_sec / 7200.0)
-                idx = np.full_like(time, False, dtype=bool)
-                idx[0::step] = True
-                time = time[idx]
-
-            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 2), name='System Time',
-                                          mode='markers', marker={'color': 'purple'}),
-                             1, 1)
-
-        # P1/GPS time points carry customdata (see BuildTimeHoverText()), system time points don't.
-        _TIME_SCALE_HOVER_JS = """\
-figure.on('plotly_hover', function(data) {
-  let point = data.points[0];
-  let time_text = point.data.customdata ? BuildTimeHoverText(point.x, GetCustomData(point, 0)) :
-                                          BuildSystemTimeHoverText(point.x);
-  let value_text = BuildAxisValueHoverText(point);
-  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
-});
-figure.on('plotly_unhover', function(data) {
-  HideCustomTooltip();
-});
-"""
+                                 1, 1)
 
         self._add_figure(name="time_scale", figure=figure, title="Time Scale", custom_hover=True,
-                         inject_js=_TIME_SCALE_HOVER_JS,
-                         time_axis_type='relative' if self.time_type == 'relative' else 'p1')
+                         inject_js=self._custom_tooltip_js())
 
     def plot_latency(self):
         if self.output_dir is None:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -229,7 +229,6 @@ figure.on('plotly_hover', function(data) {
         self.time_type = time_type
 
         if self.time_type == 'relative':
-            self.time_axis = 'relative'
             self.t0 = self.reader.t0
             if self.t0 is None:
                 self.t0 = Timestamp()
@@ -241,9 +240,6 @@ figure.on('plotly_hover', function(data) {
             self.p1_time_label = 'Relative Time (sec)'
             self.system_time_label = 'Relative Time (sec)'
         else:
-            # Per-plot support for 'gps'/'utc' X-axis values is added incrementally (see _resolve_x_axis()); until a
-            # given plot has been updated, it falls back to absolute P1/system time here.
-            self.time_axis = 'absolute'
             self.t0 = Timestamp(0.0)
             self.system_t0 = 0.0
             self.p1_time_label = 'P1 Time (sec)'
@@ -293,8 +289,8 @@ figure.on('plotly_hover', function(data) {
             return
 
         # Setup the figure.
-        time_axis_str = 'Relative Time' if self.time_axis == 'relative' else 'P1/System Time'
-        p1_time_axis_str = 'Relative Time' if self.time_axis == 'relative' else 'P1 Time'
+        time_axis_str = 'Relative Time' if self.time_type == 'relative' else 'P1/System Time'
+        p1_time_axis_str = 'Relative Time' if self.time_type == 'relative' else 'P1 Time'
         figure = make_subplots(rows=2, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=[f'Device Time vs. {time_axis_str}',
                                                f'Pose Message Interval vs. {p1_time_axis_str}'])
@@ -427,7 +423,7 @@ figure.on('plotly_hover', function(data) {
 
         self._add_figure(name="time_scale", figure=figure, title="Time Scale",
                          inject_js=self._TIME_HOVER_JS + self._SYSTEM_TIME_HOVER_JS,
-                         time_axis_type='relative' if self.time_axis == 'relative' else 'p1')
+                         time_axis_type='relative' if self.time_type == 'relative' else 'p1')
 
     def plot_latency(self):
         if self.output_dir is None:
@@ -3333,7 +3329,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         # in case, we'll approximate the GPS time _at_ t0 if needed.
         idx = find_first(~np.isnan(pose_data.gps_time))
         if idx >= 0:
-            first_p1_time = self.t0 if self.time_axis == 'relative' else pose_data.p1_time[0]
+            first_p1_time = self.t0 if self.time_type == 'relative' else pose_data.p1_time[0]
             dt_p1_sec = pose_data.p1_time[idx] - float(first_p1_time)
             t0_gps = Timestamp(pose_data.gps_time[idx]) - dt_p1_sec
             # If the first pose is pretty close to t0, we'll assume the approximation is reasonably accurate and not
@@ -3541,7 +3537,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         system_t0_sec = None if np.isnan(self.system_t0) else float(self.system_t0)
         post_script += f"""\
 var p1_t0_sec = {p1_t0_sec if p1_t0_sec is not None else 'null'};
-var p1_time_axis_rel = {'true' if self.time_axis == 'relative' else 'false'};
+var p1_time_axis_rel = {'true' if self.time_type == 'relative' else 'false'};
 var gps_posix_offset_sec = {gps_posix_offset_sec if gps_posix_offset_sec is not None else 'null'};
 var system_t0_sec = {system_t0_sec if system_t0_sec is not None else 'null'};
 var time_axis_type = '{time_axis_type}';

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -290,7 +290,7 @@ figure.on('plotly_hover', function(data) {
             time, _ = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time, ignore_gps=True)
 
             # Calculate time intervals, rounded to the nearest 0.1 ms.
-            dp1_time = np.diff(time, prepend=np.nan)
+            dp1_time = np.diff(pose_data.p1_time, prepend=np.nan)
             dp1_time = np.round(dp1_time * 1e4) * 1e-4
 
             dgps_time = np.diff(pose_data.gps_time, prepend=np.nan)

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -5,6 +5,7 @@ from typing import Union, List, Any, Optional
 from collections import namedtuple, defaultdict
 import copy
 import inspect
+import json
 import os
 import sys
 import webbrowser
@@ -1593,7 +1594,8 @@ figure.on('plotly_hover', function(data) {
         }]
 
         name = self._gnss_plot_filename('gnss_cn0', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS C/N0 vs Time', inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name=name, figure=figure, title=f'{label} GNSS C/N0 vs Time', custom_hover=True,
+                         inject_js=self._custom_tooltip_js(precision=2))
 
     def plot_gnss_azimuth_elevation(self):
         """!
@@ -3476,7 +3478,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         self.plots[name] = {'title': title, 'path': path}
 
     def _add_figure(self, name, figure=None, title=None, config=None, inject_js: str = None,
-                    time_axis_type: Optional[str] = None):
+                    time_axis_type: Optional[str] = None, custom_hover: bool = False):
         """!
         @brief Generate an HTML file for the specified figure.
 
@@ -3490,6 +3492,9 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         @param time_axis_type The time domain actually plotted on this figure's X axis (`relative`, `p1`, `gps`, or
                `utc`; see @ref BuildTimeHoverText() in `plotly_data_support.js`). Defaults to `self.time_type`; only
                needs to be overridden by plots (e.g., @ref plot_time_scale()) whose X axis does not follow it.
+        @param custom_hover If `True`, set `hoverinfo='none'` on all of this figure's traces so Plotly's native hover
+               label never draws, for use with a custom-tooltip `inject_js` (see @ref _custom_tooltip_js()) instead
+               of per-trace `hoverinfo='none'` at every `go.Scatter()`/`go.Scattergl()` call site.
         """
         if title is None:
             title = name
@@ -3504,6 +3509,8 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
 
         if figure is not None:
             figure.update_traces(hoverlabel_namelength=-1)
+            if custom_hover:
+                figure.update_traces(hoverinfo='none')
 
             path = os.path.join(self.output_dir, self.prefix + name + '.html')
             self.logger.info('Creating %s...' % path)
@@ -3705,6 +3712,57 @@ var time_axis_type = '{time_axis_type}';
             return np.vstack((gps_time,))
         else:
             return np.vstack((p1_time,))
+
+    def _custom_tooltip_js(self, time_source: str = 'p1', precision: Optional[int] = 3,
+                           value_label: Optional[str] = None) -> str:
+        """!
+        @brief Build hover JS that draws its own tooltip instead of relying on Plotly's native hover label (see
+               `ShowCustomTooltip()`/`HideCustomTooltip()` in `plotly_data_support.js`).
+
+        Unlike @ref _TIME_HOVER_JS/@ref _SYSTEM_TIME_HOVER_JS (which mutate `fullData.text` for Plotly's own hover
+        label to pick up on its next render), this draws synchronously inside the `'plotly_hover'` handler itself,
+        avoiding the race that can otherwise leave the native label blank or stale on plots with many traces/points
+        (see @ref plot_gnss_cn0()). Only supports the single-nearest-point case (the default `'closest'` hovermode),
+        not `'x'`/`'x unified'`.
+
+        @param time_source The native time domain of the data being plotted, as in @ref _x_axis_layout(): `p1` (the
+               default -- P1/relative/GPS/UTC, per @c self.time_type; requires the trace's customdata to be set per
+               @ref _time_hover_customdata()) or `system` (device system time; no customdata needed).
+        @param precision Number of digits after the decimal point to show for the Y value (see
+               `BuildAxisValueHoverText()`).
+        @param value_label Override label to show instead of the Y axis title (see `BuildAxisValueHoverText()`).
+
+        @return The JS to pass as `inject_js` to @ref _add_figure().
+        """
+        if time_source == 'p1':
+            build_time_text_js = (
+                '  let time_text = point.data.customdata ? '
+                'BuildTimeHoverText(point.x, GetCustomData(point, 0)) : BuildTimeHoverText(point.x);')
+            tick_reformat_js = self._GPS_TICK_REFORMAT_JS
+        elif time_source == 'system':
+            build_time_text_js = '  let time_text = BuildSystemTimeHoverText(point.x);'
+            tick_reformat_js = ''
+        else:
+            raise ValueError(f"Unsupported time source '{time_source}'.")
+
+        # Room to grow: additional BuildAxisValueHoverText() options can be added here as more callers need them.
+        value_options = {}
+        if precision is not None:
+            value_options['precision'] = precision
+        if value_label is not None:
+            value_options['label'] = value_label
+
+        return ("""\
+figure.on('plotly_hover', function(data) {
+  let point = data.points[0];
+""" + build_time_text_js + """
+  let value_text = BuildAxisValueHoverText(point, """ + json.dumps(value_options) + """);
+  ShowCustomTooltip(point, `<b>${point.data.name}</b><br>${value_text}<br>${time_text}`);
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
+});
+""" + tick_reformat_js)
 
     def _auto_detect_message_type(self, types: List[MessageType]):
         types = [t.MESSAGE_TYPE if inspect.isclass(t) else t for t in types]

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -468,7 +468,7 @@ figure.on('plotly_hover', function(data) {
 
         figure.update_layout(title_text='NOTE: Latency assumes the host system clock is synced to GPS time. '
                                         'Any error will impact the latency computation.')
-        self._add_figure(name="host_latency", figure=figure, title="Host Recieved Latency")
+        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency")
 
     def plot_reset_timing(self):
         if self.output_dir is None:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -710,7 +710,7 @@ setTimeout(_ReformatGpsAxisTicks, 0);
             self.logger.info('No calibration data available. Skipping calibration plot.')
             return
 
-        time, axis_label, axis_layout = self._resolve_x_axis(p1_time=cal_data.p1_time)
+        time, axis_layout = self._resolve_x_axis(p1_time=cal_data.p1_time)
         time_customdata = self._time_hover_customdata(p1_time=cal_data.p1_time)
 
         # Map calibration stage enum values onto a [0, N) range for plotting.
@@ -725,7 +725,7 @@ setTimeout(_ReformatGpsAxisTicks, 0);
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(4):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=axis_label, showticklabels=True, **axis_layout)
+            figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Percent Complete", range=[0, 100])
         figure['layout']['yaxis2'].update(ticktext=['%s' % e.name for e in CalibrationStage],
                                           tickvals=list(range(len(stage_map))))
@@ -3393,40 +3393,54 @@ var time_axis_type = '{time_axis_type}';
         elif time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
             return float(self.system_t0)
 
-    def _resolve_x_axis(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None) -> \
-            Tuple[np.ndarray, str, dict]:
+    def _x_axis_layout(self) -> dict:
         """!
-        @brief Resolve the X axis values, label, and layout to use for a time series, per @c self.time_type.
+        @brief Get the `go.layout.XAxis` kwargs (including `title`) for the current @c self.time_type.
 
-        @param p1_time The P1 time for each point.
-        @param gps_time The GPS time for each point, if already known (e.g., from a @ref PoseMessage). If `None`, it
-               will be computed from `p1_time` via @c self.time_provider when needed.
-
-        @return A tuple `(x, axis_label, axis_layout)`:
-                - `x`: The X axis values to plot.
-                - `axis_label`: The axis title to use.
-                - `axis_layout`: Extra `go.layout.XAxis` kwargs needed to display `x` (e.g., `type='date'`).
+        @return A dict of `go.layout.XAxis` kwargs, e.g. `{'title': ..., 'type': 'date'}`.
         """
-        if self.time_type == 'relative':
-            return p1_time - float(self.t0), self.p1_time_label, {}
-        elif self.time_type == 'p1':
-            return p1_time, self.p1_time_label, {}
-
-        if gps_time is None:
-            gps_time = self.time_provider.p1_to_gps(p1_time)
-
-        if self.time_type == 'gps':
+        if self.time_type in ('relative', 'p1'):
+            return {'title': self.p1_time_label}
+        elif self.time_type == 'gps':
             # GPS seconds are large enough that Plotly may otherwise render ticks in scientific/SI-prefix notation,
             # which _ReformatGpsAxisTicks() (see plotly_data_support.js) can't parse back into week:tow. We let
             # Plotly auto-generate normal (zoom-aware) numeric ticks here, and rewrite the rendered tick text into
             # week:tow client-side, rather than computing fixed tick positions/labels ourselves -- those wouldn't
             # regenerate on zoom/pan and could leave a zoomed-in view with no visible ticks at all.
-            return gps_time, 'GPS Time (week:tow)', {'exponentformat': 'none'}
+            return {'title': 'GPS Time (week:tow)', 'exponentformat': 'none'}
         else:
             # Plotly serializes a datetime64 array as literal date strings, so (unlike plain milliseconds-since-
             # epoch numbers) they display as given, without being reinterpreted in the browser's local timezone.
+            return {'title': 'UTC Time', 'type': 'date'}
+
+    def _resolve_x_axis(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None) -> \
+            Tuple[np.ndarray, dict]:
+        """!
+        @brief Resolve the X axis values and layout to use for a time series, per @c self.time_type.
+
+        @param p1_time The P1 time for each point.
+        @param gps_time The GPS time for each point, if already known (e.g., from a @ref PoseMessage). If `None`, it
+               will be computed from `p1_time` via @c self.time_provider when needed.
+
+        @return A tuple `(x, axis_layout)`:
+                - `x`: The X axis values to plot.
+                - `axis_layout`: `go.layout.XAxis` kwargs needed to display `x` (title, and e.g. `type='date'`).
+        """
+        axis_layout = self._x_axis_layout()
+
+        if self.time_type == 'relative':
+            return p1_time - float(self.t0), axis_layout
+        elif self.time_type == 'p1':
+            return p1_time, axis_layout
+
+        if gps_time is None:
+            gps_time = self.time_provider.p1_to_gps(p1_time)
+
+        if self.time_type == 'gps':
+            return gps_time, axis_layout
+        else:
             utc = self.time_provider.gps_sec_to_datetime64_array(gps_time)
-            return utc, 'UTC Time', {'type': 'date'}
+            return utc, axis_layout
 
     def _time_hover_customdata(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None,
                                x_domain: Optional[str] = None) -> np.ndarray:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -898,7 +898,7 @@ figure.on('plotly_hover', function(data) {
         self._add_figure(name="stationary_status", figure=figure, title="Stationary Status",
                          inject_js=self._TIME_HOVER_JS)
 
-    def _plot_displacement(self, source, time, solution_type, displacement_enu_m, std_enu_m,
+    def _plot_displacement(self, source, p1_time, solution_type, displacement_enu_m, std_enu_m, gps_time=None,
                            title='Displacement'):
         """!
         @brief Generate a topocentric (top-down) plot of position displacement, as well as plot of displacement over
@@ -907,9 +907,21 @@ figure.on('plotly_hover', function(data) {
         if self.output_dir is None:
             return
 
+        # Note: _resolve_x_axis() can do this internally, but we also need it for the topo customdata below.
+        if gps_time is None:
+            gps_time = self.time_provider.p1_to_gps(p1_time)
+
+        time, axis_layout = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+        time_customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
+
+        # The topocentric plot's axes are spatial (East/North), not time, so unlike time_customdata above (which
+        # carries only whichever of P1/GPS time is not already reflected by the X axis), its hover text needs both
+        # times directly -- neither is recoverable from a point's X/Y position.
+        topo_customdata = np.vstack((p1_time, gps_time, displacement_enu_m, std_enu_m))
+        time_customdata = np.vstack((time_customdata, displacement_enu_m, std_enu_m))
+
         # Setup the figure.
-        topo_figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=False,
-                                    subplot_titles=[title])
+        topo_figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=False, subplot_titles=[title])
         topo_figure['layout']['xaxis1'].update(title="East (m)")
         topo_figure['layout']['yaxis1'].update(title="North (m)")
 
@@ -917,14 +929,14 @@ figure.on('plotly_hover', function(data) {
                                     subplot_titles=['3D', 'East', 'North', 'Up'])
         time_figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(4):
-            time_figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True)
+            time_figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         time_figure['layout']['yaxis1'].update(title=f"{title} (m)")
         time_figure['layout']['yaxis2'].update(title=f"{title} (m)")
         time_figure['layout']['yaxis3'].update(title=f"{title} (m)")
         time_figure['layout']['yaxis4'].update(title=f"{title} (m)")
 
         # Remove invalid solutions.
-        valid_idx = np.logical_and(~np.isnan(time), solution_type != SolutionType.Invalid)
+        valid_idx = np.logical_and(~np.isnan(p1_time), solution_type != SolutionType.Invalid)
         if not np.any(valid_idx):
             self.logger.info('No valid position solutions detected. Skipping displacement plots.')
             return
@@ -962,24 +974,22 @@ figure.on('plotly_hover', function(data) {
                 style['marker'].update(marker_style)
 
             if np.any(idx):
-                text = ["Time: %.3f sec (%.3f sec)<br>Delta (ENU): (%.2f, %.2f, %.2f) m" \
-                        "<br>Std (ENU): (%.2f, %.2f, %.2f) m" %
-                        (t, t + float(self.t0), *delta, *std)
-                        for t, delta, std in zip(time[idx], displacement_enu_m[:, idx].T, std_enu_m[:, idx].T)]
+                topo_cd = topo_customdata[:, idx]
+                time_cd = time_customdata[:, idx]
                 topo_figure.add_trace(go.Scattergl(x=displacement_enu_m[0, idx], y=displacement_enu_m[1, idx],
-                                                   name=name, text=text, **style), 1, 1)
+                                                   name=name, customdata=topo_cd, **style), 1, 1)
 
                 displacement_3d_m = np.linalg.norm(displacement_enu_m[:, idx], axis=0)
                 max_3d_diff_m[0] = max(max_3d_diff_m[0], np.nanmax(displacement_3d_m))
                 time_figure.add_trace(go.Scattergl(x=time[idx], y=displacement_3d_m,
-                                                   name=name, text=text, **style), 1, 1)
+                                                   name=name, customdata=time_cd, **style), 1, 1)
                 style['showlegend'] = False
                 time_figure.add_trace(go.Scattergl(x=time[idx], y=displacement_enu_m[0, idx], name=name,
-                                                   text=text, **style), 2, 1)
+                                                   customdata=time_cd, **style), 2, 1)
                 time_figure.add_trace(go.Scattergl(x=time[idx], y=displacement_enu_m[1, idx], name=name,
-                                                   text=text, **style), 3, 1)
+                                                   customdata=time_cd, **style), 3, 1)
                 time_figure.add_trace(go.Scattergl(x=time[idx], y=displacement_enu_m[2, idx], name=name,
-                                                   text=text, **style), 4, 1)
+                                                   customdata=time_cd, **style), 4, 1)
             else:
                 # If there's no data, draw a dummy trace so it shows up in the legend anyway.
                 topo_figure.add_trace(go.Scattergl(x=[np.nan], y=[np.nan], name=name, visible='legendonly', **style),
@@ -997,8 +1007,48 @@ figure.on('plotly_hover', function(data) {
         time_figure['layout']['yaxis1'].update(range=[0, max_y])
 
         name = source.replace(' ', '_').lower()
-        self._add_figure(name=f"{name}_top_down", figure=topo_figure, title=f"{source}: Top-Down (Topocentric)")
-        self._add_figure(name=f"{name}_vs_time", figure=time_figure, title=f"{source}: vs. Time")
+
+        # Topocentric hover: X/Y are spatial (East/North), not time, so both P1 and GPS time must come directly from
+        # customdata (rows 0/1) rather than from the point's axis position -- see BuildTimeHoverTextFromTimes().
+        _DISPLACEMENT_TOPO_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    if (!point.data.customdata) {
+      continue;
+    }
+    let new_text = BuildTimeHoverTextFromTimes(GetCustomData(point, 0), GetCustomData(point, 1));
+    new_text += `<br>Delta (ENU): (${GetCustomData(point, 2).toFixed(2)}, ${GetCustomData(point, 3).toFixed(2)}, ` +
+                `${GetCustomData(point, 4).toFixed(2)}) m`;
+    new_text += `<br>Std (ENU): (${GetCustomData(point, 5).toFixed(2)}, ${GetCustomData(point, 6).toFixed(2)}, ` +
+                `${GetCustomData(point, 7).toFixed(2)}) m`;
+    ChangeHoverText(point, new_text);
+  }
+});
+        """
+
+        # Time-series hover: like _TIME_HOVER_JS, but with extra Delta/Std (ENU) customdata rows appended.
+        _DISPLACEMENT_TIME_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    if (!point.data.customdata) {
+      continue;
+    }
+    let new_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
+    new_text += `<br>Delta (ENU): (${GetCustomData(point, 1).toFixed(2)}, ${GetCustomData(point, 2).toFixed(2)}, ` +
+                `${GetCustomData(point, 3).toFixed(2)}) m`;
+    new_text += `<br>Std (ENU): (${GetCustomData(point, 4).toFixed(2)}, ${GetCustomData(point, 5).toFixed(2)}, ` +
+                `${GetCustomData(point, 6).toFixed(2)}) m`;
+    ChangeHoverText(point, new_text);
+  }
+});
+        """ + self._GPS_TICK_REFORMAT_JS
+
+        self._add_figure(name=f"{name}_top_down", figure=topo_figure, title=f"{source}: Top-Down (Topocentric)",
+                         inject_js=_DISPLACEMENT_TOPO_HOVER_JS)
+        self._add_figure(name=f"{name}_vs_time", figure=time_figure, title=f"{source}: vs. Time",
+                         inject_js=_DISPLACEMENT_TIME_HOVER_JS)
 
     def plot_pose_error(self, reference: ReferenceData):
         """!
@@ -1053,7 +1103,7 @@ figure.on('plotly_hover', function(data) {
             self.logger.info('No valid position solutions detected. Skipping displacement plots.')
             return None
 
-        time = pose_data.p1_time[valid_idx] - float(self.t0)
+        p1_time = pose_data.p1_time[valid_idx]
         gps_time = pose_data.gps_time[valid_idx]
         solution_type = pose_data.solution_type[valid_idx]
         lla_deg = pose_data.lla_deg[:, valid_idx]
@@ -1072,7 +1122,8 @@ figure.on('plotly_hover', function(data) {
                                 f"range. Skipping displacement plots.")
             return None
         elif not np.all(valid_ref_idx):
-            time = time[valid_ref_idx]
+            p1_time = p1_time[valid_ref_idx]
+            gps_time = gps_time[valid_ref_idx]
             solution_type = solution_type[valid_ref_idx]
             lla_deg = lla_deg[:, valid_ref_idx]
             std_enu_m = std_enu_m[:, valid_ref_idx]
@@ -1087,7 +1138,7 @@ figure.on('plotly_hover', function(data) {
         source = f'Position {axis_title} vs. {"Reference" if reference.is_truth else reference.description}'
 
         self._plot_displacement(source=source, title=axis_title,
-                                time=time, solution_type=solution_type,
+                                p1_time=p1_time, gps_time=gps_time, solution_type=solution_type,
                                 displacement_enu_m=displacement_enu_m, std_enu_m=std_enu_m)
 
         return displacement_enu_m
@@ -1115,12 +1166,15 @@ figure.on('plotly_hover', function(data) {
             self.logger.info('No valid position solutions detected. Skipping relative position vs. base station plots.')
             return
 
-        time = relative_position_data.p1_time[valid_idx] - float(self.t0)
+        p1_time = relative_position_data.p1_time[valid_idx]
+        gps_time = relative_position_data.gps_time[valid_idx]
         solution_type = relative_position_data.solution_type[valid_idx]
         displacement_enu_m = relative_position_data.relative_position_enu_m[:, valid_idx]
         std_enu_m = relative_position_data.position_std_enu_m[:, valid_idx]
 
-        self._plot_displacement('Position vs. Base Station', time, solution_type, displacement_enu_m, std_enu_m)
+        self._plot_displacement('Position vs. Base Station', p1_time=p1_time, gps_time=gps_time,
+                                solution_type=solution_type, displacement_enu_m=displacement_enu_m,
+                                std_enu_m=std_enu_m)
 
     def plot_map(self, mapbox_token):
         """!

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2689,7 +2689,7 @@ figure.on('plotly_unhover', function(data) {
             primary_time, _ = self._resolve_x_axis(p1_time=primary_pose_data.p1_time,
                                                     gps_time=primary_pose_data.gps_time)
             primary_customdata = self._time_hover_customdata(p1_time=primary_pose_data.p1_time,
-                                                              gps_time=primary_pose_data.gps_time)
+                                                             gps_time=primary_pose_data.gps_time)
 
         have_raw = len(raw_heading_data.p1_time) > 0
         if have_raw:
@@ -2702,7 +2702,7 @@ figure.on('plotly_unhover', function(data) {
             corrected_gps_time = getattr(heading_data, 'gps_time', None)
             corrected_time, _ = self._resolve_x_axis(p1_time=heading_data.p1_time, gps_time=corrected_gps_time)
             corrected_customdata = self._time_hover_customdata(p1_time=heading_data.p1_time,
-                                                                gps_time=corrected_gps_time)
+                                                               gps_time=corrected_gps_time)
 
         # Setup the figure.
         fig = make_subplots(

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -120,6 +120,8 @@ setTimeout(_ReformatGpsAxisTicks, 0);
     # X axis (see BuildTimeHoverText() in plotly_data_support.js, and _time_hover_customdata() below). Plots needing
     # additional custom hover logic (e.g., decoding a status bitmask) should not use this directly -- build a custom
     # 'plotly_hover' handler instead, but still append _GPS_TICK_REFORMAT_JS to it.
+    #
+    # If customdata is omitted, the hover text will just show the X axis value (absolute or relative time).
     _TIME_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
   for (let i = 0; i < data.points.length; ++i) {
@@ -127,9 +129,25 @@ figure.on('plotly_hover', function(data) {
     if (point.data.customdata) {
       ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
     }
+    else {
+      ChangeHoverText(point, BuildTimeHoverText(point.x));
+    }
   }
 });
 """ + _GPS_TICK_REFORMAT_JS
+
+    # Generic hover JS for traces on a device system-time axis (see BuildSystemTimeHoverText() in
+    # plotly_data_support.js). Unlike _TIME_HOVER_JS, no customdata is needed -- system time has no GPS-like alternate
+    # domain, so the value not shown on the X axis (relative vs. absolute) is always a constant offset (system_t0_sec)
+    # away, not a per-point value.
+    _SYSTEM_TIME_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    ChangeHoverText(point, BuildSystemTimeHoverText(point.x));
+  }
+});
+"""
 
     def __init__(self,
                  file: Union[DataLoader, str], ignore_index: bool = False,
@@ -564,26 +582,25 @@ figure.on('plotly_hover', function(data) {
         figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Elapsed Time (sec)", rangemode="tozero")
 
-        text = ["System Time: %.3f sec" % (t + self.system_t0) for t in time]
-        figure.add_trace(go.Scattergl(x=time, y=dt_reset_to_valid, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=dt_reset_to_valid,
                                       name='Command -> Valid', mode='markers'),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=dt_reset_to_invalid, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=dt_reset_to_invalid,
                                       name='Command -> Invalid', mode='markers'),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=dt_invalid_to_valid, text=text,
+        figure.add_trace(go.Scattergl(x=time, y=dt_invalid_to_valid,
                                       name='Invalid -> Valid', mode='markers'),
                          1, 1)
 
         if len(unstarted_resets) > 0:
             idx = np.array(unstarted_resets)
             time = time[idx]
-            text = ["System Time: %.3f sec" % (t + self.system_t0) for t in time]
-            figure.add_trace(go.Scattergl(x=time, y=np.zeros_like(time), text=text,
+            figure.add_trace(go.Scattergl(x=time, y=np.zeros_like(time),
                                           name='Unstarted Resets', mode='markers'),
                              1, 1)
 
-        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing")
+        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing",
+                         inject_js=self._SYSTEM_TIME_HOVER_JS)
 
     def plot_pose(self):
         """!
@@ -3512,13 +3529,19 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         if post_script is None:
             post_script = ""
 
-        # Create global variables with the log's t0 timestamp, the (leap-second accurate) GPS/POSIX offset, and the
-        # time domain plotted on this figure's X axis (see BuildTimeHoverText()).
+        # Create global variables with the log's t0 timestamp, the (leap-second accurate) GPS/POSIX offset, the
+        # system time t0 (see BuildSystemTimeHoverText()), and the time domain plotted on this figure's X axis (see
+        # BuildTimeHoverText()). Note: self.reader.t0 and self.system_t0 may each independently be unavailable (e.g.
+        # a system-time-only profiling log has no P1 time at all), so both need a 'null' fallback -- plots that
+        # don't use one of these domains at all still go through this same code path whenever inject_js is set.
         gps_posix_offset_sec = self.time_provider.get_gps_posix_offset_sec()
+        p1_t0_sec = None if self.reader.t0 is None else float(self.reader.t0)
+        system_t0_sec = None if np.isnan(self.system_t0) else float(self.system_t0)
         post_script += f"""\
-var p1_t0_sec = {float(self.reader.t0)};
+var p1_t0_sec = {p1_t0_sec if p1_t0_sec is not None else 'null'};
 var p1_time_axis_rel = {'true' if self.time_axis == 'relative' else 'false'};
 var gps_posix_offset_sec = {gps_posix_offset_sec if gps_posix_offset_sec is not None else 'null'};
+var system_t0_sec = {system_t0_sec if system_t0_sec is not None else 'null'};
 var time_axis_type = '{time_axis_type}';
 """
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1877,7 +1877,7 @@ function SetSignalStatusHover(point) {{
 figure.on('plotly_hover', function(data) {{
   for (let i = 0; i < data.points.length; ++i) {{
     let point = data.points[i];
-    if (point.curveNumber > {num_count_traces}) {{
+    if (point.curveNumber >= {num_count_traces}) {{
       SetSignalStatusHover(point);
     }}
     else {{

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -434,15 +434,16 @@ figure.on('plotly_hover', function(data) {
 
         last_gps_time = gps_time[-1]
 
+        time, axis_layout = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+        customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
+
         # Setup the figure.
         figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=[f'Pose Message Latency'])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis1'].update(title=self.p1_time_label, showticklabels=True)
+        figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Latency (sec)")
-
-        time = p1_time - float(self.t0)
 
         # Use the last GPS Time to get the offset between UNIX and GPS time. This includes the epoch difference and the
         # current leap second.
@@ -461,14 +462,14 @@ figure.on('plotly_hover', function(data) {
         # This absolute latency value is only reliable if the host clock was synced to GPS time.
         latency_sec = (host_posix_times - gps_posix_times).astype(float) / 1e9
 
-        text = ['P1: %.3f sec<br>%s' % (p, g) for p, g in zip(p1_time, latency_sec)]
-        figure.add_trace(go.Scattergl(x=time, y=latency_sec, name='Pose Message Latency', text=text,
+        figure.add_trace(go.Scattergl(x=time, y=latency_sec, customdata=customdata, name='Pose Message Latency',
                                       mode='markers', marker={'color': 'blue'}),
                          1, 1)
 
         figure.update_layout(title_text='NOTE: Latency assumes the host system clock is synced to GPS time. '
                                         'Any error will impact the latency computation.')
-        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency")
+        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency",
+                         inject_js=self._TIME_HOVER_JS)
 
     def plot_reset_timing(self):
         if self.output_dir is None:
@@ -2792,29 +2793,30 @@ figure.on('plotly_hover', function(data) {{
             self.logger.info('No system status data available. Skipping plot.')
             return
 
+        time, axis_layout = self._resolve_x_axis(p1_time=data.p1_time)
+        customdata = self._time_hover_customdata(p1_time=data.p1_time)
+
         # Setup the figure.
         figure = make_subplots(rows=2, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=['GNSS Temperature', 'Positioning Engine CPU Temperature'])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(2):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True)
+            figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Temp (deg C)")
 
         # Plot the data.
-        time = data.p1_time - float(self.t0)
-        figure.add_trace(go.Scattergl(x=time, y=data.gnss_temperature_degc, customdata=data.p1_time,
+        figure.add_trace(go.Scattergl(x=time, y=data.gnss_temperature_degc, customdata=customdata,
                                       name='GNSS Temperature',
-                                      hovertemplate='Time: %{x:.3f} sec (%{customdata:.3f} sec)',
                                       mode='markers', line={'color': 'red'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=data.pe_cpu_temperature_degc, customdata=data.p1_time,
+        figure.add_trace(go.Scattergl(x=time, y=data.pe_cpu_temperature_degc, customdata=customdata,
                                       name='PE CPU Temperature',
-                                      hovertemplate='Time: %{x:.3f} sec (%{customdata:.3f} sec)',
                                       mode='markers', line={'color': 'orange'}),
                          2, 1)
 
-        self._add_figure(name="profile_system_status", figure=figure, title="Profiling: System Status")
+        self._add_figure(name="profile_system_status", figure=figure, title="Profiling: System Status",
+                         inject_js=self._TIME_HOVER_JS)
 
     def plot_events(self):
         """!

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -417,19 +417,19 @@ figure.on('plotly_hover', function(data) {
         # P1/GPS time points carry customdata (see BuildTimeHoverText()), system time points don't.
         _TIME_SCALE_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
-  for (let i = 0; i < data.points.length; ++i) {
-    let point = data.points[i];
-    if (point.data.customdata) {
-      ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
-    }
-    else {
-      ChangeHoverText(point, BuildSystemTimeHoverText(point.x));
-    }
-  }
+  let point = data.points[0];
+  let time_text = point.data.customdata ? BuildTimeHoverText(point.x, GetCustomData(point, 0)) :
+                                          BuildSystemTimeHoverText(point.x);
+  let value_text = BuildAxisValueHoverText(point);
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
 });
 """
 
-        self._add_figure(name="time_scale", figure=figure, title="Time Scale", inject_js=_TIME_SCALE_HOVER_JS,
+        self._add_figure(name="time_scale", figure=figure, title="Time Scale", custom_hover=True,
+                         inject_js=_TIME_SCALE_HOVER_JS,
                          time_axis_type='relative' if self.time_type == 'relative' else 'p1')
 
     def plot_latency(self):
@@ -491,8 +491,8 @@ figure.on('plotly_hover', function(data) {
 
         figure.update_layout(title_text='NOTE: Latency assumes the host system clock is synced to GPS time. '
                                         'Any error will impact the latency computation.')
-        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency",
-                         inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency", custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def plot_reset_timing(self):
         if self.output_dir is None:
@@ -604,8 +604,8 @@ figure.on('plotly_hover', function(data) {
                                           name='Unstarted Resets', mode='markers'),
                              1, 1)
 
-        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing",
-                         inject_js=self._SYSTEM_TIME_HOVER_JS)
+        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing", custom_hover=True,
+                         inject_js=self._custom_tooltip_js(time_source='system'))
 
     def plot_pose(self):
         """!
@@ -729,7 +729,8 @@ figure.on('plotly_hover', function(data) {
                                       line={'color': 'blue'}),
                          2, 3)
 
-        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time", inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time", custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def plot_calibration(self):
         """!
@@ -832,7 +833,8 @@ figure.on('plotly_hover', function(data) {
                                       mode='lines', line={'color': 'black', 'dash': 'dash'}),
                          4, 1)
 
-        self._add_figure(name="calibration", figure=figure, title="Calibration Status", inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name="calibration", figure=figure, title="Calibration Status", custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def plot_solution_type(self):
         """!
@@ -883,7 +885,8 @@ figure.on('plotly_hover', function(data) {
                                           mode='markers', marker={'color': 'red', 'symbol': 'diamond-open'}),
                              1, 1)
 
-        self._add_figure(name="solution_type", figure=figure, title="Solution Type", inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name="solution_type", figure=figure, title="Solution Type", custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def plot_stationary_status(self):
         """!
@@ -917,8 +920,8 @@ figure.on('plotly_hover', function(data) {
 
         figure.add_trace(go.Scattergl(x=time, y=stationary_status, customdata=customdata, mode='markers'), 1, 1)
 
-        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status",
-                         inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status", custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def _plot_displacement(self, source, p1_time, solution_type, displacement_enu_m, std_enu_m, gps_time=None,
                            title='Displacement'):
@@ -1034,43 +1037,45 @@ figure.on('plotly_hover', function(data) {
         # customdata (rows 0/1) rather than from the point's axis position -- see BuildTimeHoverTextFromTimes().
         _DISPLACEMENT_TOPO_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
-  for (let i = 0; i < data.points.length; ++i) {
-    let point = data.points[i];
-    if (!point.data.customdata) {
-      continue;
-    }
-    let new_text = BuildTimeHoverTextFromTimes(GetCustomData(point, 0), GetCustomData(point, 1));
-    new_text += `<br>Delta (ENU): (${GetCustomData(point, 2).toFixed(2)}, ${GetCustomData(point, 3).toFixed(2)}, ` +
-                `${GetCustomData(point, 4).toFixed(2)}) m`;
-    new_text += `<br>Std (ENU): (${GetCustomData(point, 5).toFixed(2)}, ${GetCustomData(point, 6).toFixed(2)}, ` +
-                `${GetCustomData(point, 7).toFixed(2)}) m`;
-    ChangeHoverText(point, new_text);
+  let point = data.points[0];
+  if (!point.data.customdata) {
+    return;
   }
+  let new_text = BuildTimeHoverTextFromTimes(GetCustomData(point, 0), GetCustomData(point, 1));
+  new_text += `<br>Delta (ENU): (${GetCustomData(point, 2).toFixed(2)}, ${GetCustomData(point, 3).toFixed(2)}, ` +
+              `${GetCustomData(point, 4).toFixed(2)}) m`;
+  new_text += `<br>Std (ENU): (${GetCustomData(point, 5).toFixed(2)}, ${GetCustomData(point, 6).toFixed(2)}, ` +
+              `${GetCustomData(point, 7).toFixed(2)}) m`;
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, undefined, new_text));
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
 });
         """
 
-        # Time-series hover: like _TIME_HOVER_JS, but with extra Delta/Std (ENU) customdata rows appended.
+        # Time-series hover: like _custom_tooltip_js(), but with extra Delta/Std (ENU) customdata rows appended.
         _DISPLACEMENT_TIME_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
-  for (let i = 0; i < data.points.length; ++i) {
-    let point = data.points[i];
-    if (!point.data.customdata) {
-      continue;
-    }
-    let new_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
-    new_text += `<br>Delta (ENU): (${GetCustomData(point, 1).toFixed(2)}, ${GetCustomData(point, 2).toFixed(2)}, ` +
-                `${GetCustomData(point, 3).toFixed(2)}) m`;
-    new_text += `<br>Std (ENU): (${GetCustomData(point, 4).toFixed(2)}, ${GetCustomData(point, 5).toFixed(2)}, ` +
-                `${GetCustomData(point, 6).toFixed(2)}) m`;
-    ChangeHoverText(point, new_text);
+  let point = data.points[0];
+  if (!point.data.customdata) {
+    return;
   }
+  let new_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
+  new_text += `<br>Delta (ENU): (${GetCustomData(point, 1).toFixed(2)}, ${GetCustomData(point, 2).toFixed(2)}, ` +
+              `${GetCustomData(point, 3).toFixed(2)}) m`;
+  new_text += `<br>Std (ENU): (${GetCustomData(point, 4).toFixed(2)}, ${GetCustomData(point, 5).toFixed(2)}, ` +
+              `${GetCustomData(point, 6).toFixed(2)}) m`;
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, undefined, new_text));
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
 });
         """ + self._GPS_TICK_REFORMAT_JS
 
         self._add_figure(name=f"{name}_top_down", figure=topo_figure, title=f"{source}: Top-Down (Topocentric)",
-                         inject_js=_DISPLACEMENT_TOPO_HOVER_JS)
+                         custom_hover=True, inject_js=_DISPLACEMENT_TOPO_HOVER_JS)
         self._add_figure(name=f"{name}_vs_time", figure=time_figure, title=f"{source}: vs. Time",
-                         inject_js=_DISPLACEMENT_TIME_HOVER_JS)
+                         custom_hover=True, inject_js=_DISPLACEMENT_TIME_HOVER_JS)
 
     def plot_pose_error(self, reference: ReferenceData):
         """!
@@ -1690,7 +1695,7 @@ figure.on('plotly_hover', function(data) {
 
         name = self._gnss_plot_filename('gnss_azimuth_elevation', source_id)
         self._add_figure(name=name, figure=figure, title=f'{label} GNSS Azimuth & Elevation vs Time',
-                         inject_js=self._TIME_HOVER_JS)
+                         custom_hover=True, inject_js=self._custom_tooltip_js())
 
     def plot_gnss_signal_status(self):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -2000,23 +2005,26 @@ function SetSignalStatusHover(point) {{
   new_text += "<br>Available: " + tracking.join(", ");
   new_text += "<br>Used: " + used.join(", ");
   new_text += "<br>Features: " + features.join(", ");
-  ChangeHoverText(point, new_text);
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, undefined, new_text));
 }}
 
 figure.on('plotly_hover', function(data) {{
-  for (let i = 0; i < data.points.length; ++i) {{
-    let point = data.points[i];
-    if (point.curveNumber >= {num_count_traces}) {{
-      SetSignalStatusHover(point);
-    }}
-    else {{
-      ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
-    }}
+  let point = data.points[0];
+  if (point.curveNumber >= {num_count_traces}) {{
+    SetSignalStatusHover(point);
   }}
+  else {{
+    let time_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
+    let value_text = BuildAxisValueHoverText(point);
+    ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
+  }}
+}});
+figure.on('plotly_unhover', function(data) {{
+  HideCustomTooltip();
 }});
 """ + self._GPS_TICK_REFORMAT_JS
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=hover_js)
+        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True, inject_js=hover_js)
 
     def _get_pose_source_ids(self) -> List[int]:
         """!
@@ -2163,7 +2171,7 @@ figure.on('plotly_hover', function(data) {{
                              1, 1)
 
         self._add_figure(name='gnss_dop', figure=figure, title='GNSS Dilution of Precision (DOP) vs. Time',
-                         inject_js=self._TIME_HOVER_JS)
+                         custom_hover=True, inject_js=self._custom_tooltip_js(value_label='DOP'))
 
     def plot_gnss_corrections_status(self):
         """!
@@ -2221,7 +2229,7 @@ figure.on('plotly_hover', function(data) {{
                              4, 1)
 
         self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS Corrections Status",
-                         inject_js=self._TIME_HOVER_JS)
+                         custom_hover=True, inject_js=self._custom_tooltip_js())
 
     def plot_wheel_data(self):
         """!
@@ -2603,7 +2611,30 @@ figure.on('plotly_hover', function(data) {{
         _plot_func(data, corrected_time_source, is_raw=False, show_gear=True)
         _plot_func(raw_data, raw_time_source, is_raw=True, show_gear=False)
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=self._TIME_HOVER_JS)
+        # Custom hover: like _custom_tooltip_js(), but some points carry a precomputed `text` string (see
+        # _get_time_and_hover_data() above) instead of customdata, for measurements not in P1 time (no P1/GPS
+        # correspondence to build a full BuildTimeHoverText() from) -- use that verbatim instead when present.
+        _WHEEL_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  let point = data.points[0];
+  let time_text;
+  if (point.data.customdata) {
+    time_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
+  } else if (point.text) {
+    time_text = point.text;
+  } else {
+    time_text = BuildTimeHoverText(point.x);
+  }
+  let value_text = BuildAxisValueHoverText(point);
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
+});
+""" + self._GPS_TICK_REFORMAT_JS
+
+        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True,
+                         inject_js=_WHEEL_HOVER_JS)
 
     def plot_imu(self):
         """!
@@ -2686,7 +2717,8 @@ figure.on('plotly_hover', function(data) {{
                                       name='Interval', mode='markers', marker={'color': 'red'}),
                          3, 1)
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=self._TIME_HOVER_JS)
+        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True,
+                         inject_js=self._custom_tooltip_js())
 
     def plot_gnss_attitude_measurements(self):
         """!
@@ -2916,29 +2948,31 @@ figure.on('plotly_hover', function(data) {{
         # see the Plotly NaN customdata bug noted above).
         _ATTITUDE_HOVER_JS = """\
 figure.on('plotly_hover', function(data) {
-  for (let i = 0; i < data.points.length; ++i) {
-    let point = data.points[i];
-    if (!point.data.customdata) {
-      continue;
-    }
-    let new_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
-    let customdata = point.data.customdata.hasOwnProperty("_inputArray") ?
-                     point.data.customdata._inputArray : point.data.customdata;
-    if (customdata.length > 1) {
-      let std = GetCustomData(point, 1);
-      if (std >= 0) {
-        let units = point.data.name.startsWith('Heading') ? 'deg' : 'm';
-        new_text += `<br>Std: ${std.toFixed(2)} ${units}`;
-      }
-    }
-    ChangeHoverText(point, new_text);
+  let point = data.points[0];
+  if (!point.data.customdata) {
+    return;
   }
+  let new_text = BuildAxisValueHoverText(point) + '<br>' +
+                 BuildTimeHoverText(point.x, GetCustomData(point, 0));
+  let customdata = point.data.customdata.hasOwnProperty("_inputArray") ?
+                   point.data.customdata._inputArray : point.data.customdata;
+  if (customdata.length > 1) {
+    let std = GetCustomData(point, 1);
+    if (std >= 0) {
+      let units = point.data.name.startsWith('Heading') ? 'deg' : 'm';
+      new_text += `<br>Std: ${std.toFixed(2)} ${units}`;
+    }
+  }
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, undefined, new_text));
+});
+figure.on('plotly_unhover', function(data) {
+  HideCustomTooltip();
 });
         """ + self._GPS_TICK_REFORMAT_JS
 
         self._add_figure(name='gnss_attitude_measurement', figure=fig,
                          title='Measurements: GNSS Attitude (Multi-Antenna Heading Sensor)',
-                         inject_js=_ATTITUDE_HOVER_JS)
+                         custom_hover=True, inject_js=_ATTITUDE_HOVER_JS)
 
     def plot_system_status_profiling(self):
         """!
@@ -2978,7 +3012,7 @@ figure.on('plotly_hover', function(data) {
                          2, 1)
 
         self._add_figure(name="profile_system_status", figure=figure, title="Profiling: System Status",
-                         inject_js=self._TIME_HOVER_JS)
+                         custom_hover=True, inject_js=self._custom_tooltip_js())
 
     def plot_events(self):
         """!
@@ -3757,7 +3791,7 @@ figure.on('plotly_hover', function(data) {
   let point = data.points[0];
 """ + build_time_text_js + """
   let value_text = BuildAxisValueHoverText(point, """ + json.dumps(value_options) + """);
-  ShowCustomTooltip(point, `<b>${point.data.name}</b><br>${value_text}<br>${time_text}`);
+  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
 });
 figure.on('plotly_unhover', function(data) {
   HideCustomTooltip();

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1395,7 +1395,7 @@ figure.on('plotly_unhover', function(data) {
 
         # Setup the figure.
         figure = go.Figure()
-        figure['layout'].update(title=f'{label} GNSS Sky Plot')
+        figure['layout'].update(title=f'{label} Antenna Sky Plot')
         figure['layout']['polar']['radialaxis'].update(range=[90, 0])
         figure['layout']['polar']['angularaxis'].update(visible=False)
 
@@ -1520,7 +1520,7 @@ figure.on('plotly_unhover', function(data) {
         figure['layout']['updatemenus'] = updatemenus
 
         name = self._gnss_plot_filename('gnss_skyplot', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS Sky Plot')
+        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): Sky Plot')
 
     def plot_gnss_cn0(self):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -1537,7 +1537,7 @@ figure.on('plotly_unhover', function(data) {
         have_gnss_signals_message = not data.using_legacy_satellite_message
 
         # Setup the figure.
-        title = 'C/N0'
+        title = f'{label} Antenna C/N0'
         if not have_gnss_signals_message:
             title += ' (L1 Only)'
         figure = make_subplots(
@@ -1592,7 +1592,7 @@ figure.on('plotly_unhover', function(data) {
         }]
 
         name = self._gnss_plot_filename('gnss_cn0', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS C/N0 vs Time', custom_hover=True,
+        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): C/N0 vs Time', custom_hover=True,
                          inject_js=self._custom_tooltip_js(precision=2))
 
     def plot_gnss_azimuth_elevation(self):
@@ -1615,8 +1615,8 @@ figure.on('plotly_unhover', function(data) {
         # Set up the figure.
         figure = make_subplots(
             rows=2, cols=1,  print_grid=False, shared_xaxes=True,
-            subplot_titles=["Azimuth Angle",
-                            "Elevation Angle"])
+            subplot_titles=[f"{label} Antenna Azimuth Angle",
+                            f"{label} Antenna Elevation Angle"])
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         axis_layout = self._x_axis_layout()
         figure['layout']['xaxis1'].update(showticklabels=True, **axis_layout)
@@ -1687,7 +1687,7 @@ figure.on('plotly_unhover', function(data) {
         }]
 
         name = self._gnss_plot_filename('gnss_azimuth_elevation', source_id)
-        self._add_figure(name=name, figure=figure, title=f'{label} GNSS Azimuth & Elevation vs Time',
+        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): Azimuth & Elevation vs Time',
                          custom_hover=True, inject_js=self._custom_tooltip_js())
 
     def plot_gnss_signal_status(self):
@@ -1697,7 +1697,7 @@ figure.on('plotly_unhover', function(data) {
     def _plot_gnss_signal_status_for_source(self, source_id: int):
         label = self._gnss_antenna_label(source_id)
         filename = self._gnss_plot_filename('gnss_signal_status', source_id)
-        figure_title = f'{label} GNSS Signal Status'
+        figure_title = f'GNSS ({label}): Signal Status'
 
         # Read the GNSS signal data.
         data = self._get_gnss_signals_data(source_id)
@@ -1746,8 +1746,8 @@ figure.on('plotly_unhover', function(data) {
                   'float': 'green', 'fixed': 'orange'}
 
         if have_gnss_signals_message:
-            title = '''\
-Signal Status<br>
+            title = f'''\
+{label} Antenna Signal Status<br>
 Black=Unused, Red=Pseudorange, Light Blue=Differential Pseudorange<br>
 Green=Float, Orange=Integer (Fixed)'''
         else:
@@ -2163,7 +2163,7 @@ figure.on('plotly_unhover', function(data) {{
                                           mode='markers', marker={'color': color_by_dop[name]}),
                              1, 1)
 
-        self._add_figure(name='gnss_dop', figure=figure, title='GNSS Dilution of Precision (DOP) vs. Time',
+        self._add_figure(name='gnss_dop', figure=figure, title='GNSS: Dilution of Precision (DOP) vs. Time',
                          custom_hover=True, inject_js=self._custom_tooltip_js(value_label='DOP'))
 
     def plot_gnss_corrections_status(self):
@@ -2221,7 +2221,7 @@ figure.on('plotly_unhover', function(data) {{
                                           mode='markers', marker={'color': color}),
                              4, 1)
 
-        self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS Corrections Status",
+        self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS: Corrections Status",
                          custom_hover=True, inject_js=self._custom_tooltip_js())
 
     def plot_wheel_data(self):

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -371,12 +371,15 @@ figure.on('plotly_hover', function(data) {
                 p1_time = pose_data.p1_time
                 gps_time = pose_data.gps_time
 
-            text = ['P1: %.3f sec<br>%s' % (p, self._gps_sec_to_string(g)) for p, g in zip(p1_time, gps_time)]
-            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 1), name='P1/GPS Time', text=text,
+            # This plot's X axis is always P1 time (relative or absolute), regardless of self.time_type, since its
+            # purpose is comparing P1/GPS/System clocks against a common elapsed timeline. So customdata only needs
+            # GPS time -- BuildTimeHoverText() (see plotly_data_support.js) recovers P1 time from the X value itself.
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time, x_domain='p1')
+            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 1), name='P1/GPS Time', customdata=customdata,
                                           mode='markers', marker={'color': 'blue'}),
                              1, 1)
 
-            figure.add_trace(go.Scattergl(x=time, y=dp1_time, name='P1 Time Interval', text=text,
+            figure.add_trace(go.Scattergl(x=time, y=dp1_time, name='P1 Time Interval', customdata=customdata,
                                           mode='markers', marker={'color': 'red'}),
                              2, 1)
             if dp1_stats is not None:
@@ -387,7 +390,7 @@ figure.on('plotly_hover', function(data) {
                                               mode='markers', marker={'symbol': 'triangle-down-open'}),
                                  2, 1)
 
-            figure.add_trace(go.Scattergl(x=time, y=dgps_time, name='GPS Time Interval', text=text,
+            figure.add_trace(go.Scattergl(x=time, y=dgps_time, name='GPS Time Interval', customdata=customdata,
                                           mode='markers', marker={'color': 'green'}),
                              2, 1)
             if dgps_stats is not None:
@@ -398,7 +401,7 @@ figure.on('plotly_hover', function(data) {
                                               mode='markers', marker={'symbol': 'triangle-down-open'}),
                                  2, 1)
 
-        # Read system timestamps from event notifications, if present.
+        # Read system timestamps from event notifications and profiling data, if present.
         result = self.reader.read(message_types=[EventNotificationMessage], **self.params)
         event_data = result[EventNotificationMessage.MESSAGE_TYPE]
         system_time_sec = None
@@ -407,7 +410,7 @@ figure.on('plotly_hover', function(data) {
 
         # Plot the result.
         if system_time_sec is not None:
-            time = system_time_sec - self.system_t0
+            time, _ = self._resolve_x_axis(system_time=system_time_sec, time_source='system')
 
             # plotly starts to struggle with > 2 hours of data and won't display mouseover text, so decimate if
             # necessary.
@@ -416,16 +419,15 @@ figure.on('plotly_hover', function(data) {
                 step = math.ceil(dt_sec / 7200.0)
                 idx = np.full_like(time, False, dtype=bool)
                 idx[0::step] = True
-
                 time = time[idx]
-                system_time_sec = system_time_sec[idx]
 
-            text = ['System: %.3f sec' % t for t in system_time_sec]
-            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 2), name='System Time', text=text,
+            figure.add_trace(go.Scattergl(x=time, y=np.full_like(time, 2), name='System Time',
                                           mode='markers', marker={'color': 'purple'}),
                              1, 1)
 
-        self._add_figure(name="time_scale", figure=figure, title="Time Scale")
+        self._add_figure(name="time_scale", figure=figure, title="Time Scale",
+                         inject_js=self._TIME_HOVER_JS + self._SYSTEM_TIME_HOVER_JS,
+                         time_axis_type='relative' if self.time_axis == 'relative' else 'p1')
 
     def plot_latency(self):
         if self.output_dir is None:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -287,7 +287,7 @@ figure.on('plotly_hover', function(data) {
         pose_data = result[PoseMessage.MESSAGE_TYPE]
 
         if len(pose_data.p1_time) > 0:
-            time, _ = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time, ignore_gps=True)
+            time, _ = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time)
 
             # Calculate time intervals, rounded to the nearest 0.1 ms.
             dp1_time = np.diff(pose_data.p1_time, prepend=np.nan)
@@ -299,7 +299,7 @@ figure.on('plotly_hover', function(data) {
             # plotly starts to struggle with > 3 hours of data and won't display mouseover text, so decimate if
             # necessary.
             decimation_limit_sec = 3 * 3600.0
-            dt_sec = time[-1] - time[0]
+            dt_sec = pose_data.p1_time[-1] - pose_data.p1_time[0]
             dp1_stats = None
             dgps_stats = None
             if dt_sec >= decimation_limit_sec:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -3841,17 +3841,14 @@ Load and display information stored in a FusionEngine binary file.
         '-m', '--measurements', action=ExtendedBooleanAction,
         help="Plot incoming measurement data (slow). Ignored if --plot is specified.")
     plot_group.add_argument(
-        '--time-type', choices=('utc', 'gps', 'p1', 'relative'), default='utc',
+        '--time-type', '--time-axis', choices=('utc', 'gps', 'p1', 'relative', 'rel', 'absolute', 'abs'),
+        default='utc',
         help="Specify the way in which time will be plotted:"
-             "\n- utc - UTC date/time, if available (falls back to P1 time otherwise)"
+             "\n- absolute, abs - Alias for 'utc'"
              "\n- gps - GPS time (week and time of week), if available (falls back to P1 time otherwise)"
              "\n- p1 - Absolute P1 (or system) time"
-             "\n- relative - Elapsed time since the start of the log")
-    plot_group.add_argument(
-        '--time-axis', choices=('absolute', 'abs', 'relative', 'rel'), default=None,
-        help="Deprecated. Use --time-type instead. If specified, overrides --time-type:"
-             "\n- absolute, abs - Equivalent to --time-type=utc"
-             "\n- relative, rel - Equivalent to --time-type=relative")
+             "\n- relative, rel - Elapsed time since the start of the log"
+             "\n- utc - UTC date/time, if available (falls back to P1 time otherwise)")
     plot_group.add_argument(
         '--truncate', '--trunc', action=ExtendedBooleanAction, default=True,
         help="When processing a very long log (>%.1f hours), reduce or skip some plots that may be very slow to "
@@ -3942,6 +3939,12 @@ Load and display information stored in a FusionEngine binary file.
 
     HighlightFormatter.install(color=True, standoff_level=logging.WARNING)
 
+    # Convenience short-hands.
+    if options.time_type in ('abs', 'absolute'):
+        options.time_type = 'utc'
+    elif options.time_type == 'rel':
+        options.time_type = 'relative'
+
     # Parse the time range.
     if options.time is not None:
         time_range = TimeRange.parse(options.time, absolute=options.absolute_time)
@@ -3974,18 +3977,10 @@ Load and display information stored in a FusionEngine binary file.
             _logger.error('Source identifiers must be integers. Exiting.')
             sys.exit(1)
 
-    # --time-axis is deprecated in favor of --time-type, but still accepted for backwards compatibility.
-    time_type = options.time_type
-    if options.time_axis is not None:
-        if options.time_axis in ('relative', 'rel'):
-            time_type = 'relative'
-        elif options.time_axis in ('absolute', 'abs'):
-            time_type = 'utc'
-
     # Read pose data from the file.
     analyzer = Analyzer(file=input_path, output_dir=output_dir, ignore_index=options.ignore_index,
                         prefix=options.prefix + '.' if options.prefix is not None else '',
-                        time_range=time_range, time_type=time_type,
+                        time_range=time_range, time_type=options.time_type,
                         truncate_long_logs=options.truncate and options.plot is None, source_id=source_id)
 
     # Resolve reference data, if specified. This must happen after the analyzer (and its DataLoader) for the primary

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -283,16 +283,18 @@ figure.on('plotly_hover', function(data) {
         if self.output_dir is None:
             return
 
-        # Setup the figure.
+        # Setup the figure. This plot's X axis is always P1 time (relative or absolute), regardless of
+        # self.time_type -- see _resolve_x_axis(..., ignore_gps=True) below.
+        axis_layout = self._x_axis_layout(ignore_gps=True)
         time_axis_str = 'Relative Time' if self.time_type == 'relative' else 'P1/System Time'
-        p1_time_axis_str = 'Relative Time' if self.time_type == 'relative' else 'P1 Time'
+        p1_time_axis_str = axis_layout['title'].replace(' (sec)', '')
         figure = make_subplots(rows=2, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=[f'Device Time vs. {time_axis_str}',
                                                f'Pose Message Interval vs. {p1_time_axis_str}'])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         figure['layout']['xaxis1'].update(title=f"{time_axis_str} (sec)", showticklabels=True)
-        figure['layout']['xaxis2'].update(title=f"{p1_time_axis_str} (sec)", showticklabels=True)
+        figure['layout']['xaxis2'].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Absolute Time",
                                           ticktext=['P1/GPS Time', 'System Time'],
                                           tickvals=[1, 2])
@@ -303,7 +305,7 @@ figure.on('plotly_hover', function(data) {
         pose_data = result[PoseMessage.MESSAGE_TYPE]
 
         if len(pose_data.p1_time) > 0:
-            time = pose_data.p1_time - float(self.t0)
+            time, _ = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time, ignore_gps=True)
 
             # Calculate time intervals, rounded to the nearest 0.1 ms.
             dp1_time = np.diff(time, prepend=np.nan)
@@ -416,8 +418,22 @@ figure.on('plotly_hover', function(data) {
                                           mode='markers', marker={'color': 'purple'}),
                              1, 1)
 
-        self._add_figure(name="time_scale", figure=figure, title="Time Scale",
-                         inject_js=self._TIME_HOVER_JS + self._SYSTEM_TIME_HOVER_JS,
+        # P1/GPS time points carry customdata (see BuildTimeHoverText()), system time points don't.
+        _TIME_SCALE_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    if (point.data.customdata) {
+      ChangeHoverText(point, BuildTimeHoverText(point.x, GetCustomData(point, 0)));
+    }
+    else {
+      ChangeHoverText(point, BuildSystemTimeHoverText(point.x));
+    }
+  }
+});
+"""
+
+        self._add_figure(name="time_scale", figure=figure, title="Time Scale", inject_js=_TIME_SCALE_HOVER_JS,
                          time_axis_type='relative' if self.time_type == 'relative' else 'p1')
 
     def plot_latency(self):

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2447,8 +2447,8 @@ figure.on('plotly_hover', function(data) {{
                     nav_time, _ = self._resolve_x_axis(p1_time=nav_engine_p1_time)
                     nav_kwargs = {'customdata': self._time_hover_customdata(p1_time=nav_engine_p1_time)}
                 else:
-                    nav_time = nav_engine_p1_time - float(self.t0)
-                    nav_kwargs = {'text': ["P1: %.3f sec" % t for t in nav_engine_p1_time]}
+                    nav_time, _ = self._resolve_x_axis(p1_time=nav_engine_p1_time, ignore_gps=True)
+                    nav_kwargs = {}
                 figure.add_trace(go.Scattergl(x=nav_time, y=nav_engine_speed_mps, name=nav_engine_speed_name,
                                               mode='lines', line={'color': 'black', 'dash': 'dash'}, **nav_kwargs),
                                  1, 1)
@@ -3584,7 +3584,7 @@ var time_axis_type = '{time_axis_type}';
         elif time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
             return float(self.system_t0)
 
-    def _x_axis_layout(self, time_source: str = 'p1') -> dict:
+    def _x_axis_layout(self, time_source: str = 'p1', ignore_gps: bool = False) -> dict:
         """!
         @brief Get the `go.layout.XAxis` kwargs (including `title`) for the current @c self.time_type.
 
@@ -3592,6 +3592,8 @@ var time_axis_type = '{time_axis_type}';
                UTC, per @c self.time_type) or `system` (device system time). There is no system-time-to-P1/GPS
                mapping yet, so `system` always resolves to plain absolute/relative system time regardless of
                @c self.time_type; once such a mapping exists, it can resolve to p1/gps/utc too, like `p1` below.
+        @param ignore_gps If `True`, return relative or absolute P1 time. Do not return GPS or UTC time, regardless of
+               @ref self.time_type.
 
         @return A dict of `go.layout.XAxis` kwargs, e.g. `{'title': ..., 'type': 'date'}`.
         """
@@ -3603,7 +3605,7 @@ var time_axis_type = '{time_axis_type}';
 
         if self.time_type == 'relative':
             return {'title': 'Relative Time (sec)'}
-        elif self.time_type == 'p1':
+        elif self.time_type == 'p1' or ignore_gps:
             return {'title': 'P1 Time (sec)'}
         elif self.time_type == 'gps':
             # GPS seconds are large enough that Plotly may otherwise render ticks in scientific/SI-prefix notation,
@@ -3618,7 +3620,8 @@ var time_axis_type = '{time_axis_type}';
             return {'title': 'UTC Time', 'type': 'date'}
 
     def _resolve_x_axis(self, p1_time: Optional[np.ndarray] = None, gps_time: Optional[np.ndarray] = None,
-                        system_time: Optional[np.ndarray] = None, time_source: str = 'p1') -> \
+                        system_time: Optional[np.ndarray] = None, time_source: str = 'p1',
+                        ignore_gps: bool = False) -> \
             Tuple[np.ndarray, dict]:
         """!
         @brief Resolve the X axis values and layout to use for a time series, per @c self.time_type.
@@ -3631,12 +3634,14 @@ var time_axis_type = '{time_axis_type}';
                `system`.
         @param time_source The native time domain of `p1_time`/`system_time`: `p1` (the default) or `system` (see
                @ref _x_axis_layout()).
+        @param ignore_gps If `True`, return relative or absolute P1 time. Do not return GPS or UTC time, regardless of
+               @ref self.time_type.
 
         @return A tuple `(x, axis_layout)`:
                 - `x`: The X axis values to plot.
                 - `axis_layout`: `go.layout.XAxis` kwargs needed to display `x` (title, and e.g. `type='date'`).
         """
-        axis_layout = self._x_axis_layout(time_source=time_source)
+        axis_layout = self._x_axis_layout(time_source=time_source, ignore_gps=ignore_gps)
 
         if time_source == 'system':
             # self.system_t0 is set to 0 when self.time_type == 'absolute', so this works for both absolute and relative
@@ -3645,7 +3650,7 @@ var time_axis_type = '{time_axis_type}';
 
         if self.time_type == 'relative':
             return p1_time - float(self.t0), axis_layout
-        elif self.time_type == 'p1':
+        elif self.time_type == 'p1' or ignore_gps:
             return p1_time, axis_layout
 
         if gps_time is None:

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -24,6 +24,7 @@ if __name__ == "__main__" and (__package__ is None or __package__ == ''):
     __package__ = "fusion_engine_client.analysis"
 
 from ..messages import *
+from ..messages.timestamp import SECONDS_PER_WEEK
 from .attitude import get_enu_rotation_matrix
 from .data_loader import DataLoader, MessageData, TimeRange
 from .reference import ReferenceData, _OWN_LOG_STATISTICS
@@ -3476,9 +3477,8 @@ var time_axis_type = '{time_axis_type}';
         if gps_time_sec is None or np.isnan(gps_time_sec):
             return "GPS: N/A<br>UTC: N/A"
         else:
-            SECS_PER_WEEK = 7 * 24 * 3600.0
-            week = int(gps_time_sec / SECS_PER_WEEK)
-            tow_sec = gps_time_sec - week * SECS_PER_WEEK
+            week = int(gps_time_sec / SECONDS_PER_WEEK)
+            tow_sec = gps_time_sec - week * SECONDS_PER_WEEK
             utc_time = gpstime.fromgps(gps_time_sec)
             approx_str = ' (approximated)' if is_approx else ''
             return "GPS: %d:%.3f (%.3f sec)%s<br>UTC: %s%s" %\

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -383,11 +383,11 @@ figure.on('plotly_hover', function(data) {
         # Read system timestamps from event notifications, if present.
         result = self.reader.read(message_types=[EventNotificationMessage], **self.params)
         event_data = result[EventNotificationMessage.MESSAGE_TYPE]
-
         system_time_sec = None
-        if len(event_data.messages) > 0:
-            system_time_sec = np.array([(m.system_time_ns * 1e-9) for m in event_data.messages])
+        if len(event_data.system_time) > 0:
+            system_time_sec = event_data.system_time
 
+        # Plot the result.
         if system_time_sec is not None:
             time = system_time_sec - self.system_t0
 

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Union, List, Any, Optional
+from typing import Union, List, Any, Optional, Tuple
 
 from collections import namedtuple, defaultdict
 import copy

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -370,8 +370,7 @@ figure.on('plotly_hover', function(data) {
                                               mode='markers', marker={'symbol': 'triangle-down-open'}),
                                  1, 1)
 
-        self._add_figure(name="time_scale", figure=figure, title="Time Scale", custom_hover=True,
-                         inject_js=self._custom_tooltip_js())
+        self._add_figure(name="time_scale", figure=figure, title="Time Scale", inject_js=self._custom_tooltip_js())
 
     def plot_latency(self):
         if self.output_dir is None:
@@ -432,7 +431,7 @@ figure.on('plotly_hover', function(data) {
 
         figure.update_layout(title_text='NOTE: Latency assumes the host system clock is synced to GPS time. '
                                         'Any error will impact the latency computation.')
-        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency", custom_hover=True,
+        self._add_figure(name="host_latency", figure=figure, title="Host Received Latency",
                          inject_js=self._custom_tooltip_js())
 
     def plot_reset_timing(self):
@@ -545,7 +544,7 @@ figure.on('plotly_hover', function(data) {
                                           name='Unstarted Resets', mode='markers'),
                              1, 1)
 
-        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing", custom_hover=True,
+        self._add_figure(name="reset_timing", figure=figure, title="Reset Recovery Timing",
                          inject_js=self._custom_tooltip_js(time_source='system'))
 
     def plot_pose(self):
@@ -670,7 +669,7 @@ figure.on('plotly_hover', function(data) {
                                       line={'color': 'blue'}),
                          2, 3)
 
-        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time", custom_hover=True,
+        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time",
                          inject_js=self._custom_tooltip_js())
 
     def plot_calibration(self):
@@ -774,7 +773,7 @@ figure.on('plotly_hover', function(data) {
                                       mode='lines', line={'color': 'black', 'dash': 'dash'}),
                          4, 1)
 
-        self._add_figure(name="calibration", figure=figure, title="Calibration Status", custom_hover=True,
+        self._add_figure(name="calibration", figure=figure, title="Calibration Status",
                          inject_js=self._custom_tooltip_js())
 
     def plot_solution_type(self):
@@ -826,7 +825,7 @@ figure.on('plotly_hover', function(data) {
                                           mode='markers', marker={'color': 'red', 'symbol': 'diamond-open'}),
                              1, 1)
 
-        self._add_figure(name="solution_type", figure=figure, title="Solution Type", custom_hover=True,
+        self._add_figure(name="solution_type", figure=figure, title="Solution Type",
                          inject_js=self._custom_tooltip_js())
 
     def plot_stationary_status(self):
@@ -861,7 +860,7 @@ figure.on('plotly_hover', function(data) {
 
         figure.add_trace(go.Scattergl(x=time, y=stationary_status, customdata=customdata, mode='markers'), 1, 1)
 
-        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status", custom_hover=True,
+        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status",
                          inject_js=self._custom_tooltip_js(value_label='Status', show_name=False))
 
     def _plot_displacement(self, source, p1_time, solution_type, displacement_enu_m, std_enu_m, gps_time=None,
@@ -1014,9 +1013,9 @@ figure.on('plotly_unhover', function(data) {
         """ + self._GPS_TICK_REFORMAT_JS
 
         self._add_figure(name=f"{name}_top_down", figure=topo_figure, title=f"{source}: Top-Down (Topocentric)",
-                         custom_hover=True, inject_js=_DISPLACEMENT_TOPO_HOVER_JS)
+                         inject_js=_DISPLACEMENT_TOPO_HOVER_JS)
         self._add_figure(name=f"{name}_vs_time", figure=time_figure, title=f"{source}: vs. Time",
-                         custom_hover=True, inject_js=_DISPLACEMENT_TIME_HOVER_JS)
+                         inject_js=_DISPLACEMENT_TIME_HOVER_JS)
 
     def plot_pose_error(self, reference: ReferenceData):
         """!
@@ -1325,7 +1324,8 @@ figure.on('plotly_unhover', function(data) {
             'yanchor': 'top'
         }]
 
-        self._add_figure(name="map", figure=figure, title="Vehicle Trajectory (Map)", config={'scrollZoom': True})
+        self._add_figure(name="map", figure=figure, title="Vehicle Trajectory (Map)", config={'scrollZoom': True},
+                         custom_hover=False)
 
     def plot_gnss_skyplot(self, decimate=True):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -1468,7 +1468,7 @@ figure.on('plotly_unhover', function(data) {
         figure['layout']['updatemenus'] = updatemenus
 
         name = self._gnss_plot_filename('gnss_skyplot', source_id)
-        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): Sky Plot')
+        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): Sky Plot', custom_hover=False)
 
     def plot_gnss_cn0(self):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -1540,7 +1540,7 @@ figure.on('plotly_unhover', function(data) {
         }]
 
         name = self._gnss_plot_filename('gnss_cn0', source_id)
-        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): C/N0 vs Time', custom_hover=True,
+        self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): C/N0 vs Time',
                          inject_js=self._custom_tooltip_js(precision=2))
 
     def plot_gnss_azimuth_elevation(self):
@@ -1636,7 +1636,7 @@ figure.on('plotly_unhover', function(data) {
 
         name = self._gnss_plot_filename('gnss_azimuth_elevation', source_id)
         self._add_figure(name=name, figure=figure, title=f'GNSS ({label}): Azimuth & Elevation vs Time',
-                         custom_hover=True, inject_js=self._custom_tooltip_js())
+                         inject_js=self._custom_tooltip_js())
 
     def plot_gnss_signal_status(self):
         for source_id in self._get_gnss_antenna_source_ids():
@@ -1965,7 +1965,7 @@ figure.on('plotly_unhover', function(data) {{
 }});
 """ + self._GPS_TICK_REFORMAT_JS
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True, inject_js=hover_js)
+        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=hover_js)
 
     def _get_pose_source_ids(self) -> List[int]:
         """!
@@ -2112,7 +2112,7 @@ figure.on('plotly_unhover', function(data) {{
                              1, 1)
 
         self._add_figure(name='gnss_dop', figure=figure, title='GNSS: Dilution of Precision (DOP) vs. Time',
-                         custom_hover=True, inject_js=self._custom_tooltip_js(value_label='DOP'))
+                         inject_js=self._custom_tooltip_js(value_label='DOP'))
 
     def plot_gnss_corrections_status(self):
         """!
@@ -2170,7 +2170,7 @@ figure.on('plotly_unhover', function(data) {{
                              4, 1)
 
         self._add_figure(name="gnss_corrections_status", figure=figure, title="GNSS: Corrections Status",
-                         custom_hover=True, inject_js=self._custom_tooltip_js())
+                         inject_js=self._custom_tooltip_js())
 
     def plot_wheel_data(self):
         """!
@@ -2574,7 +2574,7 @@ figure.on('plotly_unhover', function(data) {
 });
 """ + self._GPS_TICK_REFORMAT_JS
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True,
+        self._add_figure(name=filename, figure=figure, title=figure_title,
                          inject_js=_WHEEL_HOVER_JS)
 
     def plot_imu(self):
@@ -2658,7 +2658,7 @@ figure.on('plotly_unhover', function(data) {
                                       name='Interval', mode='markers', marker={'color': 'red'}),
                          3, 1)
 
-        self._add_figure(name=filename, figure=figure, title=figure_title, custom_hover=True,
+        self._add_figure(name=filename, figure=figure, title=figure_title,
                          inject_js=self._custom_tooltip_js())
 
     def plot_gnss_attitude_measurements(self):
@@ -2913,7 +2913,7 @@ figure.on('plotly_unhover', function(data) {
 
         self._add_figure(name='gnss_attitude_measurement', figure=fig,
                          title='Measurements: GNSS Attitude (Multi-Antenna Heading Sensor)',
-                         custom_hover=True, inject_js=_ATTITUDE_HOVER_JS)
+                         inject_js=_ATTITUDE_HOVER_JS)
 
     def plot_system_status_profiling(self):
         """!
@@ -2954,7 +2954,7 @@ figure.on('plotly_unhover', function(data) {
                          2, 1)
 
         self._add_figure(name="profile_system_status", figure=figure, title="Profiling: System Status",
-                         custom_hover=True, inject_js=self._custom_tooltip_js())
+                         inject_js=self._custom_tooltip_js())
 
     def plot_events(self):
         """!
@@ -3454,7 +3454,7 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         self.plots[name] = {'title': title, 'path': path}
 
     def _add_figure(self, name, figure=None, title=None, config=None, inject_js: str = None,
-                    time_axis_type: Optional[str] = None, custom_hover: bool = False):
+                    time_axis_type: Optional[str] = None, custom_hover: bool = True):
         """!
         @brief Generate an HTML file for the specified figure.
 
@@ -3468,9 +3468,12 @@ document.body.querySelector(".table").appendChild(filtered_table.getElement());
         @param time_axis_type The time domain actually plotted on this figure's X axis (`relative`, `p1`, `gps`, or
                `utc`; see @ref BuildTimeHoverText() in `plotly_data_support.js`). Defaults to `self.time_type`; only
                needs to be overridden by plots (e.g., @ref plot_time_scale()) whose X axis does not follow it.
-        @param custom_hover If `True`, set `hoverinfo='none'` on all of this figure's traces so Plotly's native hover
-               label never draws, for use with a custom-tooltip `inject_js` (see @ref _custom_tooltip_js()) instead
-               of per-trace `hoverinfo='none'` at every `go.Scatter()`/`go.Scattergl()` call site.
+        @param custom_hover If `True` (the default), set `hoverinfo='none'` on all of this figure's traces so
+               Plotly's native hover label never draws, for use with a custom-tooltip `inject_js` (see @ref
+               _custom_tooltip_js()) instead of per-trace `hoverinfo='none'` at every `go.Scatter()`/
+               `go.Scattergl()` call site. Set to `False` for figures with no custom-tooltip `inject_js` at all
+               (e.g. @ref plot_map(), whose Mapbox traces use `hovertemplate` instead) or that still rely on the
+               older `ChangeHoverText()`-based native hover.
         """
         if title is None:
             title = name

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1194,11 +1194,49 @@ figure.on('plotly_hover', function(data) {
             self._mapbox_token_missing = True
             mapbox_token = None
 
+        # Plotly's Mapbox/WebGL map trace hover renderer reads hover content from calcdata, baked in at plot time, and
+        # does not pick up a later client-side mutation of fullData.text the way cartesian (Scatter/Scattergl) traces
+        # do, so we cannot inject a plotly_hover() function like we do for most other plots. Instead, we have to use
+        # Plotly's `hovertemplate` function.
+        #
+        # hovertemplate can't apply date/time formatting to a bare *numeric* customdata value (that only works for a
+        # `%{x}` tied to a real date-typed axis) -- but a customdata entry with no format spec at all is substituted
+        # verbatim, so we precompute the UTC string in Python (cheap, vectorized) and reference it that way.
+        _POSITION_HOVERTEMPLATE = (
+            "LLA: %{lat:.8f}, %{lon:.8f}, %{customdata[4]:.2f}<br>"
+            "Rel: %{customdata[0]:.3f} sec (P1: %{customdata[1]:.3f} sec)<br>"
+            "UTC: %{customdata[8]}<br>"
+            "GPS: %{customdata[2]:.0f}:%{customdata[3]:.3f}<br>"
+            "Std (ENU): (%{customdata[5]:.2f}, %{customdata[6]:.2f}, %{customdata[7]:.2f}) m"
+        )
+
+        def _build_position_customdata(p1_time: np.ndarray, gps_time: np.ndarray,
+                                       lla_deg: np.ndarray, std_enu_m: np.ndarray) -> list:
+            rel_time = p1_time - float(self.reader.t0)
+            gps_week = np.floor(gps_time / SECONDS_PER_WEEK)
+            gps_tow_sec = gps_time - gps_week * SECONDS_PER_WEEK
+
+            utc_times = self.time_provider.gps_sec_to_datetime64_array(gps_time)
+            utc_strs = np.where(np.isnat(utc_times), 'N/A',
+                                np.datetime_as_string(utc_times, unit='ms'))
+            utc_strs = np.char.replace(utc_strs, 'T', ' ')
+
+            # Note: unlike the field-major (num_fields x N) arrays built by _time_hover_customdata() for use with our
+            # own GetCustomData() JS helper, Plotly's native `hovertemplate` expects customdata in the opposite,
+            # point-major layout -- one row per point, indexed as customdata[pointIndex][fieldIndex].
+            #
+            # utc_strs is a string column mixed in with the numeric ones above, so this can't be a single numpy
+            # array (that would coerce every column to strings, breaking the numeric %{customdata[N]:.3f}-style
+            # formatting for the rest); build it as a plain list of per-point rows instead.
+            numeric = np.column_stack((rel_time, p1_time, gps_week, gps_tow_sec, lla_deg[2], std_enu_m[0],
+                                       std_enu_m[1], std_enu_m[2]))
+            return [row.tolist() + [utc_str] for row, utc_str in zip(numeric, utc_strs)]
+
         # Add data to the map.
         map_data = []
         indices_by_engine = defaultdict(list)
 
-        def _plot_data(name, selected_idx, flags, source_id, marker_style=None):
+        def _plot_data(name, selected_idx, flags, source_id, lla_deg, customdata_all, marker_style=None):
             style = {'mode': 'markers', 'marker': {'size': 8}, 'showlegend': True}
             if marker_style is not None:
                 style['marker'].update(marker_style)
@@ -1213,22 +1251,20 @@ figure.on('plotly_hover', function(data) {
 
                 if np.any(is_nav_engine):
                     idx = is_nav_engine
-                    text = ["Time: %.3f sec (%.3f sec)<br>Std (ENU): (%.2f, %.2f, %.2f) m" %
-                            (t, t + float(self.t0), std[0], std[1], std[2])
-                            for t, std in zip(time[idx], std_enu_m[:, idx].T)]
-                    map_data.append(go.Scattermapbox(lat=lla_deg[0, idx], lon=lla_deg[1, idx], name=name, text=text,
+                    map_data.append(go.Scattermapbox(lat=lla_deg[0, idx], lon=lla_deg[1, idx], name=name,
+                                                     customdata=[customdata_all[i] for i in np.nonzero(idx)[0]],
+                                                     hovertemplate=_POSITION_HOVERTEMPLATE,
                                                      legendgroup=legendgroup, visible=visible, **style))
                     indices_by_engine['Nav Engine'].append(len(map_data) - 1)
 
                 if np.any(is_gnss_rx):
                     idx = is_gnss_rx
-                    text = ["Time: %.3f sec (%.3f sec)<br>Std (ENU): (%.2f, %.2f, %.2f) m" %
-                            (t, t + float(self.t0), std[0], std[1], std[2])
-                            for t, std in zip(time[idx], std_enu_m[:, idx].T)]
                     style['marker']['opacity'] = 0.5
                     style['marker']['size'] = 5
                     map_data.append(go.Scattermapbox(lat=lla_deg[0, idx], lon=lla_deg[1, idx],
-                                                     name=name + ' (Receiver Solution)', text=text,
+                                                     name=name + ' (Receiver Solution)',
+                                                     customdata=[customdata_all[i] for i in np.nonzero(idx)[0]],
+                                                     hovertemplate=_POSITION_HOVERTEMPLATE,
                                                      legendgroup=legendgroup, visible=visible, **style))
                     indices_by_engine['Receiver Solution'].append(len(map_data) - 1)
 
@@ -1256,11 +1292,14 @@ figure.on('plotly_hover', function(data) {
 
             have_pose_data = True
 
-            time = pose_data.p1_time[valid_idx] - float(self.t0)
             solution_type = pose_data.solution_type[valid_idx]
             flags = pose_data.flags[valid_idx]
             lla_deg = pose_data.lla_deg[:, valid_idx]
             std_enu_m = pose_data.position_std_enu_m[:, valid_idx]
+
+            customdata_all = _build_position_customdata(p1_time=pose_data.p1_time[valid_idx],
+                                                        gps_time=pose_data.gps_time[valid_idx],
+                                                        lla_deg=lla_deg, std_enu_m=std_enu_m)
 
             for type, info in _SOLUTION_TYPE_MAP.items():
                 if len(pose_source_ids) > 1:
@@ -1268,7 +1307,7 @@ figure.on('plotly_hover', function(data) {
                 else:
                     name = info.name
                 _plot_data(name=name, selected_idx=solution_type == type, flags=flags, source_id=source_id,
-                           marker_style=info.style)
+                           lla_deg=lla_deg, customdata_all=customdata_all, marker_style=info.style)
 
         if not have_pose_data:
             return

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -3568,12 +3568,20 @@ var time_axis_type = '{time_axis_type}';
         elif time_source == SystemTimeSource.TIMESTAMPED_ON_RECEPTION:
             return float(self.system_t0)
 
-    def _x_axis_layout(self) -> dict:
+    def _x_axis_layout(self, time_source: str = 'p1') -> dict:
         """!
         @brief Get the `go.layout.XAxis` kwargs (including `title`) for the current @c self.time_type.
 
+        @param time_source The native time domain of the data being plotted: `p1` (the default -- P1/relative/GPS/
+               UTC, per @c self.time_type) or `system` (device system time). There is no system-time-to-P1/GPS
+               mapping yet, so `system` always resolves to plain absolute/relative system time regardless of
+               @c self.time_type; once such a mapping exists, it can resolve to p1/gps/utc too, like `p1` below.
+
         @return A dict of `go.layout.XAxis` kwargs, e.g. `{'title': ..., 'type': 'date'}`.
         """
+        if time_source == 'system':
+            return {'title': self.system_time_label}
+
         if self.time_type in ('relative', 'p1'):
             return {'title': self.p1_time_label}
         elif self.time_type == 'gps':
@@ -3588,20 +3596,31 @@ var time_axis_type = '{time_axis_type}';
             # epoch numbers) they display as given, without being reinterpreted in the browser's local timezone.
             return {'title': 'UTC Time', 'type': 'date'}
 
-    def _resolve_x_axis(self, p1_time: np.ndarray, gps_time: Optional[np.ndarray] = None) -> \
+    def _resolve_x_axis(self, p1_time: Optional[np.ndarray] = None, gps_time: Optional[np.ndarray] = None,
+                        system_time: Optional[np.ndarray] = None, time_source: str = 'p1') -> \
             Tuple[np.ndarray, dict]:
         """!
         @brief Resolve the X axis values and layout to use for a time series, per @c self.time_type.
 
-        @param p1_time The P1 time for each point.
+        @param p1_time The P1 time for each point. Required (and only used) when `time_source` is `p1`.
         @param gps_time The GPS time for each point, if already known (e.g., from a @ref PoseMessage). If `None`, it
-               will be computed from `p1_time` via @c self.time_provider when needed.
+               will be computed from `p1_time` via @c self.time_provider when needed. Only used when `time_source`
+               is `p1`.
+        @param system_time The device system time for each point. Required (and only used) when `time_source` is
+               `system`.
+        @param time_source The native time domain of `p1_time`/`system_time`: `p1` (the default) or `system` (see
+               @ref _x_axis_layout()).
 
         @return A tuple `(x, axis_layout)`:
                 - `x`: The X axis values to plot.
                 - `axis_layout`: `go.layout.XAxis` kwargs needed to display `x` (title, and e.g. `type='date'`).
         """
-        axis_layout = self._x_axis_layout()
+        axis_layout = self._x_axis_layout(time_source=time_source)
+
+        if time_source == 'system':
+            # self.system_t0 is set to 0 when self.time_type == 'absolute', so this works for both absolute and relative
+            # time axes. See _x_axis_layout().
+            return system_time - float(self.system_t0), axis_layout
 
         if self.time_type == 'relative':
             return p1_time - float(self.t0), axis_layout

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -599,7 +599,8 @@ figure.on('plotly_hover', function(data) {
             self.logger.info('No pose data available. Skipping pose vs. time plot.')
             return
 
-        time = pose_data.p1_time - float(self.t0)
+        time, axis_layout = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time)
+        customdata = self._time_hover_customdata(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time)
 
         valid_idx = np.logical_and(~np.isnan(pose_data.p1_time), pose_data.solution_type != SolutionType.Invalid)
         if not np.any(valid_idx):
@@ -620,7 +621,7 @@ figure.on('plotly_hover', function(data) {
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(6):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True, matches='x')
+            figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, matches='x', **axis_layout)
         figure['layout']['yaxis1'].update(title="Degrees")
         figure['layout']['yaxis2'].update(title="Meters")
         figure['layout']['yaxis3'].update(title="Meters/Second")
@@ -629,24 +630,24 @@ figure.on('plotly_hover', function(data) {
         figure['layout']['yaxis6'].update(title="Meters/Second")
 
         # Plot YPR.
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[0, :], name='Yaw', legendgroup='yaw',
-                                      mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[0, :], customdata=customdata, name='Yaw',
+                                      legendgroup='yaw', mode='lines', line={'color': 'red'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[1, :], name='Pitch', legendgroup='pitch',
-                                      mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[1, :], customdata=customdata, name='Pitch',
+                                      legendgroup='pitch', mode='lines', line={'color': 'green'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[2, :], name='Roll', legendgroup='roll',
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_deg[2, :], customdata=customdata, name='Roll',
+                                      legendgroup='roll', mode='lines', line={'color': 'blue'}),
                          1, 1)
 
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[0, :], name='Yaw', legendgroup='yaw',
-                                      showlegend=False, mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[0, :], customdata=customdata, name='Yaw',
+                                      legendgroup='yaw', showlegend=False, mode='lines', line={'color': 'red'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[1, :], name='Pitch', legendgroup='pitch',
-                                      showlegend=False, mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[1, :], customdata=customdata, name='Pitch',
+                                      legendgroup='pitch', showlegend=False, mode='lines', line={'color': 'green'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[2, :], name='Roll', legendgroup='roll',
-                                      showlegend=False, mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.ypr_std_deg[2, :], customdata=customdata, name='Roll',
+                                      legendgroup='roll', showlegend=False, mode='lines', line={'color': 'blue'}),
                          2, 1)
 
         # Plot position/displacement.
@@ -654,51 +655,58 @@ figure.on('plotly_hover', function(data) {
                                                  alt=pose_data.lla_deg[2, :], deg=True))
         displacement_ecef_m = position_ecef_m - position_ecef_m[:, first_idx].reshape(3, 1)
         displacement_enu_m = c_enu_ecef.dot(displacement_ecef_m)
-        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[0, :], name='East', legendgroup='e',
-                                      mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[0, :], customdata=customdata, name='East',
+                                      legendgroup='e', mode='lines', line={'color': 'red'}),
                          1, 2)
-        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[1, :], name='North', legendgroup='n',
-                                      mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[1, :], customdata=customdata, name='North',
+                                      legendgroup='n', mode='lines', line={'color': 'green'}),
                          1, 2)
-        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[2, :], name='Up', legendgroup='u',
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=displacement_enu_m[2, :], customdata=customdata, name='Up',
+                                      legendgroup='u', mode='lines', line={'color': 'blue'}),
                          1, 2)
 
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[0, :], name='East', legendgroup='e',
-                                      showlegend=False, mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[0, :], customdata=customdata,
+                                      name='East', legendgroup='e', showlegend=False, mode='lines',
+                                      line={'color': 'red'}),
                          2, 2)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[1, :], name='North', legendgroup='n',
-                                      showlegend=False, mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[1, :], customdata=customdata,
+                                      name='North', legendgroup='n', showlegend=False, mode='lines',
+                                      line={'color': 'green'}),
                          2, 2)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[2, :], name='Up', legendgroup='u',
-                                      showlegend=False, mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.position_std_enu_m[2, :], customdata=customdata,
+                                      name='Up', legendgroup='u', showlegend=False, mode='lines',
+                                      line={'color': 'blue'}),
                          2, 2)
 
         # Plot velocity.
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[0, :], name='X', legendgroup='x',
-                                      mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[0, :], customdata=customdata, name='X',
+                                      legendgroup='x', mode='lines', line={'color': 'red'}),
                          1, 3)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[1, :], name='Y', legendgroup='y',
-                                      mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[1, :], customdata=customdata, name='Y',
+                                      legendgroup='y', mode='lines', line={'color': 'green'}),
                          1, 3)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[2, :], name='Z', legendgroup='z',
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_body_mps[2, :], customdata=customdata, name='Z',
+                                      legendgroup='z', mode='lines', line={'color': 'blue'}),
                          1, 3)
-        figure.add_trace(go.Scattergl(x=time, y=np.linalg.norm(pose_data.velocity_body_mps, axis=0), name='3D',
+        figure.add_trace(go.Scattergl(x=time, y=np.linalg.norm(pose_data.velocity_body_mps, axis=0),
+                                      customdata=customdata, name='3D',
                                       mode='lines', line={'color': 'orange', 'dash': 'dash'}),
                          1, 3)
 
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[0, :], name='X', legendgroup='x',
-                                      showlegend=False, mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[0, :], customdata=customdata,
+                                      name='X', legendgroup='x', showlegend=False, mode='lines',
+                                      line={'color': 'red'}),
                          2, 3)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[1, :], name='Y', legendgroup='y',
-                                      showlegend=False, mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[1, :], customdata=customdata,
+                                      name='Y', legendgroup='y', showlegend=False, mode='lines',
+                                      line={'color': 'green'}),
                          2, 3)
-        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[2, :], name='Z', legendgroup='z',
-                                      showlegend=False, mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=pose_data.velocity_std_body_mps[2, :], customdata=customdata,
+                                      name='Z', legendgroup='z', showlegend=False, mode='lines',
+                                      line={'color': 'blue'}),
                          2, 3)
 
-        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time")
+        self._add_figure(name="pose", figure=figure, title="Vehicle Pose vs. Time", inject_js=self._TIME_HOVER_JS)
 
     def plot_calibration(self):
         """!
@@ -821,35 +829,38 @@ figure.on('plotly_hover', function(data) {
         # Setup the figure.
         figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=True, subplot_titles=['Solution Type'])
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis'].update(title=self.p1_time_label)
+        figure['layout']['xaxis'].update(**self._x_axis_layout())
         figure['layout']['yaxis1'].update(title="Solution Type",
                                           ticktext=['%s (%d)' % (e.name, e.value) for e in SolutionType],
                                           tickvals=[e.value for e in SolutionType])
 
-        all_time = pose_data.p1_time - float(self.t0)
         is_gnss_rx = (pose_data.flags & PoseMessage.FLAG_RECEIVER_SOLUTION) != 0
         is_nav_engine = ~is_gnss_rx
 
         # Plot nav engine solutions.
         if np.any(is_nav_engine):
             idx = is_nav_engine
-            time = all_time[idx]
-            text = ["Time: %.3f sec (%.3f sec)" % (t, t + float(self.t0)) for t in time]
-            figure.add_trace(go.Scattergl(x=time, y=pose_data.solution_type[idx], text=text, name='Nav Engine',
-                                          mode='markers'),
+            p1_time = pose_data.p1_time[idx]
+            gps_time = pose_data.gps_time[idx]
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
+            figure.add_trace(go.Scattergl(x=time, y=pose_data.solution_type[idx], customdata=customdata,
+                                          name='Nav Engine', mode='markers'),
                              1, 1)
 
         # Plot GNSS receiver solutions, if any.
         if np.any(is_gnss_rx):
             idx = is_gnss_rx
-            time = all_time[idx]
-            text = ["Time: %.3f sec (%.3f sec)" % (t, t + float(self.t0)) for t in time]
-            figure.add_trace(go.Scattergl(x=time, y=pose_data.solution_type[idx], text=text,
+            p1_time = pose_data.p1_time[idx]
+            gps_time = pose_data.gps_time[idx]
+            time, _ = self._resolve_x_axis(p1_time=p1_time, gps_time=gps_time)
+            customdata = self._time_hover_customdata(p1_time=p1_time, gps_time=gps_time)
+            figure.add_trace(go.Scattergl(x=time, y=pose_data.solution_type[idx], customdata=customdata,
                                           name='Receiver Solution',
                                           mode='markers', marker={'color': 'red', 'symbol': 'diamond-open'}),
                              1, 1)
 
-        self._add_figure(name="solution_type", figure=figure, title="Solution Type")
+        self._add_figure(name="solution_type", figure=figure, title="Solution Type", inject_js=self._TIME_HOVER_JS)
 
     def plot_stationary_status(self):
         """!
@@ -870,20 +881,21 @@ figure.on('plotly_hover', function(data) {
         figure = make_subplots(rows=1, cols=1, print_grid=False, shared_xaxes=True,
                                subplot_titles=['Stationary Status'])
 
-        figure['layout']['xaxis'].update(title=self.p1_time_label)
         figure['layout']['yaxis1'].update(title="Stationary Status",
                                           ticktext=['Moving', 'Stationary'],
                                           tickvals=[0, PoseMessage.FLAG_STATIONARY])
 
-        time = pose_data.p1_time - float(self.t0)
+        time, axis_layout = self._resolve_x_axis(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time)
+        customdata = self._time_hover_customdata(p1_time=pose_data.p1_time, gps_time=pose_data.gps_time)
+        figure['layout']['xaxis'].update(**axis_layout)
 
         # Extract the stationary status from the pose data flags.
         stationary_status = pose_data.flags & PoseMessage.FLAG_STATIONARY
 
-        text = ["Time: %.3f sec (%.3f sec)" % (t, t + float(self.t0)) for t in time]
-        figure.add_trace(go.Scattergl(x=time, y=stationary_status, text=text, mode='markers'), 1, 1)
+        figure.add_trace(go.Scattergl(x=time, y=stationary_status, customdata=customdata, mode='markers'), 1, 1)
 
-        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status")
+        self._add_figure(name="stationary_status", figure=figure, title="Stationary Status",
+                         inject_js=self._TIME_HOVER_JS)
 
     def _plot_displacement(self, source, time, solution_type, displacement_enu_m, std_enu_m,
                            title='Displacement'):
@@ -2009,13 +2021,16 @@ figure.on('plotly_hover', function(data) {{
             self.logger.info('No GNSS info data available. Skipping dilution of precision plot.')
             return
 
+        time, axis_layout = self._resolve_x_axis(p1_time=data.p1_time, gps_time=data.gps_time)
+        customdata = self._time_hover_customdata(p1_time=data.p1_time, gps_time=data.gps_time)
+
         # # Setup the figure.
         figure = make_subplots(
             rows=1, cols=1,  print_grid=False, shared_xaxes=True,
             subplot_titles=['Dilution of Precision (DOP)'])
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
-        figure['layout']['xaxis'].update(title=self.p1_time_label)
+        figure['layout']['xaxis'].update(**axis_layout)
 
         dops = [('GDOP', data.gdop), ('PDOP', data.pdop), ('HDOP', data.hdop), ('VDOP', data.vdop)]
 
@@ -2026,13 +2041,12 @@ figure.on('plotly_hover', function(data) {{
         for entry in dops:
             name, dop = entry
 
-            text = ['P1: %.1f sec' % t for t in data.p1_time]
-            time = data.p1_time - float(self.t0)
-            figure.add_trace(go.Scattergl(x=time, y=dop, text=text, name=name,
+            figure.add_trace(go.Scattergl(x=time, y=dop, customdata=customdata, name=name,
                                           mode='markers', marker={'color': color_by_dop[name]}),
                              1, 1)
 
-        self._add_figure(name='gnss_dop', figure=figure, title='GNSS Dilution of Precision (DOP) vs. Time')
+        self._add_figure(name='gnss_dop', figure=figure, title='GNSS Dilution of Precision (DOP) vs. Time',
+                         inject_js=self._TIME_HOVER_JS)
 
     def plot_gnss_corrections_status(self):
         """!

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -229,15 +229,10 @@ figure.on('plotly_hover', function(data) {
         self.time_type = time_type
 
         if self.time_type == 'relative':
-            self.t0 = self.reader.t0
-            if self.t0 is None:
-                self.t0 = Timestamp()
-
             self.system_t0 = self.reader.get_system_t0()
             if self.system_t0 is None:
                 self.system_t0 = np.nan
         else:
-            self.t0 = Timestamp(0.0)
             self.system_t0 = 0.0
 
         # The time domain -- `p1` (covers both relative and absolute P1 time) or `gps` (covers both GPS and UTC) --

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -3748,7 +3748,7 @@ var time_axis_type = '{time_axis_type}';
             return np.vstack((p1_time,))
 
     def _custom_tooltip_js(self, time_source: str = 'p1', precision: Optional[int] = 3,
-                           value_label: Optional[str] = None) -> str:
+                           value_label: Optional[str] = None, show_name: bool = True, show_value: bool = True) -> str:
         """!
         @brief Build hover JS that draws its own tooltip instead of relying on Plotly's native hover label (see
                `ShowCustomTooltip()`/`HideCustomTooltip()` in `plotly_data_support.js`).
@@ -3765,6 +3765,8 @@ var time_axis_type = '{time_axis_type}';
         @param precision Number of digits after the decimal point to show for the Y value (see
                `BuildAxisValueHoverText()`).
         @param value_label Override label to show instead of the Y axis title (see `BuildAxisValueHoverText()`).
+        @param show_name Show trace names in the tooltip.
+        @param show_value Show trace values in the tooltip.
 
         @return The JS to pass as `inject_js` to @ref _add_figure().
         """
@@ -3786,12 +3788,19 @@ var time_axis_type = '{time_axis_type}';
         if value_label is not None:
             value_options['label'] = value_label
 
+        name_arg = 'point.data.name' if show_name else 'undefined'
+        if show_value:
+            value_text_js = f'  let value_text = BuildAxisValueHoverText(point, {json.dumps(value_options)});'
+            value_arg = 'value_text'
+        else:
+            value_text_js = ''
+            value_arg = 'undefined'
+
         return ("""\
 figure.on('plotly_hover', function(data) {
   let point = data.points[0];
-""" + build_time_text_js + """
-  let value_text = BuildAxisValueHoverText(point, """ + json.dumps(value_options) + """);
-  ShowCustomTooltip(point, GetCustomTooltipHTML(point.data.name, value_text, time_text));
+""" + build_time_text_js + "\n" + value_text_js + """
+  ShowCustomTooltip(point, GetCustomTooltipHTML(""" + name_arg + ", " + value_arg + """, time_text));
 });
 figure.on('plotly_unhover', function(data) {
   HideCustomTooltip();

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -236,14 +236,9 @@ figure.on('plotly_hover', function(data) {
             self.system_t0 = self.reader.get_system_t0()
             if self.system_t0 is None:
                 self.system_t0 = np.nan
-
-            self.p1_time_label = 'Relative Time (sec)'
-            self.system_time_label = 'Relative Time (sec)'
         else:
             self.t0 = Timestamp(0.0)
             self.system_t0 = 0.0
-            self.p1_time_label = 'P1 Time (sec)'
-            self.system_time_label = 'System Time (sec)'
 
         # The time domain -- `p1` (covers both relative and absolute P1 time) or `gps` (covers both GPS and UTC) --
         # implied by @c self.time_type, used by @ref _resolve_x_axis() and the default of _time_hover_customdata()'s
@@ -3601,10 +3596,15 @@ var time_axis_type = '{time_axis_type}';
         @return A dict of `go.layout.XAxis` kwargs, e.g. `{'title': ..., 'type': 'date'}`.
         """
         if time_source == 'system':
-            return {'title': self.system_time_label}
+            if self.time_type == 'relative':
+                return {'title': 'Relative Time (sec)'}
+            else:
+                return {'title': 'System Time (sec)'}
 
-        if self.time_type in ('relative', 'p1'):
-            return {'title': self.p1_time_label}
+        if self.time_type == 'relative':
+            return {'title': 'Relative Time (sec)'}
+        elif self.time_type == 'p1':
+            return {'title': 'P1 Time (sec)'}
         elif self.time_type == 'gps':
             # GPS seconds are large enough that Plotly may otherwise render ticks in scientific/SI-prefix notation,
             # which _ReformatGpsAxisTicks() (see plotly_data_support.js) can't parse back into week:tow. We let

--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -2278,13 +2278,18 @@ figure.on('plotly_hover', function(data) {{
                 self.logger.warning('Both raw and corrected %s data present, but timestamped with different '
                                     'sources. Plotted data may not align in time.' % source)
 
+        # Time-type-based (relative/P1/GPS/UTC) axis display is only meaningful when all of the data being plotted is
+        # natively in P1 time -- there's no P1/GPS correspondence to fall back on for other time sources (system time
+        # of reception, etc.), which are only ever used for input messages.
+        use_time_type = same_time_source and common_time_source == SystemTimeSource.P1_TIME
+
         if same_time_source:
             time_name = self._time_source_to_display_name(common_time_source)
             figure['layout']['annotations'][0]['text'] += '<br>Time Source: %s' % time_name
 
-            time_label = f'{time_name} Time (sec)'
+            axis_layout = self._x_axis_layout() if use_time_type else {'title': f'{time_name} Time (sec)'}
             for i in range(len(titles)):
-                figure['layout']['xaxis%d' % (i + 1)].update(title=time_label, showticklabels=True)
+                figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         else:
             corrected_time_name = self._time_source_to_display_name(corrected_time_source)
             raw_time_name = self._time_source_to_display_name(raw_time_source)
@@ -2335,31 +2340,67 @@ figure.on('plotly_hover', function(data) {{
                     nav_engine_speed_name = '|3D Speed Estimate| (Nav Engine)'
 
             if nav_engine_speed_mps is not None:
-                time = nav_engine_p1_time - float(self.t0)
-                text = ["P1: %.3f sec" % t for t in nav_engine_p1_time]
-                figure.add_trace(go.Scattergl(x=time, y=nav_engine_speed_mps, text=text, name=nav_engine_speed_name,
-                                              mode='lines', line={'color': 'black', 'dash': 'dash'}),
+                if use_time_type:
+                    nav_time, _ = self._resolve_x_axis(p1_time=nav_engine_p1_time)
+                    nav_kwargs = {'customdata': self._time_hover_customdata(p1_time=nav_engine_p1_time)}
+                else:
+                    nav_time = nav_engine_p1_time - float(self.t0)
+                    nav_kwargs = {'text': ["P1: %.3f sec" % t for t in nav_engine_p1_time]}
+                figure.add_trace(go.Scattergl(x=nav_time, y=nav_engine_speed_mps, name=nav_engine_speed_name,
+                                              mode='lines', line={'color': 'black', 'dash': 'dash'}, **nav_kwargs),
                                  1, 1)
 
+        # Hover text helper functions.
+        def _get_time_and_hover_data(abs_time_sec, time_source):
+            # If every message being plotted is natively in P1 time, use the current --time-type (relative/P1/GPS/
+            # UTC) axis and shared hover text; otherwise fall back to plotting in the message's own raw time source,
+            # which has no P1/GPS correspondence to convert from.
+            #
+            # Returns (time, time_sec, hover_kwargs): `time` is the X axis value to plot (may be a datetime64 array
+            # in UTC mode), while `time_sec` is always plain elapsed seconds, suitable for interval/rate calculations.
+            if use_time_type:
+                time, _ = self._resolve_x_axis(p1_time=abs_time_sec)
+                return time, abs_time_sec, {'customdata': self._time_hover_customdata(p1_time=abs_time_sec)}
+            else:
+                t0 = self._get_t0_for_time_source(time_source)
+                time = abs_time_sec - t0
+                time_name = self._time_source_to_display_name(time_source)
+                text = ["%s Time: %.3f sec" % (time_name, t) for t in abs_time_sec]
+                return time, abs_time_sec, {'text': text}
+
+        def _slice_hover_kwargs(hover_kwargs, s):
+            # Slice a {'text': ...} or {'customdata': ...} dict (see _get_time_and_hover_data()) down to a subset of
+            # points, e.g. for a trace plotted against time[1:] (an interval or rate derived via np.diff()).
+            if 'text' in hover_kwargs:
+                return {'text': hover_kwargs['text'][s]}
+            elif 'customdata' in hover_kwargs:
+                return {'customdata': hover_kwargs['customdata'][:, s]}
+            else:
+                return {}
+
         # Plot the data.
-        def _plot_trace(time, data, name, color, text, style=None):
+        def _plot_trace(time, time_sec, data, name, color, text=None, customdata=None, style=None):
             if style is None:
                 style = {}
             style.setdefault('mode', 'lines')
             style.setdefault('line', {}).setdefault('color', color)
+            kwargs = {'text': text} if text is not None else {'customdata': customdata}
 
             if type == 'tick':
-                figure.add_trace(go.Scattergl(x=time, y=data, text=text, name=name, legendgroup=name, **style),
+                figure.add_trace(go.Scattergl(x=time, y=data, name=name, legendgroup=name, **kwargs, **style),
                                  1, 1)
 
-                dt_sec = np.diff(time)
+                # Note: Rate is always computed from time_sec (plain seconds), not time -- time may be a datetime64
+                # axis (UTC mode), which does not support division.
+                dt_sec = np.diff(time_sec)
                 ticks_per_sec = np.diff(data) / dt_sec
-                figure.add_trace(go.Scattergl(x=time[1:], y=ticks_per_sec, text=text, name=name,
+                rate_kwargs = _slice_hover_kwargs(kwargs, slice(1, None))
+                figure.add_trace(go.Scattergl(x=time[1:], y=ticks_per_sec, name=name,
                                               legendgroup=name, showlegend=False,
-                                              **style),
+                                              **rate_kwargs, **style),
                                  2, 1)
             else:
-                figure.add_trace(go.Scattergl(x=time, y=data, text=text, name=name, legendgroup=name, **style),
+                figure.add_trace(go.Scattergl(x=time, y=data, name=name, legendgroup=name, **kwargs, **style),
                                  1, 1)
 
         def _plot_wheel_data(data, time_source, is_raw=False, show_gear=False, style=None):
@@ -2379,33 +2420,29 @@ figure.on('plotly_hover', function(data) {{
                 var_suffix = 'speed_mps'
                 name_suffix = ' (Uncorrected)' if is_raw else ' (Corrected)'
 
-            abs_time_sec = self._get_measurement_time(data, time_source)
-            idx = ~np.isnan(abs_time_sec)
-            abs_time_sec = abs_time_sec[idx]
+            measurement_time = self._get_measurement_time(data, time_source)
+            idx = ~np.isnan(measurement_time)
+            time, time_sec, hover_kwargs = _get_time_and_hover_data(measurement_time[idx], time_source)
 
-            t0 = self._get_t0_for_time_source(time_source)
-            time = abs_time_sec - t0
-            time_name = self._time_source_to_display_name(time_source)
-            text = ["%s Time: %.3f sec" % (time_name, t) for t in abs_time_sec]
-
-            _plot_trace(time=time, data=getattr(data, 'front_left_' + var_suffix)[idx], text=text,
-                        name='Front Left Wheel' + name_suffix, color='red', style=style)
-            _plot_trace(time=time, data=getattr(data, 'front_right_' + var_suffix)[idx], text=text,
-                        name='Front Right Wheel' + name_suffix, color='green', style=style)
-            _plot_trace(time=time, data=getattr(data, 'rear_left_' + var_suffix)[idx], text=text,
-                        name='Rear Left Wheel' + name_suffix, color='blue', style=style)
-            _plot_trace(time=time, data=getattr(data, 'rear_right_' + var_suffix)[idx], text=text,
-                        name='Rear Right Wheel' + name_suffix, color='purple', style=style)
+            _plot_trace(time=time, time_sec=time_sec, data=getattr(data, 'front_left_' + var_suffix)[idx],
+                        name='Front Left Wheel' + name_suffix, color='red', style=style, **hover_kwargs)
+            _plot_trace(time=time, time_sec=time_sec, data=getattr(data, 'front_right_' + var_suffix)[idx],
+                        name='Front Right Wheel' + name_suffix, color='green', style=style, **hover_kwargs)
+            _plot_trace(time=time, time_sec=time_sec, data=getattr(data, 'rear_left_' + var_suffix)[idx],
+                        name='Rear Left Wheel' + name_suffix, color='blue', style=style, **hover_kwargs)
+            _plot_trace(time=time, time_sec=time_sec, data=getattr(data, 'rear_right_' + var_suffix)[idx],
+                        name='Rear Right Wheel' + name_suffix, color='purple', style=style, **hover_kwargs)
 
             if show_gear:
-                figure.add_trace(go.Scattergl(x=time, y=data.gear[idx], text=text, name='Gear (Wheel Data)',
-                                              mode='markers', marker={'color': 'red'}),
+                figure.add_trace(go.Scattergl(x=time, y=data.gear[idx], name='Gear (Wheel Data)',
+                                              mode='markers', marker={'color': 'red'}, **hover_kwargs),
                                  gear_y_axis, 1)
 
             name = "Wheel Interval" + name_suffix
             color = 'blue' if is_raw else 'red'
-            figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(time), name=name,
-                                          mode='markers', marker={'color': color}),
+            figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(time_sec), name=name,
+                                          mode='markers', marker={'color': color},
+                                          **_slice_hover_kwargs(hover_kwargs, slice(1, None))),
                              interval_y_axis, 1)
 
         def _plot_vehicle_data(data, time_source, is_raw=False, show_gear=False, style=None):
@@ -2425,27 +2462,23 @@ figure.on('plotly_hover', function(data) {{
                 var_suffix = 'vehicle_speed_mps'
                 name_suffix = ' (Uncorrected)' if is_raw else ' (Corrected)'
 
-            abs_time_sec = self._get_measurement_time(data, time_source)
-            idx = ~np.isnan(abs_time_sec)
-            abs_time_sec = abs_time_sec[idx]
+            measurement_time = self._get_measurement_time(data, time_source)
+            idx = ~np.isnan(measurement_time)
+            time, time_sec, hover_kwargs = _get_time_and_hover_data(measurement_time[idx], time_source)
 
-            t0 = self._get_t0_for_time_source(time_source)
-            time = abs_time_sec - t0
-            time_name = self._time_source_to_display_name(time_source)
-            text = ["%s Time: %.3f sec" % (time_name, t) for t in abs_time_sec]
-
-            _plot_trace(time=time, data=getattr(data, var_suffix)[idx], text=text,
-                        name='Speed Measurement' + name_suffix, color='orange', style=style)
+            _plot_trace(time=time, time_sec=time_sec, data=getattr(data, var_suffix)[idx],
+                        name='Speed Measurement' + name_suffix, color='orange', style=style, **hover_kwargs)
 
             if show_gear:
-                figure.add_trace(go.Scattergl(x=time, y=data.gear[idx], text=text, name='Gear (Vehicle Data)',
-                                              mode='markers', marker={'color': 'orange'}),
+                figure.add_trace(go.Scattergl(x=time, y=data.gear[idx], name='Gear (Vehicle Data)',
+                                              mode='markers', marker={'color': 'orange'}, **hover_kwargs),
                                  gear_y_axis, 1)
 
             name = "Vehicle Interval" + name_suffix
             color = 'blue' if is_raw else 'red'
-            figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(time), name=name,
-                                          mode='markers', marker={'color': color}),
+            figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(time_sec), name=name,
+                                          mode='markers', marker={'color': color},
+                                          **_slice_hover_kwargs(hover_kwargs, slice(1, None))),
                              interval_y_axis, 1)
 
         # Plot the data. If we have both corrected (e.g., WheelSpeedOutput) and uncorrected (e.g., RawWheelSpeedOutput)
@@ -2454,7 +2487,7 @@ figure.on('plotly_hover', function(data) {{
         _plot_func(data, corrected_time_source, is_raw=False, show_gear=True)
         _plot_func(raw_data, raw_time_source, is_raw=True, show_gear=False)
 
-        self._add_figure(name=filename, figure=figure, title=figure_title)
+        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=self._TIME_HOVER_JS)
 
     def plot_imu(self):
         """!
@@ -2492,7 +2525,8 @@ figure.on('plotly_hover', function(data) {{
                              ('IMU' if message_cls is IMUOutput else 'raw IMU'))
             return
 
-        time = data.p1_time - float(self.t0)
+        time, axis_layout = self._resolve_x_axis(p1_time=data.p1_time)
+        customdata = self._time_hover_customdata(p1_time=data.p1_time)
 
         titles = ['Acceleration', 'Gyro']
         if message_cls == RawIMUOutput:
@@ -2505,36 +2539,38 @@ figure.on('plotly_hover', function(data) {{
 
         figure['layout'].update(showlegend=True, modebar_add=['v1hovermode'])
         for i in range(3):
-            figure['layout']['xaxis%d' % (i + 1)].update(title=self.p1_time_label, showticklabels=True)
+            figure['layout']['xaxis%d' % (i + 1)].update(showticklabels=True, **axis_layout)
         figure['layout']['yaxis1'].update(title="Acceleration (m/s^2)")
         figure['layout']['yaxis2'].update(title="Rotation Rate (rad/s)")
         figure['layout']['yaxis3'].update(title="Interval (sec)")
 
-        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[0, :], name='X', legendgroup='x',
-                                      mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[0, :], customdata=customdata, name='X',
+                                      legendgroup='x', mode='lines', line={'color': 'red'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[1, :], name='Y', legendgroup='y',
-                                      mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[1, :], customdata=customdata, name='Y',
+                                      legendgroup='y', mode='lines', line={'color': 'green'}),
                          1, 1)
-        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[2, :], name='Z', legendgroup='z',
-                                      mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.accel_mps2[2, :], customdata=customdata, name='Z',
+                                      legendgroup='z', mode='lines', line={'color': 'blue'}),
                          1, 1)
 
-        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[0, :], name='X', legendgroup='x',
-                                      showlegend=False, mode='lines', line={'color': 'red'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[0, :], customdata=customdata, name='X',
+                                      legendgroup='x', showlegend=False, mode='lines', line={'color': 'red'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[1, :], name='Y', legendgroup='y',
-                                      showlegend=False, mode='lines', line={'color': 'green'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[1, :], customdata=customdata, name='Y',
+                                      legendgroup='y', showlegend=False, mode='lines', line={'color': 'green'}),
                          2, 1)
-        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[2, :], name='Z', legendgroup='z',
-                                      showlegend=False, mode='lines', line={'color': 'blue'}),
+        figure.add_trace(go.Scattergl(x=time, y=data.gyro_rps[2, :], customdata=customdata, name='Z',
+                                      legendgroup='z', showlegend=False, mode='lines', line={'color': 'blue'}),
                          2, 1)
 
-        figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(time), name='Interval',
-                                      mode='markers', marker={'color': 'red'}),
+        # Note: Interval is always computed from data.p1_time (plain seconds), not time -- time may be a datetime64
+        # axis (UTC mode), which does not support subtraction the same way.
+        figure.add_trace(go.Scattergl(x=time[1:], y=np.diff(data.p1_time), customdata=customdata[:, 1:],
+                                      name='Interval', mode='markers', marker={'color': 'red'}),
                          3, 1)
 
-        self._add_figure(name=filename, figure=figure, title=figure_title)
+        self._add_figure(name=filename, figure=figure, title=figure_title, inject_js=self._TIME_HOVER_JS)
 
     def plot_gnss_attitude_measurements(self):
         """!
@@ -2556,6 +2592,28 @@ figure.on('plotly_hover', function(data) {{
         # there's no heading data in the log.
         result = self.reader.read(message_types=[PoseMessage], source_ids=self.default_source_id, **self.params)
         primary_pose_data = result[PoseMessage.MESSAGE_TYPE]
+        have_primary = (primary_pose_data is not None and
+                        np.any(primary_pose_data.solution_type != SolutionType.Invalid))
+
+        # Extract X axis data to be plotted below.
+        if have_primary:
+            primary_time, _ = self._resolve_x_axis(p1_time=primary_pose_data.p1_time,
+                                                    gps_time=primary_pose_data.gps_time)
+            primary_customdata = self._time_hover_customdata(p1_time=primary_pose_data.p1_time,
+                                                              gps_time=primary_pose_data.gps_time)
+
+        have_raw = len(raw_heading_data.p1_time) > 0
+        if have_raw:
+            raw_gps_time = getattr(raw_heading_data, 'gps_time', None)
+            raw_time, _ = self._resolve_x_axis(p1_time=raw_heading_data.p1_time, gps_time=raw_gps_time)
+            raw_customdata = self._time_hover_customdata(p1_time=raw_heading_data.p1_time, gps_time=raw_gps_time)
+
+        have_corrected = len(heading_data.p1_time) > 0
+        if have_corrected:
+            corrected_gps_time = getattr(heading_data, 'gps_time', None)
+            corrected_time, _ = self._resolve_x_axis(p1_time=heading_data.p1_time, gps_time=corrected_gps_time)
+            corrected_customdata = self._time_hover_customdata(p1_time=heading_data.p1_time,
+                                                                gps_time=corrected_gps_time)
 
         # Setup the figure.
         fig = make_subplots(
@@ -2571,7 +2629,7 @@ figure.on('plotly_hover', function(data) {{
         fig.update_layout(title='GNSS Attitude Measurements (Multi-Antenna Heading Sensor)',
                           showlegend=True, modebar_add=['v1hovermode'])
 
-        fig.update_xaxes(title_text=self.p1_time_label, showticklabels=True)
+        fig.update_xaxes(showticklabels=True, **self._x_axis_layout())
         fig.update_yaxes(title_text='Heading (deg)', rangemode='tozero', row=1, col=1)
         fig.update_yaxes(title_text='Distance (m)', row=2, col=1)
         fig.update_yaxes(
@@ -2587,9 +2645,7 @@ figure.on('plotly_hover', function(data) {{
 
         # Display the navigation engine's heading estimate, if available, for comparison with the heading sensor
         # measurement.
-        if primary_pose_data is not None and np.any(primary_pose_data.solution_type != SolutionType.Invalid):
-            p1_time = primary_pose_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_primary:
             heading_deg = yaw_to_heading(primary_pose_data.ypr_deg[0, :])
             yaw_std_deg = primary_pose_data.ypr_std_deg[0, :]
 
@@ -2599,38 +2655,30 @@ figure.on('plotly_hover', function(data) {{
 
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=heading_deg,
-                    customdata=np.stack((p1_time, yaw_std_deg), axis=-1),
+                    x=primary_time, y=heading_deg,
+                    customdata=np.vstack((primary_customdata, yaw_std_deg)),
                     name='Heading: Navigation Engine', legendgroup='nav',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata[0]:.3f} sec)'
-                                  '<br><b>Heading</b>: %{y:.2f} deg (<b>Std</b>: %{customdata[1]:.2f} deg)',
                     mode='lines', line={'color': 'yellow'}
                 ),
                 row=1, col=1
             )
 
         # Raw (uncorrected) heading, derived from reported ENU vector.
-        if len(raw_heading_data.p1_time) > 0:
-            p1_time = raw_heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_raw:
             yaw_deg = np.degrees(np.arctan2(raw_heading_data.relative_position_enu_m[1, :],
                                             raw_heading_data.relative_position_enu_m[0, :]))
             heading_deg = yaw_to_heading(yaw_deg)
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=heading_deg, customdata=p1_time,
+                    x=raw_time, y=heading_deg, customdata=raw_customdata,
                     name='Heading: Raw Measurement', legendgroup='raw',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Heading</b>: %{y:.2f} deg',
                     mode='markers', marker={"color": "purple"}
                 ),
                 row=1, col=1
             )
 
         # Corrected heading plot
-        if len(heading_data.p1_time) > 0:
-            p1_time = heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_corrected:
             heading_deg = yaw_to_heading(heading_data.ypr_deg[0, :])
             yaw_std_deg = heading_data.ypr_std_deg[0, :]
 
@@ -2639,11 +2687,9 @@ figure.on('plotly_hover', function(data) {{
 
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=heading_deg,
-                    customdata=np.stack((p1_time, yaw_std_deg), axis=-1),
+                    x=corrected_time, y=heading_deg,
+                    customdata=np.vstack((corrected_customdata, yaw_std_deg)),
                     name='Heading: Corrected Measurement', legendgroup='corr',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata[0]:.3f} sec)'
-                                  '<br><b>Heading</b>: %{y:.2f} deg (<b>Std</b>: %{customdata[1]:.2f} deg)',
                     mode='markers', marker={"color": "orange"}
                 ),
                 row=1, col=1
@@ -2654,51 +2700,41 @@ figure.on('plotly_hover', function(data) {{
         ########################################
 
         # Baseline vector from raw attitude measurement.
-        if len(raw_heading_data.p1_time) > 0:
-            p1_time = raw_heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_raw:
             baseline_distance_m = np.linalg.norm(raw_heading_data.relative_position_enu_m, axis=0)
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=baseline_distance_m, customdata=p1_time,
+                    x=raw_time, y=baseline_distance_m, customdata=raw_customdata,
                     name='Baseline Distance: Raw Measurement', legendgroup='raw',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Distance</b>: %{y:.2f} m',
                     mode='markers', marker={"color": "purple"}
                 ),
                 row=2, col=1
             )
 
         # Baseline distance from corrected measurement.
-        if len(heading_data.p1_time) > 0:
-            p1_time = heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_corrected:
             baseline_distance_m = heading_data.baseline_distance_m
             baseline_std_m = heading_data.baseline_distance_std_m
 
             # See explanation above about the Plotly bug when the value is NAN.
-            baseline_std_m[np.isnan(yaw_std_deg)] = -1.0
+            baseline_std_m[np.isnan(baseline_std_m)] = -1.0
 
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=baseline_distance_m,
-                    customdata=np.stack((p1_time, baseline_std_m), axis=-1),
+                    x=corrected_time, y=baseline_distance_m,
+                    customdata=np.vstack((corrected_customdata, baseline_std_m)),
                     name='Baseline Distance: Corrected Measurement', legendgroup='corr',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata[0]:.3f} sec)'
-                                  '<br><b>Distance</b>: %{y:.2f} m (<b>Std</b>: %{customdata[1]:.2f} m)',
                     mode='markers', marker={"color": "orange"}
                 ),
                 row=2, col=1
             )
 
         # ENU vector from raw attitude measurement.
-        if len(raw_heading_data.p1_time) > 0:
+        if have_raw:
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=raw_heading_data.relative_position_enu_m[0], customdata=p1_time,
+                    x=raw_time, y=raw_heading_data.relative_position_enu_m[0], customdata=raw_customdata,
                     name='Primary->Secondary (East)',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>East</b>: %{y:.2f} m',
                     mode='markers', marker={"color": "red"}
                 ),
                 row=2, col=1
@@ -2706,10 +2742,8 @@ figure.on('plotly_hover', function(data) {{
 
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=raw_heading_data.relative_position_enu_m[1], customdata=p1_time,
+                    x=raw_time, y=raw_heading_data.relative_position_enu_m[1], customdata=raw_customdata,
                     name='Primary->Secondary (North)',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>North</b>: %{y:.2f} m',
                     mode='markers', marker={"color": "green"}
                 ),
                 row=2, col=1
@@ -2717,10 +2751,8 @@ figure.on('plotly_hover', function(data) {{
 
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=raw_heading_data.relative_position_enu_m[2], customdata=p1_time,
+                    x=raw_time, y=raw_heading_data.relative_position_enu_m[2], customdata=raw_customdata,
                     name='Primary->Secondary (Up)',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Up</b>: %{y:.2f} m',
                     mode='markers', marker={"color": "blue"}
                 ),
                 row=2, col=1
@@ -2731,52 +2763,66 @@ figure.on('plotly_hover', function(data) {{
         ########################################
 
         # Display the navigation engine's solution type.
-        if primary_pose_data is not None:
-            p1_time = primary_pose_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_primary:
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=primary_pose_data.solution_type, customdata=p1_time,
+                    x=primary_time, y=primary_pose_data.solution_type, customdata=primary_customdata,
                     name='Solution Type: Navigation Engine', legendgroup='nav',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Type</b>: %{y}',
                     mode='markers', marker={'color': 'yellow'},
                 ),
                 row=3, col=1
             )
 
         # Display the raw measurement's solution type.
-        if len(raw_heading_data.p1_time) > 0:
-            p1_time = raw_heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_raw:
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=raw_heading_data.solution_type, customdata=p1_time,
+                    x=raw_time, y=raw_heading_data.solution_type, customdata=raw_customdata,
                     name='Solution Type: Raw Measurement', legendgroup='raw',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Type</b>: %{y}',
                     mode='markers', marker={'color': 'purple'},
                 ),
                 row=3, col=1
             )
 
         # Display the corrected measurement's solution type.
-        if len(heading_data.p1_time) > 0:
-            p1_time = heading_data.p1_time
-            time = p1_time - float(self.t0)
+        if have_corrected:
             fig.add_trace(
                 go.Scatter(
-                    x=time, y=heading_data.solution_type, customdata=p1_time,
+                    x=corrected_time, y=heading_data.solution_type, customdata=corrected_customdata,
                     name='Solution Type: Corrected Measurement', legendgroup='corr',
-                    hovertemplate='<b>Time</b>: %{x:.3f} sec (%{customdata:.3f} sec)'
-                                  '<br><b>Type</b>: %{y}',
                     mode='markers', marker={'color': 'orange'},
                 ),
                 row=3, col=1
             )
 
+        # Custom hover function: like _TIME_HOVER_JS, but some traces carry a second customdata row with a standard
+        # deviation value (in degrees for heading traces, meters for baseline distance traces; -1 means not available -
+        # see the Plotly NaN customdata bug noted above).
+        _ATTITUDE_HOVER_JS = """\
+figure.on('plotly_hover', function(data) {
+  for (let i = 0; i < data.points.length; ++i) {
+    let point = data.points[i];
+    if (!point.data.customdata) {
+      continue;
+    }
+    let new_text = BuildTimeHoverText(point.x, GetCustomData(point, 0));
+    let customdata = point.data.customdata.hasOwnProperty("_inputArray") ?
+                     point.data.customdata._inputArray : point.data.customdata;
+    if (customdata.length > 1) {
+      let std = GetCustomData(point, 1);
+      if (std >= 0) {
+        let units = point.data.name.startsWith('Heading') ? 'deg' : 'm';
+        new_text += `<br>Std: ${std.toFixed(2)} ${units}`;
+      }
+    }
+    ChangeHoverText(point, new_text);
+  }
+});
+        """ + self._GPS_TICK_REFORMAT_JS
+
         self._add_figure(name='gnss_attitude_measurement', figure=fig,
-                         title='Measurements: GNSS Attitude (Multi-Antenna Heading Sensor)')
+                         title='Measurements: GNSS Attitude (Multi-Antenna Heading Sensor)',
+                         inject_js=_ATTITUDE_HOVER_JS)
 
     def plot_system_status_profiling(self):
         """!

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -51,6 +51,14 @@ function BuildTimeHoverText(x_value, other_time_sec) {
     p1_time_sec = other_time_sec;
   }
 
+  return BuildTimeHoverTextFromTimes(p1_time_sec, gps_time_sec);
+}
+
+// Same as BuildTimeHoverText(), but for hover text on a plot whose X/Y axes are not time at all (e.g. a topocentric
+// East/North plot), where neither P1 nor GPS time can be recovered from the point's axis position -- both must be
+// supplied directly (e.g. via customdata).
+function BuildTimeHoverTextFromTimes(p1_time_sec, gps_time_sec) {
+  let have_offset = (typeof gps_posix_offset_sec === 'number');
   let lines = [];
 
   if (p1_time_sec !== undefined && p1_time_sec !== null && !isNaN(p1_time_sec)) {

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -9,6 +9,70 @@ function GetTimeText(time_sec) {
   }
 }
 
+// Convert whatever Plotly hands back for a 'date'-type axis point -- a plain number (milliseconds since the Unix
+// epoch), a Date, or a "YYYY-MM-DD HH:MM:SS.ffffff"-ish string, depending on context -- into seconds since the Unix
+// epoch.
+function _DateAxisValueToPosixSec(x_value) {
+  if (typeof x_value === 'number') {
+    return x_value / 1000.0;
+  }
+  if (x_value instanceof Date) {
+    return x_value.getTime() / 1000.0;
+  }
+  return new Date(String(x_value).replace(' ', 'T') + 'Z').getTime() / 1000.0;
+}
+
+// Build multi-format hover text (relative, P1, UTC, GPS week:tow) for a point whose X axis is time_axis_type
+// ('relative', 'p1', 'gps', or 'utc') and whose customdata carries whichever of P1/GPS time is NOT reflected
+// (directly, or via the constant offsets below) by x_value -- see Analyzer._time_hover_customdata().
+//
+// Note that the P1 vs GPS/UTC time relationship can change as the clock model is adjusted, so it is not a constant
+// offset.
+//
+// Note: gps_posix_offset_sec is computed once per log so it includes the log's current leap second count. For
+// simplicity, we assume logs do not span leap second changes. See time_provider.py for details.
+function BuildTimeHoverText(x_value, other_time_sec) {
+  let p1_time_sec, gps_time_sec;
+  let have_offset = (typeof gps_posix_offset_sec === 'number');
+  if (time_axis_type === 'relative') {
+    p1_time_sec = x_value + p1_t0_sec;
+    gps_time_sec = other_time_sec;
+  }
+  else if (time_axis_type === 'p1') {
+    p1_time_sec = x_value;
+    gps_time_sec = other_time_sec;
+  }
+  else if (time_axis_type === 'gps') {
+    gps_time_sec = x_value;
+    p1_time_sec = other_time_sec;
+  }
+  else { // 'utc'
+    gps_time_sec = have_offset ? (_DateAxisValueToPosixSec(x_value) - gps_posix_offset_sec) : NaN;
+    p1_time_sec = other_time_sec;
+  }
+
+  let lines = [];
+
+  if (p1_time_sec !== undefined && p1_time_sec !== null && !isNaN(p1_time_sec)) {
+    let rel_sec = p1_time_sec - p1_t0_sec;
+    lines.push(`Rel: ${rel_sec.toFixed(3)} sec (P1: ${p1_time_sec.toFixed(3)} sec)`);
+  }
+
+  if (gps_time_sec !== undefined && gps_time_sec !== null && !isNaN(gps_time_sec)) {
+    if (have_offset) {
+      let utc_date = new Date((gps_time_sec + gps_posix_offset_sec) * 1000.0);
+      lines.push(`UTC: ${utc_date.toISOString().replace('T', ' ').replace('Z', '')}`);
+    }
+
+    const SECONDS_PER_WEEK = 7 * 24 * 3600.0;
+    let week = Math.floor(gps_time_sec / SECONDS_PER_WEEK);
+    let tow_sec = gps_time_sec - week * SECONDS_PER_WEEK;
+    lines.push(`GPS: ${week}:${tow_sec.toFixed(3)} (${gps_time_sec.toFixed(3)} sec)`);
+  }
+
+  return lines.join('<br>');
+}
+
 function ChangeHoverText(point, new_text) {
   // Note: Technically calling restyle() is more correct, however it can only restyle an entire trace, not just one
   // point in a trace, and in practice it's very sluggish. Manually modifying fullData.text is much faster. Both options
@@ -25,4 +89,37 @@ function GetCustomData(point, row) {
                    point.data.customdata._inputArray :
                    point.data.customdata;
   return customdata[row][point.pointNumber];
+}
+
+// Plotly doesn't support a custom per-tick label formatter function for numeric axes (only D3 format strings), and
+// tickmode='array' with precomputed tick positions/labels doesn't regenerate on zoom/pan -- it only shows whichever
+// of the fixed positions fall in the current view, which can leave a zoomed-in time axis with no visible ticks at
+// all. So instead, for GPS-time axes we let Plotly auto-generate normal (zoom-aware) numeric ticks, then rewrite the
+// already-rendered tick label text into GPS week:tow format after every redraw (initial render, zoom, and pan all
+// trigger 'plotly_afterplot').
+function _ReformatGpsAxisTicks() {
+  if (time_axis_type !== 'gps') {
+    return;
+  }
+  // Plotly names each subplot's X axis tick class after its axis number: 'xtick' for xaxis, 'x2tick' for xaxis2,
+  // etc. -- a plain '.xtick' selector only catches the first subplot.
+  document.querySelectorAll('[class^="x"][class$="tick"] text').forEach(function(el) {
+    // This can run more than once on the same tick across a single zoom/pan (Plotly may fire 'plotly_afterplot'
+    // more than once, reusing the same DOM element). Only reformat plain numbers -- an already-reformatted
+    // "week:tow" string would otherwise get re-parsed and corrupted (parseFloat stops at the ':').
+    let match = el.textContent.match(/^-?([\d,]+)(\.(\d+))?$/);
+    if (!match) {
+      return;
+    }
+    let raw_value = parseFloat(el.textContent.replace(/,/g, ''));
+    if (!isNaN(raw_value)) {
+      const SECONDS_PER_WEEK = 7 * 24 * 3600.0;
+      let week = Math.floor(raw_value / SECONDS_PER_WEEK);
+      let tow_sec = raw_value - week * SECONDS_PER_WEEK;
+      // Match whatever decimal precision Plotly's own tick text already had, rather than always rounding to whole
+      // seconds -- otherwise, zoomed in past 1 second, every tick in view would round to the same displayed value.
+      let decimals = match[3] ? match[3].length : 0;
+      el.textContent = `${week}:${tow_sec.toFixed(decimals)}`;
+    }
+  });
 }

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -1,5 +1,20 @@
 var figure = document.getElementsByClassName("plotly-graph-div js-plotly-plot")[0];
 
+// Build a "<Y axis title>: <value>" hover line straight from the point's own axis, so callers don't need to
+// hardcode a plot-specific label/unit/precision.
+// @param options.precision If set, number of digits after the decimal point (toFixed()). Defaults to 6 significant
+//        digits (toPrecision()), which reads better across very different Y axis scales.
+// @param options.label Override for the Y axis title, if the default isn't appropriate (e.g. no title set).
+function BuildAxisValueHoverText(point, options) {
+  options = options || {};
+  let label = options.label || (point.yaxis.title && point.yaxis.title.text) || 'Value';
+  let value = point.y;
+  if (typeof value === 'number') {
+    value = (typeof options.precision === 'number') ? value.toFixed(options.precision) : value.toPrecision(6);
+  }
+  return `${label}: ${value}`;
+}
+
 function GetTimeText(time_sec) {
   if (p1_time_axis_rel) {
     return `Rel: ${time_sec.toFixed(3)} sec (P1: ${(time_sec + p1_t0_sec).toFixed(3)} sec)`;
@@ -114,6 +129,161 @@ function GetCustomData(point, row) {
                    point.data.customdata._inputArray :
                    point.data.customdata;
   return customdata[row][point.pointNumber];
+}
+
+// PROTOTYPE: a custom tooltip drawn directly by us, positioned at the hovered point via
+// 'plotly_hover'/'plotly_unhover', instead of relying on Plotly's native hover label + ChangeHoverText(). Plotly
+// renders its own hover label as part of its internal mousemove handling, separately from our injected
+// 'plotly_hover' listener -- there's no guaranteed order between "Plotly reads fullData.text to draw its label"
+// and "our handler mutates fullData.text", so on plots with many traces (more work for Plotly's internal
+// hit-testing, more timing variance) the label sometimes renders before our mutation lands, showing stale or no
+// extra text until the next mousemove. Drawing our own tooltip synchronously inside the same handler that computes
+// the text eliminates that race entirely -- there's nothing left for an external renderer to read at the wrong
+// time. Requires hoverinfo='none' on the trace so Plotly's native label doesn't also try to draw at the same time.
+//
+// Styled to resemble Plotly's own hover label: background matches the trace's color, font matches
+// layout.hoverlabel.font, and it's positioned like Plotly's does -- an arrow-and-box to the right of the point,
+// flipping to the left near the plot's right edge, vertically centered on the point.
+var _customTooltipDiv = null;
+var _customTooltipArrowDiv = null;
+var _customTooltipArrowBorderDiv = null;
+const _CUSTOM_TOOLTIP_ARROW_SIZE = 6;
+const _CUSTOM_TOOLTIP_GAP = 2;
+const _CUSTOM_TOOLTIP_BORDER_WIDTH = 1;
+
+function _GetCustomTooltipDiv() {
+  if (_customTooltipDiv === null) {
+    _customTooltipDiv = document.createElement('div');
+    _customTooltipDiv.style.position = 'fixed';
+    _customTooltipDiv.style.pointerEvents = 'none';
+    _customTooltipDiv.style.borderRadius = '2px';
+    _customTooltipDiv.style.border = _CUSTOM_TOOLTIP_BORDER_WIDTH + 'px solid black';
+    _customTooltipDiv.style.padding = '2px 4px';
+    _customTooltipDiv.style.zIndex = '10000';
+    _customTooltipDiv.style.display = 'none';
+    _customTooltipDiv.style.whiteSpace = 'nowrap';
+    document.body.appendChild(_customTooltipDiv);
+
+    // Drawn one size larger and directly behind the fill arrow below, so only a 1px black rim peeks out along the
+    // two slanted edges. Its flat (base) edge lines up exactly with the fill's, staying hidden behind/flush with
+    // the box's own border.
+    _customTooltipArrowBorderDiv = document.createElement('div');
+    _customTooltipArrowBorderDiv.style.position = 'fixed';
+    _customTooltipArrowBorderDiv.style.pointerEvents = 'none';
+    _customTooltipArrowBorderDiv.style.width = '0';
+    _customTooltipArrowBorderDiv.style.height = '0';
+    _customTooltipArrowBorderDiv.style.zIndex = '10000';
+    _customTooltipArrowBorderDiv.style.display = 'none';
+    document.body.appendChild(_customTooltipArrowBorderDiv);
+
+    _customTooltipArrowDiv = document.createElement('div');
+    _customTooltipArrowDiv.style.position = 'fixed';
+    _customTooltipArrowDiv.style.pointerEvents = 'none';
+    _customTooltipArrowDiv.style.width = '0';
+    _customTooltipArrowDiv.style.height = '0';
+    _customTooltipArrowDiv.style.borderTop = _CUSTOM_TOOLTIP_ARROW_SIZE + 'px solid transparent';
+    _customTooltipArrowDiv.style.borderBottom = _CUSTOM_TOOLTIP_ARROW_SIZE + 'px solid transparent';
+    _customTooltipArrowDiv.style.zIndex = '10000';
+    _customTooltipArrowDiv.style.display = 'none';
+    document.body.appendChild(_customTooltipArrowDiv);
+  }
+  return _customTooltipDiv;
+}
+
+// Resolve an arbitrary CSS color string (hex, rgb(), named color, ...) to a readable text color (black or white),
+// the same way Plotly picks contrasting text for its own colored hover labels.
+function _GetContrastingTextColor(css_color) {
+  let probe = document.createElement('div');
+  probe.style.display = 'none';
+  probe.style.color = css_color;
+  document.body.appendChild(probe);
+  let computed = getComputedStyle(probe).color;
+  document.body.removeChild(probe);
+
+  let m = computed.match(/\d+/g);
+  if (!m || m.length < 3) {
+    return '#000';
+  }
+  let luminance = (0.299 * m[0] + 0.587 * m[1] + 0.114 * m[2]) / 255;
+  return luminance > 0.6 ? '#000' : '#fff';
+}
+
+// @param point A point from a 'plotly_hover' event (data.points[i]) -- used for its data value (to compute pixel
+//        position via point.xaxis/yaxis) and its trace's color (point.data.marker/line.color).
+// @param html_text The tooltip content.
+function ShowCustomTooltip(point, html_text) {
+  let div = _GetCustomTooltipDiv();
+  let arrow = _customTooltipArrowDiv;
+  let arrow_border = _customTooltipArrowBorderDiv;
+  const B = _CUSTOM_TOOLTIP_BORDER_WIDTH;
+
+  let bgcolor = (point.data.marker && point.data.marker.color) || (point.data.line && point.data.line.color) ||
+               '#444';
+  let hoverlabel_font = (figure._fullLayout.hoverlabel && figure._fullLayout.hoverlabel.font) || {};
+
+  div.innerHTML = html_text;
+  div.style.backgroundColor = bgcolor;
+  div.style.color = _GetContrastingTextColor(bgcolor);
+  div.style.fontFamily = hoverlabel_font.family || 'Arial, sans-serif';
+  div.style.fontSize = (hoverlabel_font.size || 13) + 'px';
+
+  // Compute the point's own pixel position (not just wherever the mouse currently is) so the box and arrow align
+  // precisely with the marker, the way Plotly's native label does.
+  let rect = figure.getBoundingClientRect();
+  // d2l() converts the raw data value (a plain number for linear axes, but a formatted date string for date axes)
+  // into the axis's internal linearized coordinate that l2p() expects -- passing point.x/point.y to l2p() directly
+  // works for numeric axes but silently yields NaN on a date axis (e.g. UTC time), leaving the tooltip unpositioned.
+  let x_px = rect.left + point.xaxis.l2p(point.xaxis.d2l(point.x)) + point.xaxis._offset;
+  let y_px = rect.top + point.yaxis.l2p(point.yaxis.d2l(point.y)) + point.yaxis._offset;
+
+  // Render invisibly first so we can measure its size before deciding where to place it.
+  div.style.visibility = 'hidden';
+  div.style.display = 'block';
+  let box_width = div.offsetWidth;
+  let box_height = div.offsetHeight;
+
+  let draw_right = (x_px + _CUSTOM_TOOLTIP_ARROW_SIZE + _CUSTOM_TOOLTIP_GAP + box_width) <= rect.right;
+
+  let box_left, arrow_left, border_left;
+  arrow_border.style.borderTop = (_CUSTOM_TOOLTIP_ARROW_SIZE + B) + 'px solid transparent';
+  arrow_border.style.borderBottom = (_CUSTOM_TOOLTIP_ARROW_SIZE + B) + 'px solid transparent';
+  if (draw_right) {
+    box_left = x_px + _CUSTOM_TOOLTIP_ARROW_SIZE + _CUSTOM_TOOLTIP_GAP;
+    arrow_left = x_px + _CUSTOM_TOOLTIP_GAP;
+    border_left = arrow_left - B;
+    arrow.style.borderLeft = '';
+    arrow.style.borderRight = _CUSTOM_TOOLTIP_ARROW_SIZE + 'px solid ' + bgcolor;
+    arrow_border.style.borderLeft = '';
+    arrow_border.style.borderRight = (_CUSTOM_TOOLTIP_ARROW_SIZE + B) + 'px solid black';
+  } else {
+    box_left = x_px - _CUSTOM_TOOLTIP_ARROW_SIZE - _CUSTOM_TOOLTIP_GAP - box_width;
+    arrow_left = x_px - _CUSTOM_TOOLTIP_ARROW_SIZE - _CUSTOM_TOOLTIP_GAP;
+    border_left = arrow_left;
+    arrow.style.borderRight = '';
+    arrow.style.borderLeft = _CUSTOM_TOOLTIP_ARROW_SIZE + 'px solid ' + bgcolor;
+    arrow_border.style.borderRight = '';
+    arrow_border.style.borderLeft = (_CUSTOM_TOOLTIP_ARROW_SIZE + B) + 'px solid black';
+  }
+
+  div.style.left = box_left + 'px';
+  div.style.top = (y_px - box_height / 2) + 'px';
+  div.style.visibility = 'visible';
+
+  arrow.style.left = arrow_left + 'px';
+  arrow.style.top = (y_px - _CUSTOM_TOOLTIP_ARROW_SIZE) + 'px';
+  arrow.style.display = 'block';
+
+  arrow_border.style.left = border_left + 'px';
+  arrow_border.style.top = (y_px - _CUSTOM_TOOLTIP_ARROW_SIZE - B) + 'px';
+  arrow_border.style.display = 'block';
+}
+
+function HideCustomTooltip() {
+  if (_customTooltipDiv !== null) {
+    _customTooltipDiv.style.display = 'none';
+    _customTooltipArrowDiv.style.display = 'none';
+    _customTooltipArrowBorderDiv.style.display = 'none';
+  }
 }
 
 // Plotly doesn't support a custom per-tick label formatter function for numeric axes (only D3 format strings), and

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -10,9 +10,16 @@ function BuildAxisValueHoverText(point, options) {
   let label = options.label !== undefined ? options.label :
                                             ((point.yaxis.title && point.yaxis.title.text) || 'Value');
   let value = point.y;
-  if (typeof value === 'number') {
+
+  // Categorical axis (e.g. Solution Type, Gear/Direction) -- show the tick label instead of the raw enum number.
+  let tick_idx = (point.yaxis.tickvals || []).indexOf(value);
+  if (tick_idx >= 0 && point.yaxis.ticktext) {
+    value = point.yaxis.ticktext[tick_idx];
+  }
+  else if (typeof value === 'number') {
     value = (typeof options.precision === 'number') ? value.toFixed(options.precision) : value.toPrecision(6);
   }
+
   if (label.length > 0) {
     return `${label}: ${value}`;
   }

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -83,13 +83,17 @@ function BuildTimeHoverTextFromTimes(p1_time_sec, gps_time_sec) {
 
 function ChangeHoverText(point, new_text) {
   // Note: Technically calling restyle() is more correct, however it can only restyle an entire trace, not just one
-  // point in a trace, and in practice it's very sluggish. Manually modifying fullData.text is much faster. Both options
-  // seem to have a small race condition and occasionally the text does not change before the hover div becomes visible.
-  // Nothing we can do about that right now.
-  // let text_array = point.data.text;
-  // text_array[point.pointNumber] = new_text;
-  // Plotly.restyle(d, {'text': text_array}, [point.curveNumber]);
-  point.fullData.text = new_text;
+  // point in a trace, and in practice it's very sluggish. Manually modifying fullData.text is much faster.
+  //
+  // fullData.text must stay an array indexed by pointNumber, not a single string -- Plotly treats a plain string as
+  // shared text for every point in the trace. Setting it that way here previously caused the hover box to always
+  // display whichever point was hovered *previously*: hovering point A set the whole trace's text to A's value: only
+  // on the *next* hover (now on point B) would it be overwritten, by which point the still-stale text for A had
+  // already been rendered. Mutating a single array slot for this point avoids touching every other point's entry.
+  if (!Array.isArray(point.fullData.text)) {
+    point.fullData.text = [];
+  }
+  point.fullData.text[point.pointNumber] = new_text;
 }
 
 function GetCustomData(point, row) {

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -208,6 +208,26 @@ function _GetContrastingTextColor(css_color) {
   return luminance > 0.6 ? '#000' : '#fff';
 }
 
+function GetCustomTooltipHTML(name, value, other_text) {
+  let tooltip = ``;
+  if (name) {
+    tooltip += `<b>${name}</b>`;
+  }
+  if (value) {
+    if (tooltip) {
+      tooltip += `<br>`;
+    }
+    tooltip += `${value}`;
+  }
+  if (other_text) {
+    if (tooltip) {
+      tooltip += `<br>`;
+    }
+    tooltip += `${other_text}`;
+  }
+  return tooltip;
+}
+
 // @param point A point from a 'plotly_hover' event (data.points[i]) -- used for its data value (to compute pixel
 //        position via point.xaxis/yaxis) and its trace's color (point.data.marker/line.color).
 // @param html_text The tooltip content.

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -7,12 +7,18 @@ var figure = document.getElementsByClassName("plotly-graph-div js-plotly-plot")[
 // @param options.label Override for the Y axis title, if the default isn't appropriate (e.g. no title set).
 function BuildAxisValueHoverText(point, options) {
   options = options || {};
-  let label = options.label || (point.yaxis.title && point.yaxis.title.text) || 'Value';
+  let label = options.label !== undefined ? options.label :
+                                            ((point.yaxis.title && point.yaxis.title.text) || 'Value');
   let value = point.y;
   if (typeof value === 'number') {
     value = (typeof options.precision === 'number') ? value.toFixed(options.precision) : value.toPrecision(6);
   }
-  return `${label}: ${value}`;
+  if (label.length > 0) {
+    return `${label}: ${value}`;
+  }
+  else {
+    return `${value}`;
+  }
 }
 
 function GetTimeText(time_sec) {

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -144,9 +144,10 @@ function GetCustomData(point, row) {
   return customdata[row][point.pointNumber];
 }
 
-// PROTOTYPE: a custom tooltip drawn directly by us, positioned at the hovered point via
-// 'plotly_hover'/'plotly_unhover', instead of relying on Plotly's native hover label + ChangeHoverText(). Plotly
-// renders its own hover label as part of its internal mousemove handling, separately from our injected
+// Draw a custom mouse hover/tooltip box (by handling 'plotly_hover'/'plotly_unhover' manually), rather than use
+// Plotly's built-in box and just changing the text by calling ChangeHoverText().
+//
+// Plotly renders its own hover label as part of its internal mousemove handling, separately from our injected
 // 'plotly_hover' listener -- there's no guaranteed order between "Plotly reads fullData.text to draw its label"
 // and "our handler mutates fullData.text", so on plots with many traces (more work for Plotly's internal
 // hit-testing, more timing variance) the label sometimes renders before our mutation lands, showing stale or no

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -81,6 +81,19 @@ function BuildTimeHoverTextFromTimes(p1_time_sec, gps_time_sec) {
   return lines.join('<br>');
 }
 
+// Build hover text for a point on a device system-time axis (relative or absolute, per Analyzer.time_type).
+// Unlike BuildTimeHoverText(), there's no GPS-like alternate domain to convert to/from here -- system_t0_sec is a
+// constant offset for the whole log, so the absolute value is always recoverable from x_value alone, with no
+// per-point customdata needed.
+function BuildSystemTimeHoverText(x_value) {
+  if (typeof system_t0_sec !== 'number') {
+    return `System Time: ${x_value.toFixed(3)} sec`;
+  }
+  else {
+    return `System Time: ${(x_value + system_t0_sec).toFixed(3)} sec`;
+  }
+}
+
 function ChangeHoverText(point, new_text) {
   // Note: Technically calling restyle() is more correct, however it can only restyle an entire trace, not just one
   // point in a trace, and in practice it's very sluggish. Manually modifying fullData.text is much faster.

--- a/python/fusion_engine_client/messages/defs.py
+++ b/python/fusion_engine_client/messages/defs.py
@@ -830,3 +830,28 @@ def heading_to_yaw(heading: Union[float, np.ndarray], deg: bool = True):
         yaw_rad = math.pi / 2.0 - heading
         yaw_rad = (yaw_rad + math.pi) % (2.0 * math.pi) - math.pi
         return np.where(yaw_rad == math.pi, -math.pi, yaw_rad)
+
+def percent_to_fixed_point(percent: float, scale: float = 2.0, tolerance: float = 0.999) -> int:
+    """!
+    @brief Convert a percentage to a fixed-point integer for packing, rounding down except when the value is
+           within floating-point noise of the next integer.
+
+    Percentages are always rounded down so we don't report reaching a milestone (e.g., 100%) before it's actually
+    reached (e.g., truncating 99.6% to 99, not rounding it up to 100). The `tolerance` exception exists only to
+    correct for floating-point representation error in values that were intended to land exactly on an integer
+    (e.g., 49.99999997 meant to be 50.0) -- it is not a general round-to-nearest.
+
+    @param percent The percentage value to convert, in `[0, 100]`.
+    @param scale The fixed-point scale factor (e.g., `2.0` to store 0.5% increments in a single byte).
+    @param tolerance How close (as a fraction of `scale`) `percent * scale` must be to the next integer to be
+           rounded up instead of down. `0.999` means within `0.1%` of `scale` (e.g., within `0.002` for
+           `scale=2.0`).
+
+    @return The scaled, floored (or ceiling-snapped) integer value.
+    """
+    scaled = percent * scale
+    ceil_scaled = math.ceil(scaled)
+    if ceil_scaled - scaled < (1.0 - tolerance) * scale:
+        return int(ceil_scaled)
+    else:
+        return int(math.floor(scaled))

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -1121,8 +1121,8 @@ class CalibrationStatus(MessagePayload):
         self._STRUCT.pack_into(
             buffer, offset,
             self.calibration_stage,
-            self.ypr_deg[0], self.ypr_deg[2], self.ypr_deg[3],
-            self.ypr_std_dev_deg[0], self.ypr_std_dev_deg[2], self.ypr_std_dev_deg[3],
+            self.ypr_deg[0], self.ypr_deg[1], self.ypr_deg[2],
+            self.ypr_std_dev_deg[0], self.ypr_std_dev_deg[1], self.ypr_std_dev_deg[2],
             self.travel_distance_m,
             self.state_verified,
             self.gyro_bias_percent_complete * 2.0,

--- a/python/fusion_engine_client/messages/solution.py
+++ b/python/fusion_engine_client/messages/solution.py
@@ -1125,9 +1125,9 @@ class CalibrationStatus(MessagePayload):
             self.ypr_std_dev_deg[0], self.ypr_std_dev_deg[1], self.ypr_std_dev_deg[2],
             self.travel_distance_m,
             self.state_verified,
-            self.gyro_bias_percent_complete * 2.0,
-            self.accel_bias_percent_complete * 2.0,
-            self.mounting_angle_percent_complete * 2.0,
+            percent_to_fixed_point(self.gyro_bias_percent_complete, scale=2.0),
+            percent_to_fixed_point(self.accel_bias_percent_complete, scale=2.0),
+            percent_to_fixed_point(self.mounting_angle_percent_complete, scale=2.0),
             self.min_travel_distance_m,
             self.mounting_angle_max_std_dev_deg[0], self.mounting_angle_max_std_dev_deg[1],
             self.mounting_angle_max_std_dev_deg[2])
@@ -1148,9 +1148,9 @@ class CalibrationStatus(MessagePayload):
          self.ypr_std_dev_deg[0], self.ypr_std_dev_deg[1], self.ypr_std_dev_deg[2],
          self.travel_distance_m,
          self.state_verified,
-         self.gyro_bias_percent_complete,
-         self.accel_bias_percent_complete,
-         self.mounting_angle_percent_complete,
+         gyro_bias_percent_complete_int,
+         accel_bias_percent_complete_int,
+         mounting_angle_percent_complete_int,
          self.min_travel_distance_m,
          self.mounting_angle_max_std_dev_deg[0], self.mounting_angle_max_std_dev_deg[1],
          self.mounting_angle_max_std_dev_deg[2]) = \
@@ -1159,9 +1159,9 @@ class CalibrationStatus(MessagePayload):
 
         self.calibration_stage = CalibrationStage(self.calibration_stage)
 
-        self.gyro_bias_percent_complete /= 2.0
-        self.accel_bias_percent_complete /= 2.0
-        self.mounting_angle_percent_complete /= 2.0
+        self.gyro_bias_percent_complete = gyro_bias_percent_complete_int / 2.0
+        self.accel_bias_percent_complete = accel_bias_percent_complete_int / 2.0
+        self.mounting_angle_percent_complete = mounting_angle_percent_complete_int / 2.0
 
         return offset - initial_offset
 

--- a/python/fusion_engine_client/utils/time_provider.py
+++ b/python/fusion_engine_client/utils/time_provider.py
@@ -1,11 +1,15 @@
-from typing import Optional, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 from datetime import datetime, timedelta
 
-from gpstime import gpstime
+from gpstime import gpstime, gps2unix
+import numpy as np
 
 from ..messages import MessageHeader, MessagePayload, PoseMessage, Timestamp
 from ..utils import trace as logging
+
+if TYPE_CHECKING:
+    from ..analysis.data_loader import DataLoader
 
 _logger = logging.getLogger('point_one.fusion_engine.utils.time_provider')
 
@@ -13,6 +17,11 @@ _logger = logging.getLogger('point_one.fusion_engine.utils.time_provider')
 class TimeProvider:
     """!
     @brief Utility for converting between P1 and GPS time.
+
+    Time relationships may be learned sequentially, by feeding in FusionEngine messages in real time (see @ref
+    handle_message()), or in bulk, by loading recorded data from an existing log (see @ref set_reference_data()). The
+    time conversion functions (@ref p1_to_gps(), @ref gps_to_p1()) support both scalar (`Timestamp`/`datetime`) or
+    vectorized (`numpy.ndarray`) input arguments, and their return types match the argument type.
     """
     def __init__(self):
         self._current_p1_time = Timestamp()
@@ -20,15 +29,92 @@ class TimeProvider:
         self._prev_p1_time = Timestamp()
         self._prev_gps_time = Timestamp()
 
+        # Bulk P1/GPS correspondence table, used for vectorized conversions. Populated by set_reference_data().
+        self._reference_p1_time = np.array([])
+        self._reference_gps_time = np.array([])
+
     def reset(self):
         self._current_p1_time = Timestamp()
         self._current_gps_time = Timestamp()
         self._prev_p1_time = Timestamp()
         self._prev_gps_time = Timestamp()
 
+    def set_reference_data(self, reader: 'DataLoader', source_id: Optional[int] = None):
+        """!
+        @brief Load time correspondence data from a recorded log file.
+
+        This is intended for offline/post-processing use (e.g., generating plots from an entire log), where the full
+        time relationships are available up front. For real-time operation, see @ref handle_message().
+
+        @param reader The @ref DataLoader to read time data from.
+        @param source_id If specified, only load time data from this source identifier.
+        """
+        result = reader.read(message_types=[PoseMessage], source_ids=source_id, return_numpy=True)
+        pose_data = result[PoseMessage.MESSAGE_TYPE]
+
+        valid = ~np.isnan(pose_data.p1_time) & ~np.isnan(pose_data.gps_time)
+        p1_time = pose_data.p1_time[valid]
+        gps_time = pose_data.gps_time[valid]
+
+        # P1 time is monotonic within a single boot session, but resets to 0 after a device reboot, so a reset splits
+        # the data into multiple per-session segments. If those segments' P1 time ranges don't overlap, a given P1 time
+        # can only belong to one session, so we can safely combine them into a single table sorted by P1 time.
+        # Otherwise, the same P1 time could mean two different real times, so we can only safely use the most recent
+        # (last) session.
+        segments = self._split_into_boot_segments(p1_time, gps_time)
+        if len(segments) > 1 and not self._segments_mutually_exclusive(segments):
+            _logger.warning('Detected %d device reset(s) in pose data used for time reference, with overlapping P1 '
+                            'time ranges across boot sessions. Only using data from the most recent session (%d of '
+                            '%d samples).' % (len(segments) - 1, len(segments[-1][0]), len(p1_time)))
+            segments = segments[-1:]
+
+        if len(segments) > 0:
+            p1_time = np.concatenate([s[0] for s in segments])
+            gps_time = np.concatenate([s[1] for s in segments])
+            order = np.argsort(p1_time)
+            p1_time = p1_time[order]
+            gps_time = gps_time[order]
+
+        # Drop non-increasing entries (e.g., duplicate timestamps) so later interpolation can assume P1 time is
+        # strictly increasing.
+        if len(p1_time) > 0:
+            keep = np.concatenate(([True], np.diff(p1_time) > 0))
+            p1_time = p1_time[keep]
+            gps_time = gps_time[keep]
+
+        self._reference_p1_time = p1_time
+        self._reference_gps_time = gps_time
+
+    @staticmethod
+    def _split_into_boot_segments(p1_time: np.ndarray, gps_time: np.ndarray) -> list:
+        """!
+        @brief Split chronologically-ordered entries into contiguous per-boot-session segments, splitting wherever
+               P1 time jumps backward (i.e., a device reset).
+
+        @return A list of `(p1_time, gps_time)` `ndarray` pairs, one per boot session.
+        """
+        if len(p1_time) == 0:
+            return []
+        reset_idx = np.nonzero(np.diff(p1_time) < -1e-3)[0]
+        boundaries = np.concatenate(([0], reset_idx + 1, [len(p1_time)]))
+        return [(p1_time[boundaries[i]:boundaries[i + 1]], gps_time[boundaries[i]:boundaries[i + 1]])
+                for i in range(len(boundaries) - 1)]
+
+    @staticmethod
+    def _segments_mutually_exclusive(segments: list) -> bool:
+        """!
+        @brief Test whether a list of `(p1_time, gps_time)` boot session segments have non-overlapping P1 time
+               ranges, i.e., whether a given P1 time can unambiguously be attributed to a single session.
+        """
+        ranges = sorted((p1_time[0], p1_time[-1]) for p1_time, _ in segments)
+        return all(ranges[i][1] < ranges[i + 1][0] for i in range(len(ranges) - 1))
+
     def handle_message(self, message: MessagePayload, header: Optional[MessageHeader] = None):
         """!
         @brief Learn time relationships from incoming FusionEngine messages.
+
+        This is intended for handling incoming messages in real time. For post-processing operation, see @ref
+        set_reference_data().
 
         @param header The message header (optional).
         @param message The message payload.
@@ -73,17 +159,25 @@ Received time update ({message.get_type()} message) at:
   P1/GPS: {scale_sps_str}
 """)
 
-    def p1_to_gps(self, p1_time: Timestamp, format: str = 'timestamp') -> Union[Timestamp, datetime]:
+    def p1_to_gps(self, p1_time: Union[Timestamp, np.ndarray], format: str = 'timestamp') -> \
+            Union[Timestamp, datetime, np.ndarray]:
         """!
-        @brief Convert a P1 timestamp to GPS time.
+        @brief Convert a P1 timestamp (or array of P1 timestamps) to GPS time.
 
-        @param p1_time The P1 time to convert.
+        @param p1_time The P1 time to convert, either a FusionEngine @ref Timestamp object, or a `numpy.ndarray` of P1
+               times in seconds.
         @param format The desired output format:
-               - `timestamp` - A FusionEngine @ref Timestamp object
-               - `datetime` - A Python `datetime` object with the corresponding UTC time
+               - `timestamp` - A FusionEngine @ref Timestamp object, or an `ndarray` of GPS times in seconds
+               - `datetime` - A Python `datetime` object, or an `ndarray` of `datetime64[ns]` UTC times
 
-        @return The resulting GPS time, or an invalid timestamp if the time could not be converted.
+        @return The resulting GPS time, matching the input type (invalid entries are NaN/NaT).
         """
+        if isinstance(p1_time, np.ndarray):
+            return self._p1_to_gps_array(p1_time, format)
+        else:
+            return self._p1_to_gps_scalar(p1_time, format)
+
+    def _p1_to_gps_scalar(self, p1_time: Timestamp, format: str = 'timestamp') -> Union[Timestamp, datetime]:
         if not p1_time:
             _logger.trace('Cannot convert invalid P1 time to GPS time.')
             if format == 'datetime':
@@ -121,14 +215,33 @@ Received time update ({message.get_type()} message) at:
         else:
             return gps_time
 
-    def gps_to_p1(self, gps_time: Union[Timestamp, datetime, gpstime]) -> Timestamp:
+    def _p1_to_gps_array(self, p1_time: np.ndarray, format: str) -> np.ndarray:
+        xp, fp = self._reference_p1_time, self._reference_gps_time
+        if len(xp) == 0:
+            xp, fp = self._fallback_reference()
+
+        gps_time = self._interp_extrap(np.asarray(p1_time, dtype=float), xp, fp)
+
+        if format == 'datetime':
+            return self._gps_sec_to_datetime64_array(gps_time)
+        else:
+            return gps_time
+
+    def gps_to_p1(self, gps_time: Union[Timestamp, datetime, gpstime, np.ndarray]) -> Union[Timestamp, np.ndarray]:
         """!
-        @brief Convert a GPS timestamp to P1 time.
+        @brief Convert a GPS timestamp (or array of GPS timestamps) to P1 time.
 
-        @param gps_time The GPS time (or UTC `datetime`) to convert.
+        @param gps_time The GPS time (or UTC `datetime`) to convert, or a `numpy.ndarray` of GPS times in seconds.
 
-        @return The resulting P1 time, or an invalid timestamp if the time could not be converted.
+        @return The resulting P1 time, matching the input type (an invalid timestamp, or NaN entries, if the time
+                could not be converted).
         """
+        if isinstance(gps_time, np.ndarray):
+            return self._gps_to_p1_array(gps_time)
+        else:
+            return self._gps_to_p1_scalar(gps_time)
+
+    def _gps_to_p1_scalar(self, gps_time: Union[Timestamp, datetime, gpstime]) -> Timestamp:
         if not gps_time:
             _logger.trace('Cannot convert invalid GPS time to P1 time.')
             return Timestamp()
@@ -158,4 +271,64 @@ Received time update ({message.get_type()} message) at:
         if _logger.isEnabledFor(logging.TRACE):
             _logger.trace('Converted GPS %s to P1 %s.', gps_time.to_gps_str(), p1_time.to_p1_str())
         return p1_time
+
+    def _gps_to_p1_array(self, gps_time: np.ndarray) -> np.ndarray:
+        xp, fp = self._reference_gps_time, self._reference_p1_time
+        if len(xp) == 0:
+            fp, xp = self._fallback_reference()
+
+        return self._interp_extrap(np.asarray(gps_time, dtype=float), xp, fp)
+
+    def _fallback_reference(self) -> (np.ndarray, np.ndarray):
+        """!
+        @brief Build a (p1_time, gps_time) reference table from the current sequential state, for use when no bulk
+               reference table has been loaded via @ref set_reference_data().
+
+        @return A tuple `(p1_time, gps_time)` `ndarray`s with 0, 1, or 2 entries.
+        """
+        if not self._current_p1_time or not self._current_gps_time:
+            return np.array([]), np.array([])
+        elif self._prev_p1_time and self._prev_gps_time:
+            return (np.array([float(self._prev_p1_time), float(self._current_p1_time)]),
+                    np.array([float(self._prev_gps_time), float(self._current_gps_time)]))
+        else:
+            return np.array([float(self._current_p1_time)]), np.array([float(self._current_gps_time)])
+
+    @staticmethod
+    def _interp_extrap(query: np.ndarray, xp: np.ndarray, fp: np.ndarray) -> np.ndarray:
+        """!
+        @brief Vectorized linear interpolation across a reference table, extrapolating beyond either end using the
+               nearest segment's slope.
+
+        @param query The query points.
+        @param xp Reference table domain values, strictly increasing.
+        @param fp Reference table range values, one per entry in `xp`.
+
+        @return The interpolated/extrapolated values, one per entry in `query`. NaN if `xp` is empty.
+        """
+        n = len(xp)
+        if n == 0:
+            return np.full_like(query, np.nan, dtype=float)
+        elif n == 1:
+            return query + (fp[0] - xp[0])
+        else:
+            idx = np.clip(np.searchsorted(xp, query), 1, n - 1)
+            x0, x1 = xp[idx - 1], xp[idx]
+            f0, f1 = fp[idx - 1], fp[idx]
+            return f0 + (f1 - f0) * (query - x0) / (x1 - x0)
+
+    @staticmethod
+    def _gps_sec_to_datetime64_array(gps_time_sec: np.ndarray) -> np.ndarray:
+        """!
+        @brief Vectorized conversion of GPS times (in seconds) to UTC `datetime64[ns]`.
+        """
+        result = np.full(gps_time_sec.shape, np.datetime64('NaT'), dtype='datetime64[ns]')
+        valid = ~np.isnan(gps_time_sec)
+        if np.any(valid):
+            # The GPS/UTC offset is constant aside from leap seconds, so compute it once from a representative
+            # sample and apply it to the whole array, rather than converting one value at a time.
+            ref_gps_sec = gps_time_sec[valid][0]
+            posix_offset_sec = gps2unix(ref_gps_sec) - ref_gps_sec
+            result[valid] = ((gps_time_sec[valid] + posix_offset_sec) * 1e9).astype('datetime64[ns]')
+        return result
 

--- a/python/fusion_engine_client/utils/time_provider.py
+++ b/python/fusion_engine_client/utils/time_provider.py
@@ -103,6 +103,9 @@ class TimeProvider:
         @brief Split chronologically-ordered entries into contiguous per-boot-session segments, splitting wherever
                P1 time jumps backward (i.e., a device reset).
 
+        @param p1_time Chronologically-ordered P1 times.
+        @param gps_time The corresponding GPS times, one per entry in `p1_time`.
+
         @return A list of `(p1_time, gps_time)` `ndarray` pairs, one per boot session.
         """
         if len(p1_time) == 0:
@@ -135,6 +138,11 @@ class TimeProvider:
         """!
         @brief Test whether a list of `(p1_time, gps_time)` boot session segments have non-overlapping P1 time
                ranges, i.e., whether a given P1 time can unambiguously be attributed to a single session.
+
+        @param segments A list of `(p1_time, gps_time)` `ndarray` pairs, as returned by
+               @ref _split_into_boot_segments().
+
+        @return `True` if no two segments' P1 time ranges overlap.
         """
         ranges = sorted((p1_time[0], p1_time[-1]) for p1_time, _ in segments)
         return all(ranges[i][1] < ranges[i + 1][0] for i in range(len(ranges) - 1))
@@ -361,13 +369,17 @@ Received time update ({message.get_type()} message) at:
     @staticmethod
     def _gps_sec_to_datetime64_array(gps_time_sec: np.ndarray) -> np.ndarray:
         """!
-        @brief Vectorized conversion of GPS times (in seconds) to UTC `datetime64[ns]`.
+        @brief Convert an array of GPS times (in seconds) to UTC (`datetime64[ns]`).
+
+        @param gps_time_sec The GPS times to be converted (in seconds).
+
+        @return An array of Python `datetime64` values representing the corresponding UTC time (in nanoseconds).
         """
         result = np.full(gps_time_sec.shape, np.datetime64('NaT'), dtype='datetime64[ns]')
         valid = ~np.isnan(gps_time_sec)
         if np.any(valid):
-            # The GPS/UTC offset is constant aside from leap seconds, so compute it once from a representative
-            # sample and apply it to the whole array, rather than converting one value at a time.
+            # For simplicity, we're assuming the data does not span a leap second changeover, so we can just compute a
+            # single offset and apply it to all timestamps. See explanation in set_reference_data().
             ref_gps_sec = gps_time_sec[valid][0]
             posix_offset_sec = gps2unix(ref_gps_sec) - ref_gps_sec
             result[valid] = ((gps_time_sec[valid] + posix_offset_sec) * 1e9).astype('datetime64[ns]')

--- a/python/fusion_engine_client/utils/time_provider.py
+++ b/python/fusion_engine_client/utils/time_provider.py
@@ -8,6 +8,7 @@ import numpy as np
 from ..messages import MessageHeader, MessagePayload, PoseMessage, Timestamp
 from ..messages.timestamp import is_gps_time
 from ..utils import trace as logging
+from ..utils.numpy_utils import find_first
 
 if TYPE_CHECKING:
     from ..analysis.data_loader import DataLoader
@@ -38,6 +39,9 @@ class TimeProvider:
         # set_reference_data().
         self._p1_time_is_gps = False
 
+        # Offset between GPS time and the POSIX epoch, computed and cached in set_reference_data().
+        self._gps_posix_offset_sec = None
+
     def reset(self):
         self._current_p1_time = Timestamp()
         self._current_gps_time = Timestamp()
@@ -61,41 +65,63 @@ class TimeProvider:
         # single sample looks like a GPS timestamp, that's conclusive -- a boot-relative counter cannot accidentally
         # cross into GPS-timestamp-sized values. In that case, P1 time can be used as GPS time directly, with no
         # interpolation needed at all (see @ref is_p1_gps_time()).
-        valid_p1_time = pose_data.p1_time[~np.isnan(pose_data.p1_time)]
-        self._p1_time_is_gps = bool(np.any(is_gps_time(valid_p1_time)))
+        p1_valid_idx = ~np.isnan(pose_data.p1_time)
+        valid_p1_time = pose_data.p1_time[p1_valid_idx]
+        gps_like_mask = is_gps_time(valid_p1_time)
+        first_gps_idx = find_first(gps_like_mask)
+        self._p1_time_is_gps = first_gps_idx >= 0
 
-        valid = ~np.isnan(pose_data.p1_time) & ~np.isnan(pose_data.gps_time)
-        p1_time = pose_data.p1_time[valid]
-        gps_time = pose_data.gps_time[valid]
+        # Align matching P1 and GPS timestamps.
+        #
+        # If P1 == GPS time, we'll skip all of this and will not populate self._reference_*_time.
+        if not self._p1_time_is_gps:
+            # Limit to entries where both P1 and GPS times are valid.
+            gps_valid_idx = ~np.isnan(pose_data.gps_time)
+            valid = p1_valid_idx & gps_valid_idx
+            p1_time = pose_data.p1_time[valid]
+            gps_time = pose_data.gps_time[valid]
 
-        # P1 time is monotonic within a single boot session, but resets to 0 after a device reboot, so a reset splits
-        # the data into multiple per-session segments. If those segments' P1 time ranges don't overlap, a given P1 time
-        # can only belong to one session, so we can safely combine them into a single table sorted by P1 time.
-        # Otherwise, the same P1 time could mean two different real times, so we can only safely use the most recent
-        # (last) session.
-        segments = self._split_into_boot_segments(p1_time, gps_time)
-        if len(segments) > 1 and not self._segments_mutually_exclusive(segments):
-            _logger.warning('Detected %d device reset(s) in pose data used for time reference, with overlapping P1 '
-                            'time ranges across boot sessions. Only using data from the most recent session (%d of '
-                            '%d samples).' % (len(segments) - 1, len(segments[-1][0]), len(p1_time)))
-            segments = segments[-1:]
+            # P1 time is monotonic within a single boot session, but resets to 0 after a device reboot, so a reset
+            # splits the data into multiple per-session segments. If those segments' P1 time ranges don't overlap, a
+            # given P1 time can only belong to one session, so we can safely combine them into a single table sorted by
+            # P1 time. Otherwise, the same P1 time could mean two different real times, so we can only safely use the
+            # most recent (last) session.
+            segments = self._split_into_boot_segments(p1_time, gps_time)
+            if len(segments) > 1 and not self._segments_mutually_exclusive(segments):
+                _logger.warning('Detected %d device reset(s) in pose data used for time reference, with overlapping P1 '
+                                'time ranges across boot sessions. Only using data from the most recent session (%d of '
+                                '%d samples).' % (len(segments) - 1, len(segments[-1][0]), len(p1_time)))
+                segments = segments[-1:]
 
-        if len(segments) > 0:
-            p1_time = np.concatenate([s[0] for s in segments])
-            gps_time = np.concatenate([s[1] for s in segments])
-            order = np.argsort(p1_time)
-            p1_time = p1_time[order]
-            gps_time = gps_time[order]
+            if len(segments) > 0:
+                p1_time = np.concatenate([s[0] for s in segments])
+                gps_time = np.concatenate([s[1] for s in segments])
+                order = np.argsort(p1_time)
+                p1_time = p1_time[order]
+                gps_time = gps_time[order]
 
-        # Drop non-increasing entries (e.g., duplicate timestamps) so later interpolation can assume P1 time is
-        # strictly increasing.
-        if len(p1_time) > 0:
-            keep = np.concatenate(([True], np.diff(p1_time) > 0))
-            p1_time = p1_time[keep]
-            gps_time = gps_time[keep]
+            # Drop non-increasing entries (e.g., duplicate timestamps) so later interpolation can assume P1 time is
+            # strictly increasing.
+            if len(p1_time) > 0:
+                keep = np.concatenate(([True], np.diff(p1_time) > 0))
+                p1_time = p1_time[keep]
+                gps_time = gps_time[keep]
 
-        self._reference_p1_time = p1_time
-        self._reference_gps_time = gps_time
+            self._reference_p1_time = p1_time
+            self._reference_gps_time = gps_time
+
+        # Compute the GPS/POSIX offset for this log from the first GPS timestamp. This includes the leap second count at
+        # the start of the log. For efficiency, we assume the log does not span a leap second change. This isn't
+        # guaranteed, but it's generally safe since they only happen once every 6 months at most, and IERS is trying to
+        # avoid them in the future. The only time this assumption won't hold is when using a GNSS simulator specifically
+        # testing leap second transitions.
+        if self._p1_time_is_gps:
+            sample_gps_sec = float(valid_p1_time[first_gps_idx])
+        elif len(self._reference_gps_time) > 0:
+            sample_gps_sec = self._reference_gps_time[0]
+        else:
+            sample_gps_sec = None
+        self._gps_posix_offset_sec = None if sample_gps_sec is None else gps2unix(sample_gps_sec) - sample_gps_sec
 
     @staticmethod
     def _split_into_boot_segments(p1_time: np.ndarray, gps_time: np.ndarray) -> list:
@@ -132,6 +158,14 @@ class TimeProvider:
         @return `True` if GPS time is available.
         """
         return self._p1_time_is_gps or len(self._reference_p1_time) > 0
+
+    def get_gps_posix_offset_sec(self) -> Optional[float]:
+        """!
+        @brief Get this log's GPS-to-POSIX time offset, in seconds, i.e., `posix_sec = gps_sec + offset`.
+
+        @return The offset, in seconds, or `None` if no GPS time reference is available.
+        """
+        return self._gps_posix_offset_sec
 
     @staticmethod
     def _segments_mutually_exclusive(segments: list) -> bool:

--- a/python/fusion_engine_client/utils/time_provider.py
+++ b/python/fusion_engine_client/utils/time_provider.py
@@ -267,7 +267,7 @@ Received time update ({message.get_type()} message) at:
             gps_time = self._interp_extrap(p1_time, xp, fp)
 
         if format == 'datetime':
-            return self._gps_sec_to_datetime64_array(gps_time)
+            return self.gps_sec_to_datetime64_array(gps_time)
         else:
             return gps_time
 
@@ -367,7 +367,7 @@ Received time update ({message.get_type()} message) at:
             return f0 + (f1 - f0) * (query - x0) / (x1 - x0)
 
     @staticmethod
-    def _gps_sec_to_datetime64_array(gps_time_sec: np.ndarray) -> np.ndarray:
+    def gps_sec_to_datetime64_array(gps_time_sec: np.ndarray) -> np.ndarray:
         """!
         @brief Convert an array of GPS times (in seconds) to UTC (`datetime64[ns]`).
 

--- a/python/fusion_engine_client/utils/time_provider.py
+++ b/python/fusion_engine_client/utils/time_provider.py
@@ -6,6 +6,7 @@ from gpstime import gpstime, gps2unix
 import numpy as np
 
 from ..messages import MessageHeader, MessagePayload, PoseMessage, Timestamp
+from ..messages.timestamp import is_gps_time
 from ..utils import trace as logging
 
 if TYPE_CHECKING:
@@ -33,6 +34,10 @@ class TimeProvider:
         self._reference_p1_time = np.array([])
         self._reference_gps_time = np.array([])
 
+        # Whether this platform's P1 time is itself GPS time (as opposed to a boot-relative counter). Populated by
+        # set_reference_data().
+        self._p1_time_is_gps = False
+
     def reset(self):
         self._current_p1_time = Timestamp()
         self._current_gps_time = Timestamp()
@@ -51,6 +56,13 @@ class TimeProvider:
         """
         result = reader.read(message_types=[PoseMessage], source_ids=source_id, return_numpy=True)
         pose_data = result[PoseMessage.MESSAGE_TYPE]
+
+        # Some platforms configure their P1 clock to be GPS time itself, rather than a boot-relative counter. If even a
+        # single sample looks like a GPS timestamp, that's conclusive -- a boot-relative counter cannot accidentally
+        # cross into GPS-timestamp-sized values. In that case, P1 time can be used as GPS time directly, with no
+        # interpolation needed at all (see @ref is_p1_gps_time()).
+        valid_p1_time = pose_data.p1_time[~np.isnan(pose_data.p1_time)]
+        self._p1_time_is_gps = bool(np.any(is_gps_time(valid_p1_time)))
 
         valid = ~np.isnan(pose_data.p1_time) & ~np.isnan(pose_data.gps_time)
         p1_time = pose_data.p1_time[valid]
@@ -99,6 +111,24 @@ class TimeProvider:
         boundaries = np.concatenate(([0], reset_idx + 1, [len(p1_time)]))
         return [(p1_time[boundaries[i]:boundaries[i + 1]], gps_time[boundaries[i]:boundaries[i + 1]])
                 for i in range(len(boundaries) - 1)]
+
+    def is_p1_gps_time(self) -> bool:
+        """!
+        @brief Test whether this platform's P1 time is itself GPS time, rather than a boot-relative counter.
+
+        Populated by @ref set_reference_data(). Always `False` until it has been called.
+
+        @return `True` if P1 time is GPS time on this platform.
+        """
+        return self._p1_time_is_gps
+
+    def has_gps_reference(self) -> bool:
+        """!
+        @brief Test whether enough information is available to convert P1 time to/from GPS time.
+
+        @return `True` if GPS time is available.
+        """
+        return self._p1_time_is_gps or len(self._reference_p1_time) > 0
 
     @staticmethod
     def _segments_mutually_exclusive(segments: list) -> bool:
@@ -216,11 +246,17 @@ Received time update ({message.get_type()} message) at:
             return gps_time
 
     def _p1_to_gps_array(self, p1_time: np.ndarray, format: str) -> np.ndarray:
-        xp, fp = self._reference_p1_time, self._reference_gps_time
-        if len(xp) == 0:
-            xp, fp = self._fallback_reference()
+        p1_time = np.asarray(p1_time, dtype=float)
 
-        gps_time = self._interp_extrap(np.asarray(p1_time, dtype=float), xp, fp)
+        # If P1 time is GPS time, no interpolation is needed -- P1 time is GPS time, by definition, for any value,
+        # no matter how far it is from the reference data used to detect this.
+        if self._p1_time_is_gps:
+            gps_time = p1_time.copy()
+        else:
+            xp, fp = self._reference_p1_time, self._reference_gps_time
+            if len(xp) == 0:
+                xp, fp = self._fallback_reference()
+            gps_time = self._interp_extrap(p1_time, xp, fp)
 
         if format == 'datetime':
             return self._gps_sec_to_datetime64_array(gps_time)
@@ -273,11 +309,16 @@ Received time update ({message.get_type()} message) at:
         return p1_time
 
     def _gps_to_p1_array(self, gps_time: np.ndarray) -> np.ndarray:
+        gps_time = np.asarray(gps_time, dtype=float)
+
+        if self._p1_time_is_gps:
+            return gps_time.copy()
+
         xp, fp = self._reference_gps_time, self._reference_p1_time
         if len(xp) == 0:
             fp, xp = self._fallback_reference()
 
-        return self._interp_extrap(np.asarray(gps_time, dtype=float), xp, fp)
+        return self._interp_extrap(gps_time, xp, fp)
 
     def _fallback_reference(self) -> (np.ndarray, np.ndarray):
         """!

--- a/python/tests/test_time_provider.py
+++ b/python/tests/test_time_provider.py
@@ -445,6 +445,55 @@ class TestHasGpsReference:
         assert not tp.has_gps_reference()
 
 
+class TestGetGpsPosixOffsetSec:
+    def test_none_with_no_reference(self):
+        tp = TimeProvider()
+        assert tp.get_gps_posix_offset_sec() is None
+
+    def test_cached_not_recomputed_per_call(self):
+        from unittest import mock
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        with mock.patch('fusion_engine_client.utils.time_provider.gps2unix') as mock_gps2unix:
+            offset1 = tp.get_gps_posix_offset_sec()
+            offset2 = tp.get_gps_posix_offset_sec()
+            mock_gps2unix.assert_not_called()
+        assert offset1 == offset2
+
+    def test_offset_matches_gpstime_library(self):
+        from gpstime import gps2unix
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        offset = tp.get_gps_posix_offset_sec()
+        assert offset == pytest.approx(gps2unix(GPS_DATE_SEC) - GPS_DATE_SEC)
+        # Applying the offset to any GPS time in the table should recover the accurate POSIX/Unix timestamp.
+        assert GPS_DATE_SEC + offset == pytest.approx(gps2unix(GPS_DATE_SEC))
+
+    def test_uses_p1_time_as_sample_when_p1_is_gps_and_table_empty(self):
+        # p1_time looks like GPS time, but gps_time was never populated, so the reference table is empty.
+        from gpstime import gps2unix
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0], gps_time=[np.nan, np.nan])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.is_p1_gps_time()
+        offset = tp.get_gps_posix_offset_sec()
+        assert offset == pytest.approx(gps2unix(GPS_DATE_SEC) - GPS_DATE_SEC)
+
+    def test_skips_non_gps_like_samples_before_gps_acquired(self):
+        # Before GPS time is first acquired, P1 time starts as a small boot-relative counter -- not GPS-like -- even
+        # though the platform switches to using GPS time as P1 time once it's available. The first valid sample
+        # (10.0) is not GPS-like and must not be used as the representative sample.
+        from gpstime import gps2unix
+        reader = _FakeReader(p1_time=[10.0, 20.0, GPS_DATE_SEC], gps_time=[np.nan, np.nan, np.nan])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.is_p1_gps_time()
+        offset = tp.get_gps_posix_offset_sec()
+        assert offset == pytest.approx(gps2unix(GPS_DATE_SEC) - GPS_DATE_SEC)
+
+
 class TestP1IsGpsTime:
     def test_default_false(self):
         tp = TimeProvider()

--- a/python/tests/test_time_provider.py
+++ b/python/tests/test_time_provider.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from gpstime import gpstime
+import numpy as np
 import pytest
 
 from fusion_engine_client.messages import PoseMessage, Timestamp
@@ -16,6 +17,21 @@ def _make_pose(p1_sec, gps_sec):
     msg.p1_time = Timestamp(p1_sec)
     msg.gps_time = Timestamp(gps_sec)
     return msg
+
+
+class _FakeReader:
+    """!
+    @brief Minimal stand-in for a @ref DataLoader, returning pre-baked pose arrays from read().
+    """
+    def __init__(self, p1_time, gps_time):
+        self.p1_time = np.asarray(p1_time, dtype=float)
+        self.gps_time = np.asarray(gps_time, dtype=float)
+        self.last_read_kwargs = None
+
+    def read(self, **kwargs):
+        self.last_read_kwargs = kwargs
+        pose_data = type('PoseData', (), {'p1_time': self.p1_time, 'gps_time': self.gps_time})()
+        return {PoseMessage.MESSAGE_TYPE: pose_data}
 
 
 class TestHandleMessage:
@@ -234,3 +250,172 @@ class TestGPSToP1:
         gps = tp.p1_to_gps(original)
         recovered = tp.gps_to_p1(gps)
         assert float(recovered) == pytest.approx(float(original), abs=1e-6)
+
+
+class TestSetReferenceData:
+    def test_loads_table_in_chronological_order(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [10.0, 20.0]
+        assert list(tp._reference_gps_time) == pytest.approx([GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+
+    def test_reset_discards_data_before_it(self):
+        # P1 time jumps backward at index 2 (device reboot) -- only data from the most recent boot session
+        # (starting at the new, smaller P1 time) should be kept, not reordered in with the earlier session.
+        reader = _FakeReader(p1_time=[10.0, 20.0, 5.0, 15.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0,
+                                       GPS_DATE_SEC + 1000.0, GPS_DATE_SEC + 1010.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [5.0, 15.0]
+        assert list(tp._reference_gps_time) == pytest.approx([GPS_DATE_SEC + 1000.0, GPS_DATE_SEC + 1010.0])
+
+    def test_multiple_resets_keeps_only_last_segment(self):
+        reader = _FakeReader(p1_time=[10.0, 5.0, 20.0, 3.0, 8.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 100.0, GPS_DATE_SEC + 110.0,
+                                       GPS_DATE_SEC + 500.0, GPS_DATE_SEC + 505.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [3.0, 8.0]
+        assert list(tp._reference_gps_time) == pytest.approx([GPS_DATE_SEC + 500.0, GPS_DATE_SEC + 505.0])
+
+    def test_reset_with_mutually_exclusive_ranges_combines_segments(self):
+        # Session 1 (recorded late, P1 in [50, 60]) is followed by a reset, then session 2 (recorded from near the
+        # start, P1 in [5, 10]). The ranges don't overlap, so both sessions can be safely combined and sorted.
+        reader = _FakeReader(p1_time=[50.0, 60.0, 5.0, 10.0],
+                             gps_time=[GPS_DATE_SEC + 50.0, GPS_DATE_SEC + 60.0,
+                                       GPS_DATE_SEC + 500.0, GPS_DATE_SEC + 505.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [5.0, 10.0, 50.0, 60.0]
+        assert list(tp._reference_gps_time) == pytest.approx(
+            [GPS_DATE_SEC + 500.0, GPS_DATE_SEC + 505.0, GPS_DATE_SEC + 50.0, GPS_DATE_SEC + 60.0])
+        # Interpolating within either session's own range should use that session's local relationship.
+        result = tp.p1_to_gps(np.array([7.5, 55.0]))
+        assert result == pytest.approx([GPS_DATE_SEC + 502.5, GPS_DATE_SEC + 55.0])
+
+    def test_drops_nan_entries(self):
+        reader = _FakeReader(p1_time=[10.0, np.nan, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 5.0, np.nan])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [10.0]
+        assert list(tp._reference_gps_time) == pytest.approx([GPS_DATE_SEC])
+
+    def test_drops_duplicate_p1_times(self):
+        reader = _FakeReader(p1_time=[10.0, 10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert list(tp._reference_p1_time) == [10.0, 20.0]
+
+    def test_passes_source_id_through(self):
+        reader = _FakeReader(p1_time=[10.0], gps_time=[GPS_DATE_SEC])
+        tp = TimeProvider()
+        tp.set_reference_data(reader, source_id=3)
+        assert reader.last_read_kwargs['source_ids'] == 3
+
+    def test_empty_pose_data(self):
+        reader = _FakeReader(p1_time=[], gps_time=[])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert len(tp._reference_p1_time) == 0
+
+
+class TestP1ToGPSArray:
+    def test_no_reference_returns_nan(self):
+        tp = TimeProvider()
+        result = tp.p1_to_gps(np.array([10.0, 12.0]))
+        assert isinstance(result, np.ndarray)
+        assert np.all(np.isnan(result))
+
+    def test_uses_bulk_reference_table_interpolation(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0, 30.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0, GPS_DATE_SEC + 20.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.p1_to_gps(np.array([15.0, 25.0]))
+        assert result == pytest.approx([GPS_DATE_SEC + 5.0, GPS_DATE_SEC + 15.0])
+
+    def test_bulk_reference_table_extrapolation(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.p1_to_gps(np.array([5.0, 25.0]))
+        assert result == pytest.approx([GPS_DATE_SEC - 5.0, GPS_DATE_SEC + 15.0])
+
+    def test_falls_back_to_sequential_state_when_no_table_loaded(self):
+        tp = TimeProvider()
+        tp.handle_message(_make_pose(10.0, GPS_DATE_SEC))
+        tp.handle_message(_make_pose(20.0, GPS_DATE_SEC + 10.0))
+        result = tp.p1_to_gps(np.array([15.0, 25.0]))
+        assert result == pytest.approx([GPS_DATE_SEC + 5.0, GPS_DATE_SEC + 15.0])
+
+    def test_bulk_table_takes_priority_over_sequential_state(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        # Sequential state implies a different (wrong) relationship; the bulk table should win.
+        tp.handle_message(_make_pose(10.0, GPS_DATE_SEC + 1000.0))
+        result = tp.p1_to_gps(np.array([15.0]))
+        assert result == pytest.approx([GPS_DATE_SEC + 5.0])
+
+    def test_matches_scalar_result(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0, 30.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0, GPS_DATE_SEC + 20.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        tp.handle_message(_make_pose(10.0, GPS_DATE_SEC))
+        tp.handle_message(_make_pose(20.0, GPS_DATE_SEC + 10.0))
+        array_result = tp.p1_to_gps(np.array([15.0]))[0]
+        scalar_result = float(tp.p1_to_gps(Timestamp(15.0)))
+        assert array_result == pytest.approx(scalar_result)
+
+    def test_datetime_format(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.p1_to_gps(np.array([10.0, np.nan]), format='datetime')
+        assert result.dtype.kind == 'M'
+        assert not np.isnat(result[0])
+        assert np.isnat(result[1])
+        expected = gpstime.fromgps(GPS_DATE_SEC)
+        assert result[0].astype('datetime64[us]').item() == expected.replace(tzinfo=None)
+
+    def test_nan_input_returns_nan(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.p1_to_gps(np.array([15.0, np.nan]))
+        assert result[0] == pytest.approx(GPS_DATE_SEC + 5.0)
+        assert np.isnan(result[1])
+
+
+class TestGPSToP1Array:
+    def test_no_reference_returns_nan(self):
+        tp = TimeProvider()
+        result = tp.gps_to_p1(np.array([GPS_DATE_SEC]))
+        assert np.all(np.isnan(result))
+
+    def test_uses_bulk_reference_table_interpolation(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0, 30.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0, GPS_DATE_SEC + 20.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.gps_to_p1(np.array([GPS_DATE_SEC + 5.0, GPS_DATE_SEC + 15.0]))
+        assert result == pytest.approx([15.0, 25.0])
+
+    def test_falls_back_to_sequential_state_when_no_table_loaded(self):
+        tp = TimeProvider()
+        tp.handle_message(_make_pose(10.0, GPS_DATE_SEC))
+        tp.handle_message(_make_pose(20.0, GPS_DATE_SEC + 10.0))
+        result = tp.gps_to_p1(np.array([GPS_DATE_SEC + 5.0]))
+        assert result == pytest.approx([15.0])
+
+    def test_roundtrip_with_bulk_table(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0, 30.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0, GPS_DATE_SEC + 20.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        original = np.array([12.5, 24.0])
+        recovered = tp.gps_to_p1(tp.p1_to_gps(original))
+        assert recovered == pytest.approx(original)

--- a/python/tests/test_time_provider.py
+++ b/python/tests/test_time_provider.py
@@ -419,3 +419,77 @@ class TestGPSToP1Array:
         original = np.array([12.5, 24.0])
         recovered = tp.gps_to_p1(tp.p1_to_gps(original))
         assert recovered == pytest.approx(original)
+
+
+class TestHasGpsReference:
+    def test_default_false(self):
+        tp = TimeProvider()
+        assert not tp.has_gps_reference()
+
+    def test_true_after_loading_reference_table(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.has_gps_reference()
+
+    def test_true_when_p1_is_gps(self):
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC], gps_time=[GPS_DATE_SEC])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.has_gps_reference()
+
+    def test_false_when_no_gps_time_in_log(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[np.nan, np.nan])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert not tp.has_gps_reference()
+
+
+class TestP1IsGpsTime:
+    def test_default_false(self):
+        tp = TimeProvider()
+        assert not tp.is_p1_gps_time()
+
+    def test_normal_boot_relative_p1_time_not_detected(self):
+        reader = _FakeReader(p1_time=[10.0, 20.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert not tp.is_p1_gps_time()
+
+    def test_detects_gps_as_p1(self):
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC, GPS_DATE_SEC + 1.0], gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 1.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.is_p1_gps_time()
+
+    def test_single_gps_like_sample_is_conclusive(self):
+        # Only one sample looks like GPS time (e.g. a reset happened partway through); that alone is conclusive.
+        reader = _FakeReader(p1_time=[5.0, GPS_DATE_SEC], gps_time=[GPS_DATE_SEC + 100.0, GPS_DATE_SEC])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        assert tp.is_p1_gps_time()
+
+    def test_p1_to_gps_array_is_identity_far_outside_reference_range(self):
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        # Query far outside the reference range -- still exact, since P1 IS GPS by definition.
+        result = tp.p1_to_gps(np.array([GPS_DATE_SEC + 1e6]))
+        assert result == pytest.approx([GPS_DATE_SEC + 1e6])
+
+    def test_gps_to_p1_array_is_identity_far_outside_reference_range(self):
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0],
+                             gps_time=[GPS_DATE_SEC, GPS_DATE_SEC + 10.0])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.gps_to_p1(np.array([GPS_DATE_SEC + 1e6]))
+        assert result == pytest.approx([GPS_DATE_SEC + 1e6])
+
+    def test_datetime_format_when_p1_is_gps(self):
+        reader = _FakeReader(p1_time=[GPS_DATE_SEC], gps_time=[GPS_DATE_SEC])
+        tp = TimeProvider()
+        tp.set_reference_data(reader)
+        result = tp.p1_to_gps(np.array([GPS_DATE_SEC]), format='datetime')
+        assert result.dtype.kind == 'M'
+        assert not np.isnat(result[0])


### PR DESCRIPTION
# New Features
- Added options for displaying UTC (default) or GPS time on all plots
- Include UTC and GPS time in hover text on all plots
- Added bulk data (post-processing) support to Python `TimeProvider` class
- Added new `--time-type={utc,gps,p1,relative}` option to control X axes

# Changes
- Deprecated `--time-axis` option in favor of new `--time-type`
- Removed Plotly `text=` arrays in favor of more efficient `customdata=` + custom JS hover callback implementation
- Removed deprecated `t0` and `system_t0` class members in favor of new resolve functions, with direct access to `self.reader` where needed
- Removed deprecated absolute time plot from time scale figure (information now contained in hover text)
- Grouped all GNSS plots together consistently

# Fixes
- Fixed packing/unpacking errors in Python `CalibrationStatus` messages
- Added new custom hover tooltip implementation to resolve Plotly race condition causing intermittent hover failures

# Examples

<img width="551" height="341" alt="image" src="https://github.com/user-attachments/assets/2051d1dc-9d1d-4b96-a210-9b0dd97079c4" />
<img width="532" height="371" alt="image" src="https://github.com/user-attachments/assets/700da9d4-a9d1-4551-a37a-de038debcc15" />
<img width="1585" height="298" alt="image" src="https://github.com/user-attachments/assets/2add5684-1d97-4d05-af45-ba3c4c2a4dfa" />
