### PR TITLE
Upgrade required plotly version to >=6.9.0

### DIFF
--- a/python/fusion_engine_client/analysis/analyzer.py
+++ b/python/fusion_engine_client/analysis/analyzer.py
@@ -1473,7 +1473,7 @@ figure.on('plotly_unhover', function(data) {
 html, body { height: 100%; margin: 0; }
 body { display: flex; flex-direction: column; }
 body > div { display: contents; }
-.plotly-graph-div.js-plotly-plot { flex: 1 1 auto; min-height: 0; width: 100%; visibility: hidden; }
+.plotly-graph-div { flex: 1 1 auto; min-height: 0; width: 100%; visibility: hidden; }
 </style>
 """
 

--- a/python/fusion_engine_client/analysis/plotly_data_support.js
+++ b/python/fusion_engine_client/analysis/plotly_data_support.js
@@ -1,4 +1,4 @@
-var figure = document.getElementsByClassName("plotly-graph-div js-plotly-plot")[0];
+var figure = document.getElementsByClassName("plotly-graph-div")[0];
 
 // Build a "<Y axis title>: <value>" hover line straight from the point's own axis, so callers don't need to
 // hardcode a plot-specific label/unit/precision.

--- a/python/fusion_engine_client/analysis/plotly_map_time_slider.js
+++ b/python/fusion_engine_client/analysis/plotly_map_time_slider.js
@@ -24,13 +24,27 @@
   var ACCENT_COLOR = '#FF9C00';
   var MIN_WINDOW_SEC = Math.max(1e-3, (P1_TIME_MAX - P1_TIME_MIN) * 0.001);
 
+  // Plotly stores large numeric arrays (e.g. lat/lon built from numpy arrays) internally as a typed-array wrapper
+  // object (`{dtype, bdata, _inputArray}`) rather than a plain Array, so a real Array can't always be recovered with
+  // trace.lat.slice() -- unwrap `_inputArray` (an array-like object keyed "0", "1", ... with a few extra
+  // non-numeric metadata keys mixed in) and copy its numeric entries out by hand instead.
+  function toPlainArray(value) {
+    if (value == null) return null;
+    if (Array.isArray(value)) return value.slice();
+    var src = value.hasOwnProperty('_inputArray') ? value._inputArray : value;
+    if (Array.isArray(src)) return src.slice();
+    var out = [];
+    for (var i = 0; src.hasOwnProperty(i); i++) out.push(src[i]);
+    return out;
+  }
+
   // Snapshot each trace's original lat/lon/customdata before any restyle() call mutates figure.data in place --
   // narrowing/widening the window always re-filters from this pristine copy, never from what's currently displayed.
   var ORIGINAL_TRACES = figure.data.map(function(trace) {
     return {
-      lat: trace.lat ? trace.lat.slice() : null,
-      lon: trace.lon ? trace.lon.slice() : null,
-      customdata: trace.customdata ? trace.customdata.slice() : null,
+      lat: toPlainArray(trace.lat),
+      lon: toPlainArray(trace.lon),
+      customdata: toPlainArray(trace.customdata),
     };
   });
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,7 +10,7 @@ construct>=2.10.0
 argparse-formatter>=1.4
 colorama>=0.4.4
 palettable>=3.3.0
-plotly>=4.0.0
+plotly>=6.9.0
 pymap3d>=2.4.3
 scipy>=1.5.0
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -33,7 +33,7 @@ tools_requirements = set([
 display_requirements = set([
     'colorama>=0.4.4',
     'palettable>=3.3.0',
-    'plotly>=4.0.0',
+    'plotly>=6.9.0',
     'pymap3d>=2.4.3',
 ]) | tools_requirements
 


### PR DESCRIPTION
# Changes
- Upgrade required plotly version to >=6.9.0

# Fixes
- Fixed map rendering bug under new plotly version caused by change in trace serialization
- Fixed graph div object name