### PR TITLE
Dispatch CI docs generation to developer-resources-site main.

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           gh api --method POST \
             /repos/${{ github.repository_owner }}/developer-resources-site/actions/workflows/build-docs.yml/dispatches \
-            -f ref="master" \
+            -f ref="main" \
             -F inputs[source_repo]="${{ github.repository }}" \
             -F inputs[release_tag]="${{ github.event.release.tag_name }}" \
             -F inputs[asset_name]="${{ vars.DOCS_ASSET_NAME }}"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -5,7 +5,7 @@ on:
   push:
     # Build on a push to any branch.
     branches:
-      - '*'
+      - '**'
     # Build on a push of any tag named v* (v1.0, etc.) and generate a release.
     tags:
       - 'v*'


### PR DESCRIPTION
# Changes
- Point build-docs workflow_dispatch at `main` now that the docs site integration branch is `main` instead of `master`

# Fixes
- Fixed CI job trigger to allow branch names with slashes